### PR TITLE
Feature/alpino lookup

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -39,15 +39,15 @@ jobs:
           - dependencies: pinned
             # removed for speed, using pre-parsed trees only
             # alpino: Alpino-x86_64-Linux-glibc-2.17-git819-sicstus
-            ticcutils: fd408a4db606ded411b002c04c96369120449a0f # 0.30
-            libfolia: 2722c53122d7e47028a999a919fd0bbc6e58a664 # 2.12
-            uctodata: a8be6cf7512998f4c8963d1021f402b8b1290085 # 0.9.1
-            ucto: 58766ef94740e6c9277c8ad77eda80f4df115443 # 0.26
-            timbl: 7dca5c783c4730f48da0be27de8e54450f3e509d # 6.8
-            mbt: 3bebc5512edf4fda9e6c38ef106567546c434c30 # 3.8
-            mbtserver: f4ef14850e242ecb60db0f99070435fe79f5d6fd # 0.16
-            frogdata: 6c8cd0bee122d2703d61395ff527592268192785 # 0.22
-            frog: 7818ce301dfdfdc026e36474adf83e3e0d769ac6 # 0.26
+            ticcutils: ecb62eb116ffc3677626c53f012f34e00854e4c4 # 0.33 2023-04-29
+            libfolia: 1a3f462f8f048df60889817325701130b6271e8a # 2.15 2023-05-01
+            uctodata: a8be6cf7512998f4c8963d1021f402b8b1290085 # 0.9.1 2022-10-04
+            ucto: d22029833b264a969351ead0ee3ab9b3f97db97d # 0.30 2023-04-29
+            timbl: 61929ce6dc7d7077cb5eeceafef86de38eb40daa # 6.9 2023-04-29
+            mbt: fd7cb7ebdd52bef2794f16f329569bedad3143e9 # 3.10 2023-04-29
+            mbtserver: a6f04f30f62965c8660ee92be99d4eb86fc4bf65 # 0.17 2023-04-30
+            frogdata: 99de9597105c2304faeb797264231ba180fcdb20 # 0.22 2023-03-07
+            frog: 991f6977cfd81b9a6538db0c6de3d26908ec16b7 # 0.29 2023-05-03
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -37,7 +37,8 @@ jobs:
           #   alpino: Alpino-x86_64-Linux-glibc-2.17-git819-sicstus
           # versions known to works
           - dependencies: pinned
-            alpino: Alpino-x86_64-Linux-glibc-2.17-git819-sicstus
+            # removed for speed, using pre-parsed trees only
+            # alpino: Alpino-x86_64-Linux-glibc-2.17-git819-sicstus
             ticcutils: fd408a4db606ded411b002c04c96369120449a0f # 0.30
             libfolia: 2722c53122d7e47028a999a919fd0bbc6e58a664 # 2.12
             uctodata: a8be6cf7512998f4c8963d1021f402b8b1290085 # 0.9.1
@@ -89,11 +90,11 @@ jobs:
         mkdir -p ~/.tscan-deps
         ls -la ~/.tscan-deps
 
-    - name: Install Alpino
-      env:
-        ALPINO_VERSION: ${{ matrix.alpino }}
-      run: |
-        .github/workflows/cpp-prep-alpino.sh $ALPINO_VERSION
+    # - name: Install Alpino
+    #   env:
+    #     ALPINO_VERSION: ${{ matrix.alpino }}
+    #   run: |
+    #     .github/workflows/cpp-prep-alpino.sh $ALPINO_VERSION
 
     - name: Install ticcutils
       run: |
@@ -133,23 +134,23 @@ jobs:
         sudo make install
     - name: Start services
       run: |
-        export ALPINO_HOME=~/.tscan-deps/Alpino
+        # export ALPINO_HOME=~/.tscan-deps/Alpino
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
         cd webservice
-        ls -la ~/.tscan-deps/Alpino
-        ./startalpino.sh &
+        # ls -la ~/.tscan-deps/Alpino
+        # ./startalpino.sh &
         ./startfrog.sh &
     - name: Services up?
-      run: |
+      run: |        
+        # .github/workflows/cpp-check-service.sh 7003
         .github/workflows/cpp-check-service.sh 7001
-        .github/workflows/cpp-check-service.sh 7003
         sleep 1
     - name: Run unit tests
       run: |
         make check
-    - name: Clear extracted Alpino files
-      run: |
-        rm -rf ~/.tscan-deps/Alpino
+    # - name: Clear extracted Alpino files
+    #   run: |
+    #     rm -rf ~/.tscan-deps/Alpino
     - name: Debug information
       if: ${{ !success() }}
       run: |
@@ -157,7 +158,5 @@ jobs:
         [ -f src/test-suite.log ] && cat src/test-suite.log
         [ -f src/test.sh.log ] && cat src/test.sh.log
         tests/logdiffs.sh
-        echo "*** ALPINO LOG ***"
-        cat /tmp/alpino_server.log
         echo "*** FROG LOG ***"
         cat /tmp/frog-tscan.log

--- a/.github/workflows/webservice.yml
+++ b/.github/workflows/webservice.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         sudo apt install libmagic-dev antiword
         python -m pip install --upgrade pip
-        pip install flake8 textract python-magic
+        pip install flake8 lxml textract python-magic
     - name: Lint with flake8
       run: |
         cd webservice

--- a/include/tscan/stats.h
+++ b/include/tscan/stats.h
@@ -921,7 +921,7 @@ struct structStats: public basicStats {
 
 
 struct sentStats : public structStats {
-  sentStats( int, folia::Sentence*, const sentStats* );
+  sentStats( const std::string&, int, folia::Sentence*, const sentStats* );
   bool isSentence() const override { return true; };
   void resolveConnectives();
   void resolveSituations();
@@ -946,13 +946,13 @@ struct sentStats : public structStats {
 
 
 struct parStats: public structStats {
-  parStats( int, folia::Paragraph* );
+  parStats( const std::string&, int, folia::Paragraph* );
   void addMetrics() const override;
 };
 
 
 struct docStats : public structStats {
-  explicit docStats( folia::Document* );
+  explicit docStats( const std::string&, folia::Document* );
   bool isDocument() const override { return true; };
   void toCSV( const std::string&, csvKind ) const;
   double rarity( int level ) const override;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -4,3 +4,5 @@
 *.err
 *.log
 *.tscan.xml
+*.alpino.xml
+out*.alpino_lookup.data

--- a/tests/afk.example.alpino
+++ b/tests/afk.example.alpino
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node aform="base" begin="0" buiging="zonder" end="1" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="2" infl="no_e" lcat="ap" lemma="gelukkig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="gelukkig" sense="gelukkig" vform="adj" word="Gelukkig"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,np_pc_pp(aan))" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="besteden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="besteed" sc="np_pc_pp(aan)" sense="besteed-aan" stype="declarative" tense="present" word="besteedt" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="su">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="proper_name(sg,'ORG')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="6" lcat="np" lemma="PvdA" naamval="stan" neclass="ORG" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="PvdA" sense="PvdA" word="PvdA"/>
+        </node>
+        <node begin="5" end="6" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="aandacht" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="aandacht" sense="aandacht" word="aandacht"/>
+        <node begin="4" cat="pp" end="7" id="8" rel="pc">
+          <node begin="4" end="5" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="9" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="obj1" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          <node begin="6" end="7" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="10" lcat="pp" lemma="aan" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="aan" sense="aan" vztype="fin" word="aan"/>
+        </node>
+        <node begin="7" cat="pp" end="10" id="11" rel="mod">
+          <node begin="7" end="8" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="12" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="bij"/>
+          <node begin="8" cat="np" end="10" id="13" rel="obj1">
+            <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="9" end="10" frame="proper_name(sg,'ORG')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="15" lcat="np" lemma="VARA" naamval="stan" neclass="ORG" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="VARA" sense="VARA" word="VARA"/>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Gelukkig besteedt de PvdA daar aandacht aan bij de VARA .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(hebben,sg_heeft,transitive_ndev)" his="normal" his_1="normal" id="3" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="transitive_ndev" sense="heb" stype="declarative" tense="present" word="heeft" wvorm="pv"/>
+        <node begin="2" end="3" frame="sentence_adverb" his="normal" his_1="abbreviation" his_1_1="normal" id="4" lcat="advp" lemma="bijvoorbeeld" pos="adv" postag="SPEC(afk)" pt="spec" rel="mod" root="bijvoorbeeld" sense="bijvoorbeeld" special="sentence" spectype="afk" word="bijv."/>
+        <node begin="3" cat="np" end="6" id="5" rel="obj1">
+          <node begin="3" end="4" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="6" lcat="np" lemma="sypmtomen" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="sypmtomen" sense="sypmtomen" word="sypmtomen"/>
+          <node begin="4" cat="pp" end="6" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="5" end="6" frame="proper_name(both,'LOC')" genus="onz" getal="ev" graad="basis" his="name" his_1="not_begin" id="9" lcat="np" lemma="Pdd-Nos" naamval="stan" neclass="LOC" ntype="eigen" num="both" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Pdd-Nos" sense="Pdd-Nos" word="Pdd-Nos"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan heeft bijv. sypmtomen van Pdd-Nos .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/alpino_lookup.data
+++ b/tests/alpino_lookup.data
@@ -1,0 +1,333 @@
+Jan en Piet en hun hond .	overlap2.example.alpino	1
+Maar ook Kees en Piet en de honden van hen .	overlap2.example.alpino	2
+Het was onze kleine boot waarin we roeiden .	overlap4.example.alpino	1
+Wij roeien in de kleine boot .	overlap3.example.alpino	1
+Behalve Britt dan .	bug5.example.alpino	1
+Behalve ongelooflijk verwend en blasé zijn ( Gooische Meisjes ) , ordinair en laagbegaafd doen ( Barbie ) of al het voorgaande tegelijk ( Kim Kardashian ) .	bug5.example.alpino	2
+De ingrediënten : een fictief land , kastelen , ridders , sex , macht , geweld en Jason Momoa .	bug5.example.alpino	3
+Die bederft niet zo snel .	bug5.example.alpino	4
+Doe er je voordeel mee .	bug5.example.alpino	5
+Dus ontwikkelen ze aan de lopende band akelige aandoeningen als bleachorexia ( voor van die leuke glow-in-the-dark-tanden ) , tanorexia ( voor de betere Rachel Hazes-teint ) en botoxia ( voor een levend dodenmasker ) .	bug5.example.alpino	6
+En dat wordt ' Game of thrones ': dé HBO-hit in Amerika , die ongetwijfeld ergens in 2012 bij ons te zien zal zijn .	bug5.example.alpino	7
+En heb je een spleetje tussen de - niet al te witte - tanden , net als Lara Stone , dan ben je nóg hipper .	bug5.example.alpino	8
+En waar verheugen we ons nu al op ?	bug5.example.alpino	9
+Game of thrones .	bug5.example.alpino	10
+Gladgepolijste mensen .	bug5.example.alpino	11
+Hun houdbaarheidsdatum komt in plaats daarvan met de dag dichterbij en wat ons betreft zijn ze nu al hopeloos over datum .	bug5.example.alpino	12
+Imperfectie is heet op de catwalk !	bug5.example.alpino	13
+In Hollywood lopen ze onbedoeld altijd een beetje achter .	bug5.example.alpino	14
+Ja , die op het plaatje .	bug5.example.alpino	15
+Jongens , niet meer doen hoor .	bug5.example.alpino	16
+Laat die wenkbrauwen maar lekker woekeren , net als HNTM-winnares Tamara !	bug5.example.alpino	17
+Na onze jarenlange obsessie met knuffelseriemoordenaar Dexter en de iets minder knuffelbare ( maar wel ongelooflijk geile ) vampier Eric in ' True blood ' , wordt het wel weer eens tijd voor een verse verslaving .	bug5.example.alpino	18
+Nu we de drempel naar 2012 goed en veilig over zijn , moet het maar eens gezegd worden : wat willen we ab-so-luut niet meer terugzien ?	bug5.example.alpino	19
+Reality-sterren .	bug5.example.alpino	20
+Toegegeven : we hebben het lang leuk gevonden om naar mensen te kijken die helemaal niets kunnen .	bug5.example.alpino	21
+Wat is HOT en wat helemaal NOT ?	bug5.example.alpino	22
+Ze blijven daar namelijk hardnekkig geloven in perfectie .	bug5.example.alpino	23
+Ze zuipen , schreeuwen , trouwen én scheiden erop los voor het oog van de camera en beginnen ondertussen zelf ook te geloven dat ze bijzonder zijn .	bug5.example.alpino	24
+Ik geef hem een boek .	depdist10.example.alpino	1
+De 35jarige bestuurder reed over de A-2 en de A50 samen met de 20-jarige liftster .	numstring.example.alpino	1
+Als de stenen op hun plek lagen , werd de grond eronder weggehaald , zodat er een grafkamer gemaakt wordt .	d7.example.alpino	1
+Ondanks het slechte weer was het een mooie dag .	connective6.example.alpino	1
+De grote boze wolf at na oma Roodkapje op als toetje .	depdist15.example.alpino	1
+ik geef de man met de pet een boek .	depdist11.example.alpino	1
+Jan gaat naar huis en zet een bakje koffie .	depdist4.example.alpino	1
+Peter , mijn zwager , heeft mijn fiets gestolen .	depdist22.example.alpino	1
+Peter , mijn zwager , is al naar huis gegaan .	depdist22.example.alpino	2
+Peter heeft mijn fiets gestolen .	depdist22.example.alpino	3
+Peter is al naar huis gegaan .	depdist22.example.alpino	4
+Hij WORDT steeds maar VROLIJKER Hij is als onderzoeker erg GOED	predc-a.example.alpino	1
+Als het droog blijft , ga ik een stuk fietsen .	dlevel5.example.alpino	1
+Een door een dolle hond in zijn been gebeten man werd binnengebracht terwijl we in de wachtkamer rustig op onze beurt zaten te wachten .	dlevel5.example.alpino	2
+Hoewel hij zelf nauwelijks zijn eigen naam kon schrijven , was hij wel bedreven in rekenen en sterrenkunde , en sprak hij verschillende talen .	dlevel5.example.alpino	3
+Julia blijft thuis , omdat het heel hard regent .	dlevel5.example.alpino	4
+Tenzij jij me tegenhoudt , ga ik nu toch echt naar huis !	dlevel5.example.alpino	5
+Het moederschap was een verrassing voor haar .	nomin.example.alpino	1
+Roeien in de kleinste boot was vermoeiend .	overlap5.example.alpino	1
+Wij roeiden in de kleine boot .	overlap5.example.alpino	2
+Bij opgravingen in en rond hunebedden zijn geen skeletten , die na al die duizenden jaren helemaal vergaan zijn , gevonden , maar wel cadeaus aan de doden voor het leven na de dood .	d6.example.alpino	1
+Het weinige dat zij hebben nagelaten , ligt meestal verscholen in de grond .	dlevel6.example.alpino	1
+Hoe het deze mensen gelukt is om zonder machines stenen te vervoeren die soms wel 20.000 kilo wegen , is ook nog steeds niet helemaal duidelijk .	d6.example.alpino	2
+Onder die cadeaus waren ook bijzondere potten , die vanwege hun vorm ' trechterbekers ' worden genoemd .	d6.example.alpino	3
+Dat de republikein , die elke dag een andere vrouw aan zijn arm had hangen , de verkiezingen won , was wel een grote verrassing .	dlevel4.example.alpino	1
+Het moeten er echter veel meer zijn geweest , want in de loop der eeuwen zijn heel wat hunebedden verdwenen , bijvoorbeeld omdat de stenen als bouwmateriaal werden gebruikt .	dlevel4.example.alpino	2
+Het plaats delict waar de jongen , die net 14 was geworden , dood is aangetroffen is inmiddels vrijgegeven .	dlevel4.example.alpino	3
+Het was niet duidelijk wie toen de vlammen uit het dak waren geslagen , de brandweer had opgebeld .	dlevel4.example.alpino	4
+Ik vond dat de spreker , die geen van de aanwezigen tekort wilde , reeds lange tijd bij het bewogen verleden van de jubilaris had verwijld .	dlevel4.example.alpino	5
+Ik zag dat de man die een gebroken been had eerder geholpen werd dan de vrouw met een gebroken arm .	dlevel4.example.alpino	6
+Terwijl we in de wachtkamer rustig op onze beurt zaten te wachten , werd er een door een dolle hond in zijn been gebeten man binnengebracht , die natuurlijk voor ging .	dlevel4.example.alpino	7
+Hij ROEPT met zijn optreden veel weerstand OP .	svp.example.alpino	1
+Hij SCHELDT iedereen die langskomt UIT .	svp.example.alpino	2
+Ik NEEM graag aan wedstrijden DEEL .	svp.example.alpino	3
+Als je hem niet ziet staan , dan ga je meteen naar huis .	relativeclauses.example.alpino	1
+Als je hem niet ziet staan , ga dan meteen naar huis .	relativeclauses.example.alpino	2
+De verwachting dat er een einde aan zou komen , werd niet bewaarheid .	relativeclauses.example.alpino	3
+Er zijn allerlei verhalen over hoe hij won .	relativeclauses.example.alpino	4
+Hij heeft over het touw gelopen zonder dat hij viel .	relativeclauses.example.alpino	5
+Hij is geworden wie hij altijd wilde zijn .	relativeclauses.example.alpino	6
+Hij is zo blind dat hij dat niet ziet .	relativeclauses.example.alpino	7
+Hij kwam omdat ik hem gevraagd had .	relativeclauses.example.alpino	8
+Ik ga weg omdat ik moe ben en omdat ik naar bed wil .	relativeclauses.example.alpino	9
+Ik heb alles gedaan , inclusief het werk voor morgen .	relativeclauses.example.alpino	10
+Ik twijfel aan wat je zegt .	relativeclauses.example.alpino	11
+Waar ik vandaan kom , houden ze juist van dat soort humor .	relativeclauses.example.alpino	12
+Wat u doet , is onaanvaardbaar .	relativeclauses.example.alpino	13
+Wie het niet begrijpt , zal ik het nog eens uitleggen .	relativeclauses.example.alpino	14
+Wie te laat komt , laten we niet meer binnen .	relativeclauses.example.alpino	15
+Zie je hem niet staan , ga dan meteen naar huis .	relativeclauses.example.alpino	16
+Zo belangrijk is kinderopvang voor wie gaat werken .	relativeclauses.example.alpino	17
+Als je te laat bent , ga dan naar huis en blijf daar .	smallconjuncts.example.alpino	1
+Dat is leuk in de middag of in de avond .	smallconjuncts.example.alpino	2
+Dat is leuk om te horen en om te zien .	smallconjuncts.example.alpino	3
+Dat is leuk om te horen en te zien .	smallconjuncts.example.alpino	4
+De man die mij sloeg en die mij bespuugde is opgepakt .	smallconjuncts.example.alpino	5
+De man die mij sloeg en verwondde is gevlucht .	smallconjuncts.example.alpino	6
+Deze man moet opgenomen , onderzocht en geholpen worden .	smallconjuncts.example.alpino	7
+Deze man moet opgenomen en geholpen worden .	smallconjuncts.example.alpino	8
+Een oeroud dilemma : aanvallen , verstoppen of vluchten .	smallconjuncts.example.alpino	9
+Een oeroud dilemma : aanvallen of vluchten .	smallconjuncts.example.alpino	10
+En toen begon het te regenen en dat deed het de rest van de dag .	smallconjuncts.example.alpino	11
+Hij gaf zich zonder slag of stoot gewonnen .	smallconjuncts.example.alpino	12
+Hij hoestte , wat mij teleurstelde en wat mij ergerde .	smallconjuncts.example.alpino	13
+Hij is altijd aan het schikken en het plooien .	smallconjuncts.example.alpino	14
+Hij is erg mooi en bijzonder intelligent .	smallconjuncts.example.alpino	15
+Hij is even boven en even beneden .	smallconjuncts.example.alpino	16
+Hij is overal en nergens .	smallconjuncts.example.alpino	17
+Hij neemt ontslag omdat hij moe is , en omdat hij weg wil .	smallconjuncts.example.alpino	18
+Ik heb genoeg van dat gezanik en gezeur .	smallconjuncts.example.alpino	19
+Ik heb hem leren lopen en fietsen .	smallconjuncts.example.alpino	20
+Ik heb zijn zoon , zijn dochter en zijn schoonzoon gezien .	smallconjuncts.example.alpino	21
+Ik heb zijn zoon en zijn dochter gezien .	smallconjuncts.example.alpino	22
+Licht wankelend en half vallend strompelde hij weg .	smallconjuncts.example.alpino	23
+Peter en Arie zijn gekomen .	smallconjuncts.example.alpino	24
+Peter en Thea en Arie en Truus zijn gekomen .	smallconjuncts.example.alpino	25
+Peter en Thea zijn gekomen , en Arie en Truus ook .	smallconjuncts.example.alpino	26
+Toen ging ik toch twijfelen en ben ik nog even teruggelopen .	smallconjuncts.example.alpino	27
+Wat hij komt doen en wat hij wil weet ik niet .	smallconjuncts.example.alpino	28
+We hebben toen langs het strand gewandeld en het stadje verkend .	smallconjuncts.example.alpino	29
+Zijn zoon , zijn dochter en zijn schoonzoon zijn verongelukt .	smallconjuncts.example.alpino	30
+Hij heeft de man met de pet gezien .	depdist17.example.alpino	1
+Jan is evenmin een roker als Piet .	connective4.example.alpino	1
+Hij is groot .	lsa1.example.alpino	1
+Ik ben bang voor de hond .	lsa1.example.alpino	2
+Ik zie de hond .	lsa1.example.alpino	3
+Piet is groot .	lsa1.example.alpino	4
+Piet is niet bang .	lsa1.example.alpino	5
+Piet ziet de hond ook .	lsa1.example.alpino	6
+Dat je in zulke kleren naar school gaat , is raar .	dlevel6.example.alpino	2
+De eik die al eeuwen oud is , is door de bliksem geveld .	dlevel6.example.alpino	3
+Het is erg aardig dat je me geholpen hebt .	dlevel6.example.alpino	4
+Het lijkt wel of ze zich heeft moeten haasten .	dlevel6.example.alpino	5
+Het testen van een game en hier een recensie over schrijven lijkt mij een ideale baan .	dlevel6.example.alpino	6
+Het voorstel , waarover ik je vertelde , is aangenomen .	dlevel6.example.alpino	7
+Hoe deze mensen in staat zijn geweest om zonder machines stenen van de grond te krijgen die soms wel 20.000 kilo wegen , is ook nog steeds niet helemaal duidelijk .	dlevel6.example.alpino	8
+Of ik morgen zal slagen is mij niet bekend .	dlevel6.example.alpino	9
+Wie verre reizen doet , kan veel verhalen .	dlevel6.example.alpino	10
+Wie zoiets dappers presteert , verdient een hoge beloning .	dlevel6.example.alpino	11
+Ik geef Jan en Piet een boek .	depdist12.example.alpino	1
+Alle boeken .	npmod.example.alpino	1
+Alle kinderen behalve de oudste .	npmod.example.alpino	2
+Alle vijf de boeken .	npmod.example.alpino	3
+Bladzij 22 .	npmod.example.alpino	4
+Blaffende honden .	npmod.example.alpino	5
+Dat soort vragen .	npmod.example.alpino	6
+De componist van deze sonate , Mozart .	npmod.example.alpino	7
+De eerste drie kinderen .	npmod.example.alpino	8
+De geasfalteerde wegen .	npmod.example.alpino	9
+De groep waartoe de grootste herten behoren .	npmod.example.alpino	10
+De groep waartoe de herten behoren .	npmod.example.alpino	11
+De groep waartoe de herten en zwijnen behoren .	npmod.example.alpino	12
+De jeugd van tegenwoordig .	npmod.example.alpino	13
+De leraar aardrijkskunde .	npmod.example.alpino	14
+De meeste boeken .	npmod.example.alpino	15
+De opdracht om thuis te blijven .	npmod.example.alpino	16
+De plek des onheils .	npmod.example.alpino	17
+De schipper , een voorzichtig man , bleef thuis .	npmod.example.alpino	18
+De stad Antwerpen .	npmod.example.alpino	19
+De te nemen maatregelen .	npmod.example.alpino	20
+De verwachting dat hij snel weer opknapt .	npmod.example.alpino	21
+De vraag wie dat gedaan heeft .	npmod.example.alpino	22
+Die kamer boven .	npmod.example.alpino	23
+Die wedstrijd Ajax-Anderlecht van vorige week .	npmod.example.alpino	24
+Die wedstrijd Ajax-Anderlecht vorige week .	npmod.example.alpino	25
+Drie en een halve liter .	npmod.example.alpino	26
+Drie liter melk .	npmod.example.alpino	27
+Een auto zoals die van Rinus .	npmod.example.alpino	28
+Een boek dat ik zelf zou willen schrijven .	npmod.example.alpino	29
+Een boek met plaatjes erin .	npmod.example.alpino	30
+Een boek zoals ik zelf zou willen schrijven .	npmod.example.alpino	31
+Een dag als vandaag .	npmod.example.alpino	32
+Een duur tweede huis .	npmod.example.alpino	33
+Een glas rode wijn .	npmod.example.alpino	34
+Een kaartje eerste klas .	npmod.example.alpino	35
+Een kind om te zoenen .	npmod.example.alpino	36
+Een plakje kaas .	npmod.example.alpino	37
+Een tweede huis .	npmod.example.alpino	38
+Het arbeidsbureau nieuwe stijl .	npmod.example.alpino	39
+Het getal zeven .	npmod.example.alpino	40
+Het hoofd buitenlandse betrekkingen .	npmod.example.alpino	41
+Het huis van mijn ouders .	npmod.example.alpino	42
+Ik heb het gevoel nergens bij te horen .	npmod.example.alpino	43
+Jongens zonder manieren .	npmod.example.alpino	44
+Koning Boudewijn van België .	npmod.example.alpino	45
+Mozart , de componist van deze schitterende sonate .	npmod.example.alpino	46
+Mozart , de componist van deze sonate .	npmod.example.alpino	47
+Peters honden .	npmod.example.alpino	48
+Prinses Juliana .	npmod.example.alpino	49
+Willem de Tweede .	npmod.example.alpino	50
+' ' Dag met wàt .. ? ' vraagt Leen .	bug4.example.alpino	1
+' ' Lieve schat , dan wordt het tijd dat ze een keuze maakt .	bug4.example.alpino	2
+' ' Tja ' , zeg ik , omdat ik niet zo gauw een betere tekst weet .	bug4.example.alpino	3
+' ' Ze gaan op wintersport ' , snikt ze .	bug4.example.alpino	4
+' Het is niet helemaal het gewenste antewoord , merk ik aan het toenemende volume van Leens gesnik .	bug4.example.alpino	5
+' Jezus Leen , gebruik je hersens nou eens een keer .	bug4.example.alpino	6
+' Liselore en die drel van haar .	bug4.example.alpino	7
+' Wat is er Leen ?	bug4.example.alpino	8
+' Wie ? ' vraag ik , al heb ik wel een idee om wie het gaat .	bug4.example.alpino	9
+' Ze houdt van me .	bug4.example.alpino	10
+Dat staat in al haar smsjes .	bug4.example.alpino	11
+Dat zegt ze elke dag als we elkaar bellen .	bug4.example.alpino	12
+Een paar keer op het strand gezien , een paar gesprekjes , een nachtje stiekem foezelen met elkaar en that's it. Misschien is ze gek op spelletjes zoals ze nu met jou speelt .	bug4.example.alpino	13
+En nu laat ze me zitten .	bug4.example.alpino	14
+Het is Agnes of Leen en anders is het dag met het handje .	bug4.example.alpino	15
+Hoe dan ook , forceer een uitspraak van haar .	bug4.example.alpino	16
+Hoe goed ken je Liselore nou eigenlijk .	bug4.example.alpino	17
+Huilen is prima , maar dan moet ze wel een publiek hebben .	bug4.example.alpino	18
+Ik ken het verschijnsel .	bug4.example.alpino	19
+Ik trek mijn jas uit en ga op een vrij plekje bank zitten .	bug4.example.alpino	20
+Leen houdt er niet van om energie te verspillen .	bug4.example.alpino	21
+Leen is in tranen als ik thuis kom .	bug4.example.alpino	22
+Misschien meent ze wat ze tegen jou zegt maar durft ze het niet aan om bij Agnes op te stappen .	bug4.example.alpino	23
+Of misschien heeft ze die al gemaakt en betekent die wintersport dat ze bij haar vriendin blijft .	bug4.example.alpino	24
+Wat trouwens niet wil zeggen dat haar verdriet daardoor minder oprecht is , het zijn gewoon twee dingen die je uit elkaar moet houden als je haar wilt begrijpen .	bug4.example.alpino	25
+Ze ligt op de bank , en zodra ze mij in de gang hoort begint ze hartverscheurend te snikken .	bug4.example.alpino	26
+Zet haar voor het blok .	bug4.example.alpino	27
+vrijdag .	bug4.example.alpino	28
+Het was een kleine boot waarin we roeiden .	overlap3.example.alpino	2
+Na een autorit door de stad heb ik een pan gekocht .	gebeuren_conc.example.alpino	1
+Ik zie met eigen ogen de man met de pet daar staan .	depdist14.example.alpino	1
+( Daar horen dus eigenlijk nog 2 spaarpunten bij ! )	bug2.example.alpino	1
+Dus nu stuur ik jullie 8 spaarpunten en 2 wikkels .	bug2.example.alpino	2
+Hallo , ik ben Natali .	bug2.example.alpino	3
+Ik had acht spaarpunten , maar er waren geen spaarpunten meer terwijl het nog geen 30 april is !	bug2.example.alpino	4
+Ik wil al jaren een mobieltje maar ik krijg het maar niet .	bug2.example.alpino	5
+Ik wist het pas toen het 18 april was , dus kocht meteen een SMIKKEL-reep .	bug2.example.alpino	6
+Toen ik de actie zag , dacht ik : als ik meedoe win ik misschien wel die telefoon !	bug2.example.alpino	7
+Van mijn moeder mocht ik er elke dag één kopen , maar nu ( 26 april ) zijn ze er niet meer !	bug2.example.alpino	8
+jan en Piet gaan naar huis en zetten een bakje koffie .	depdist6.example.alpino	1
+Jan is net als Piet een nietroker .	connective2.example.alpino	1
+Gelukkig besteedt de PvdA daar aandacht aan bij de VARA .	afk.example.alpino	1
+Jan heeft bijv. sypmtomen van Pdd-Nos .	afk.example.alpino	2
+Carola vond , dat Artur wel erg raar deed .	dlevel3.example.alpino	1
+De man die daar loopt , heb ik nog nooit gezien .	d3.example.alpino	1
+Hij leerde er jongens kennen die dol waren op een biertje en meisjes met blonde haren .	dlevel3.example.alpino	2
+Ik geloof dat hij de weg kwijt is .	dlevel3.example.alpino	3
+Ik verwacht dat hij niet komt .	dlevel3.example.alpino	4
+Jan vertelde dat hij verhinderd was .	dlevel3.example.alpino	5
+Ik waardeer en bewonder hem .	depdist13.example.alpino	1
+Met behulp van Rogier komt Ko er wel uit , alhoewel het niet a la minute zal zijn !	connective3.example.alpino	1
+Na een zwerftocht door de stad heb ik een pan gekocht .	gebeuren_abstr.example.alpino	1
+De kans dat hij Piet ziet is vrij klein .	depdist21.example.alpino	1
+Ik zie Piet .	lsa2.example.alpino	1
+Piet zie ik .	lsa2.example.alpino	2
+Zie ik Piet ?	lsa2.example.alpino	3
+Gelieve een telefoon terug te sturen naar het adres .	bug1.example.alpino	1
+Helaas heb ik een probleem de situatie zit zo .	bug1.example.alpino	2
+Ik doe mee aan jullie spaaractie maar er zijn geen repen met punten meer dus kocht ik 2 repen zonder punten .	bug1.example.alpino	3
+Ik zie de man met de pet daar staan .	depdist8.example.alpino	1
+De man met de pet gaat naar huis .	depdist2.example.alpino	1
+Hij ging naar huis omdat ie moe was .	depdist18.example.alpino	1
+Jan gaat naar huis .	depdist1.example.alpino	1
+Die waren alleen te vinden in Drenthe , Denemarken en Noord-Duitsland .	d2.example.alpino	1
+Het gaat om hunebedden , grote steenformaties die door mensenhanden geordend en op elkaar gestapeld zijn .	d2.example.alpino	2
+Maar in de provincie Drenthe liggen hun resten gewoon boven de grond .	d2.example.alpino	3
+Maar lang niet overal zijn deze begraafplaatsen gebouwd met zulke grote zwerfkeien .	d2.example.alpino	4
+Zij woonden in lemen boerderijen , gebruikten houten en stenen werktuigen en maakten dus potten om voorraden in te bewaren .	d2.example.alpino	5
+Hij maakte er mooie plaatjes bij , zodat Ko het beter kon zien .	depdist20.example.alpino	1
+Frans dacht te kunnen scoren met die goedkope songtekstjes van 'm .	d1.example.alpino	1
+Piet vergat zijn haar te kammen .	d1.example.alpino	2
+Ik drink een glas bourgogne uit het noorden van de Bourgogne .	concreet2.example.alpino	1
+Ik zie Jan en Piet daar staan .	depdist9.example.alpino	1
+De vergadering zou een week later worden gehouden .	dlevel1.example.alpino	1
+Ella had de hele avond bij ons gezellig zitten babbelen .	dlevel1.example.alpino	2
+Jan schijnt aardig te zijn .	dlevel1.example.alpino	3
+Mijn moeder heeft gisteren op de markt appels gekocht Ik ben maar gaan lopen .	dlevel1.example.alpino	4
+Ook toen de wereld vijfduizend jaar jonger was , woonden er mensen in de Lage Landen .	d5.example.alpino	1
+Ze hebben zeker ook afspraken gemaakt over bezit en rechtspraak , maar welke dat zijn is niet meer te achterhalen , omdat deze vroege boeren geen schrift kenden .	d5.example.alpino	2
+Zij hielden als eersten in deze streek op met het bestaan als jager en verzamelaar en gingen wonen op een vaste plek .	d5.example.alpino	3
+De dashond snuffelde aan de klaproos .	concreet1.example.alpino	1
+Als het goed is ben ik om 18:30 daar .	connective1.example.alpino	1
+Ik vertrek naar Ede aangezien het 5 uur is .	connective1.example.alpino	2
+Ik zie hem daar staan .	depdist7.example.alpino	1
+Jan en Piet gaan naar huis .	depdist3.example.alpino	1
+Hij loopt eeuwen achter .	noun-adv.example.alpino	1
+hij is jaren niet thuis geweest .	noun-adv.example.alpino	2
+hij tennist al jaren niet meer .	noun-adv.example.alpino	3
+De jongen liep de trap op en ging zijn kamer in .	dlevel2.example.alpino	1
+Het meisje heet Aïsha en komt uit Rotterdam .	dlevel2.example.alpino	2
+Het regent , de straten worden nat .	dlevel2.example.alpino	3
+Ik houd niet van Koos Alberts , maar ik ben sowieso geen liefhebber van het Nederlandse lied .	dlevel2.example.alpino	4
+In Drenthe zijn nog ruim vijftig hunebedden bewaard gebleven , en nog twee in Groningen .	dlevel2.example.alpino	5
+Karel hechtte groot belang aan onderwijs , cultuur en wetenschap .	dlevel2.example.alpino	6
+Na over de muur te zijn gesprongen , raakte hij uit balans en viel .	dlevel2.example.alpino	7
+Onder de gasten zagen we mevrouw Bruinsma , de moeder van de jubilaris en de burgemeester .	dlevel2.example.alpino	8
+Zij woonden in lemen boerderijen , hanteerden houten en stenen werktuigen en maakten dus potten om voorraden in te bewaren .	dlevel2.example.alpino	9
+Jan en de man met de pet liepen naar huis .	depdist19.example.alpino	1
+Men denkt dat ze van grond een ' oprit ' maakten , en ronde stammetjes gebruikten om de steen overheen te laten rollen .	d3.example.alpino	2
+Men denkt dat zij daar tijdens een van de ijstijden , zo'n 150.000 jaar geleden , terecht zijn gekomen .	d3.example.alpino	3
+Met zulke resten in de grond hebben onderzoekers achterhaald hoe de eerste generaties landbouwers leefden .	d3.example.alpino	4
+Jan is zomin een roker als Piet dat is .	connective5.example.alpino	1
+Erg geloofwaardig OPEREERT hij als woordvoerder NIET .	mod_adv.example.alpino	1
+Hij LEEST al jaren niet MEER .	mod_adv.example.alpino	2
+Hij LIEP een halve marathon in een half uur GISTEREN .	mod_adv.example.alpino	3
+En ik wil weten waarom niet want het is nog geen 30 april .	bug3.example.alpino	1
+Ik ben Romy en ik doe mee aan de spaaractie .	bug3.example.alpino	2
+Ik heb al 8 punten , toen ik naar de winkel toe ging wou ik 2 repen kopen , maar er waren geen punten op de verpakking .	bug3.example.alpino	3
+Ik heb dus 8 punten en 2 repen opgestuurd .	bug3.example.alpino	4
+Want ik wil heel graag die telefoon hebben dus stuur zo snel mogelijk een brief terug a.u.b. Alvast hartelijk dank .	bug3.example.alpino	5
+Dit is allesbehalve een onmogelijk plan , met uitzondering van de decompunder .	negative.example.alpino	1
+Het is duidelijk dan non-issue een nonissue is .	negative.example.alpino	2
+We moeten de software deinstalleren .	negative.example.alpino	3
+Before is Taro’s name on textbook but	mtld.example.alpino	1
+Lake is very beautiful and beside there is a tree and over there I see the big mountain .	mtld.example.alpino	2
+There is a very beautiful And this Taro’s room .	mtld.example.alpino	3
+This mountain is very big and the scene is very good and there is a lake .	mtld.example.alpino	4
+Jouw hond is niet lief .	overlap1.example.alpino	1
+Ik ruik de geur van aangebrand vlees .	concreet3.example.alpino	1
+Hij LAS het boek SNEL .	mod_bw.example.alpino	1
+Hij LAS het boek erg VLUG .	mod_bw.example.alpino	2
+Pietje is groter dan Jantje .	d4.example.alpino	1
+Dat soort stenen begraafplaatsen was in die tijd niet ongewoon .	d0.example.alpino	1
+Ze dienden als begraafplaats .	d0.example.alpino	2
+Dit zijn twee zinnen ; althans , zo zien we dat .	semicolon.example.alpino	1
+De man , met de pet op , gaat naar huis en zet een bakje koffie .	depdist5.example.alpino	1
+' ' Goed zoon , gaan we doen .	flair1.example.alpino	1
+' ' Ok man , cool , Ollie kan je ff helpen ?	flair1.example.alpino	2
+' ...	flair1.example.alpino	3
+' Euh ja zeker , alles kits achter de rits ...	flair1.example.alpino	4
+' Goeiemiddag , ik kom voor een skateboard voor mijn zoontje .	flair1.example.alpino	5
+' Het belooft een mannendag te worden .	flair1.example.alpino	6
+' Hey man , alles flex ?	flair1.example.alpino	7
+' Ik voel mijn zoontje duizend doden sterven .	flair1.example.alpino	8
+' Ollie blijkt een opgeschoten lange jongen van een jaar of twintig te zijn .	flair1.example.alpino	9
+' Pap , ik weet waar we moeten zijn .	flair1.example.alpino	10
+' Pap , ik wil een skateboard voor mijn verjaardag .	flair1.example.alpino	11
+' Toen ik tien was , maakten we zelf een skateboard met een plank en vier wieltjes van een gevonden winkelkar van de Aldi .	flair1.example.alpino	12
+' Ziehier , een summiere samenvatting van een goed vader-zoon gesprek .	flair1.example.alpino	13
+Achterin de winkel staat hij dozen in of uit te pakken , dat is mij niet helemaal duidelijk .	flair1.example.alpino	14
+Camelkleurig van wol met een fijn visgraatje .	flair1.example.alpino	15
+De muziek is wat heftig en net iets te hard voor op de achtergrond , zou ik zo denken .	flair1.example.alpino	16
+Die wieltjes lieten te snel los , ' vervolgde ik .	flair1.example.alpino	17
+En dus sta ik op zaterdagochtend in een skateboard afgezakte broeken winkel met mijn mannetje .	flair1.example.alpino	18
+Grote zoekende ogen want hij is best onder de indruk maar zijn stoere slenter-sleep loopje compenseert dat ruimschoots .	flair1.example.alpino	19
+Ik heb voor de gelegenheid mijn favoriete jasje aangetrokken .	flair1.example.alpino	20
+Ik kijk naar Ollie en Ollie kijkt naar mij .	flair1.example.alpino	21
+Ja , papa wordt oud , ik weet het .	flair1.example.alpino	22
+Kinderen worden zo snel groot .	flair1.example.alpino	23
+Kun je ze niet af en toe sealen zodat ze niet ouder worden ?	flair1.example.alpino	24
+Lage zwarte broek , grote gympen met losse veters , een zwart T-shirt met een cartoon gothic kop erop en op zijn eigen hoofd een ( hoe kan het ook anders ) zwart mutsje .	flair1.example.alpino	25
+Maar hij is er best druk mee .	flair1.example.alpino	26
+Mijn zoontje wordt ook ouder , want hij is ook al ' bijna ' tien en hij vindt het hier helemaal ' top ' .	flair1.example.alpino	27
+Niets leukers dan je als ouwe lul te kleden .	flair1.example.alpino	28
+Hij is bakker Hij IS sinds jaren de beste SKIER van Nederland Hij probeert al jaren verwoed de beste SKIER van Nederland te ZIJN .	predc-n.example.alpino	1

--- a/tests/bug1.example.alpino
+++ b/tests/bug1.example.alpino
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="sv1" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="verb(hebben,subjunctive,vp)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="subjunctive" lcat="sv1" lemma="gelieven" pos="verb" postag="WW(pv,conj,ev)" pt="ww" pvagr="ev" pvtijd="conj" rel="hd" root="gelief" sc="vp" sense="gelief" stype="topic_drop" tense="subjunctive" word="Gelieve" wvorm="pv"/>
+        <node begin="1" cat="ti" end="9" id="3" rel="vc">
+          <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="4" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="1" cat="inf" end="9" id="5" rel="body">
+            <node begin="1" cat="np" end="3" id="6" rel="obj1">
+              <node begin="1" end="2" frame="determiner(een)" his="normal" his_1="normal" id="7" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="telefoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="telefoon" sense="telefoon" word="telefoon"/>
+            </node>
+            <node begin="3" end="4" frame="particle(terug)" his="normal" his_1="normal" id="9" lcat="part" lemma="terug" pos="part" postag="BW()" pt="bw" rel="svp" root="terug" sense="terug" word="terug"/>
+            <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,part_np_ld_pp(terug))" his="normal" his_1="normal" id="10" infl="inf" lcat="inf" lemma="terug_sturen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="stuur_terug" sc="part_np_ld_pp(terug)" sense="stuur_terug" word="sturen" wvorm="inf"/>
+            <node begin="6" cat="pp" end="9" id="11" rel="ld">
+              <node begin="6" end="7" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="12" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+              <node begin="7" cat="np" end="9" id="13" rel="obj1">
+                <node begin="7" end="8" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="14" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                <node begin="8" end="9" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="adres" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="adres" sense="adres" word="adres"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Gelieve een telefoon terug te sturen naar het adres .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="du" end="9" id="1" rel="--">
+        <node begin="0" cat="smain" end="5" id="2" rel="dp">
+          <node begin="0" end="1" frame="sentence_adverb" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="advp" lemma="helaas" pos="adv" postag="BW()" pt="bw" rel="mod" root="helaas" sense="helaas" special="sentence" word="Helaas"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev)" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="transitive_ndev" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+          <node begin="2" case="nom" def="def" end="3" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="5" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="3" cat="np" end="5" id="6" rel="obj1">
+            <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="7" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="probleem" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="probleem" sense="probleem" word="probleem"/>
+          </node>
+        </node>
+        <node begin="5" cat="smain" end="9" id="9" rel="dp">
+          <node begin="5" cat="np" end="7" id="10" rel="su">
+            <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="11" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="situatie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="situatie" sense="situatie" word="situatie"/>
+          </node>
+          <node begin="7" end="8" frame="verb(hebben,sg,nonp_copula)" his="normal" his_1="normal" id="13" infl="sg" lcat="smain" lemma="zitten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zit" sc="nonp_copula" sense="zit" stype="declarative" tense="present" word="zit" wvorm="pv"/>
+          <node aform="base" begin="8" end="9" frame="adjective(pred(nonadv))" his="normal" his_1="normal" id="14" infl="pred" lcat="ap" lemma="zo" pos="adj" postag="BW()" pt="bw" rel="predc" root="zo" sense="zo" vform="adj" word="zo"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="robust_skip" id="15" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Helaas heb ik een probleem de situatie zit zo .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="22" id="0" rel="top">
+      <node begin="0" cat="conj" end="21" id="1" rel="--">
+        <node begin="0" cat="smain" end="6" id="2" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,part_pc_pp(mee,aan))" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="mee_doen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="doe_mee" sc="part_pc_pp(mee,aan)" sense="doe_mee-aan" stype="declarative" tense="present" word="doe" wvorm="pv"/>
+          <node begin="2" end="3" frame="particle(mee)" his="normal" his_1="normal" id="5" lcat="part" lemma="mee" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="mee" sense="mee" vztype="fin" word="mee"/>
+          <node begin="3" cat="pp" end="6" id="6" rel="pc">
+            <node begin="3" end="4" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="7" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+            <node begin="4" cat="np" end="6" id="8" rel="obj1">
+              <node begin="4" buiging="zonder" end="5" frame="determiner(pron)" getal="mv" his="normal" his_1="normal" id="9" infl="pron" lcat="detp" lemma="jullie" naamval="stan" npagr="agr" pdtype="det" persoon="2v" pos="det" positie="prenom" postag="VNW(bez,det,stan,nadr,2v,mv,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="jullie" sense="jullie" status="nadr" vwtype="bez" word="jullie"/>
+              <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="10" lcat="np" lemma="sparen_actie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="spaar_actie" sense="spaar_actie" word="spaaractie"/>
+            </node>
+          </node>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(maar)" his="normal" his_1="normal" id="11" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="7" cat="conj" end="21" id="12" rel="cnj">
+          <node begin="7" cat="smain" end="14" id="13" rel="cnj">
+            <node begin="7" end="8" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="14" index="1" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+            <node begin="8" end="9" frame="verb(unacc,pl,intransitive)" his="normal" his_1="normal" id="15" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+            <node begin="9" cat="np" end="13" id="16" rel="su">
+              <node begin="9" buiging="zonder" end="10" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="17" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+              <node begin="10" end="11" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="reep" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="reep" sense="reep" word="repen"/>
+              <node begin="11" cat="pp" end="13" id="19" rel="mod">
+                <node begin="11" end="12" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="20" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+                <node begin="12" end="13" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="punt" sense="punt" special="meas_mod" word="punten"/>
+              </node>
+            </node>
+            <node aform="compar" begin="13" buiging="zonder" end="14" frame="adjective(meer)" graad="comp" his="normal" his_1="normal" id="22" infl="meer" lcat="ap" lemma="veel" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="meer" sense="meer" vform="adj" vwtype="onbep" word="meer"/>
+          </node>
+          <node begin="14" end="15" frame="conj(dus)" his="normal" his_1="normal" id="23" lcat="vg" lemma="dus" pos="vg" postag="BW()" pt="bw" rel="crd" root="dus" sense="dus" word="dus"/>
+          <node begin="7" cat="smain" end="21" id="24" rel="cnj">
+            <node begin="7" end="8" id="25" index="1" rel="mod"/>
+            <node begin="15" end="16" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="26" infl="sg" lcat="smain" lemma="kopen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="koop" sc="transitive" sense="koop" tense="past" word="kocht" wvorm="pv"/>
+            <node begin="16" case="nom" def="def" end="17" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="27" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="17" cat="np" end="19" id="28" rel="obj1">
+              <node begin="17" end="18" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="29" infl="pl_num" lcat="detp" lemma="2" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="2" sense="2" word="2"/>
+              <node begin="18" end="19" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="30" lcat="np" lemma="reep" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="reep" sense="reep" word="repen"/>
+            </node>
+            <node begin="19" cat="pp" end="21" id="31" rel="mod">
+              <node begin="19" end="20" frame="preposition(zonder,[])" his="normal" his_1="normal" id="32" lcat="pp" lemma="zonder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="zonder" sense="zonder" vztype="init" word="zonder"/>
+              <node begin="20" end="21" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="33" lcat="np" lemma="punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="punt" sense="punt" special="meas_mod" word="punten"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="21" end="22" frame="punct(punt)" his="normal" his_1="normal" id="34" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik doe mee aan jullie spaaractie maar er zijn geen repen met punten meer dus kocht ik 2 repen zonder punten .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/bug1.example.ok
+++ b/tests/bug1.example.ok
@@ -386,26 +386,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zit</t>
-                <feat class="[zit]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zit</t>
-                  <feat class="[zit]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.1.w.8.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zit</t>
                 <feat class="[zit]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -801,26 +781,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.2.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>doe</t>
-                <feat class="[doe]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>doe</t>
-                  <feat class="[doe]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="full-lemma" value="meedoen"/>
           <metric class="content_word" value="true"/>

--- a/tests/bug2.example.alpino
+++ b/tests/bug2.example.alpino
@@ -1,0 +1,271 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(haak_open)" his="normal" his_1="normal" id="1" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="1" cat="smain" end="9" id="2" rel="--">
+        <node begin="2" end="3" frame="verb(hebben,pl,ld_pp)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="horen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="hoor" sc="ld_pp" sense="hoor" stype="declarative" tense="present" word="horen" wvorm="pv"/>
+        <node begin="3" end="4" frame="sentence_adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="dus" pos="adv" postag="BW()" pt="bw" rel="mod" root="dus" sense="dus" special="sentence" word="dus"/>
+        <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(sentadv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="eigenlijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="eigenlijk" sense="eigenlijk" vform="adj" word="eigenlijk"/>
+        <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+        <node begin="6" cat="np" end="8" id="7" rel="su">
+          <node begin="6" end="7" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="8" infl="pl_num" lcat="detp" lemma="2" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="2" sense="2" word="2"/>
+          <node begin="7" end="8" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="compound" his_1="2" id="9" lcat="np" lemma="sparen_punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="spaar_punt" sense="spaar_punt" special="meas_mod" word="spaarpunten"/>
+        </node>
+        <node begin="1" cat="pp" end="9" id="10" rel="ld">
+          <node begin="1" end="2" frame="er_loc_adverb" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="11" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="obj1" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="Daar"/>
+          <node begin="8" end="9" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="12" lcat="pp" lemma="bij" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="bij" sense="bij" vztype="fin" word="bij"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(uitroep)" his="normal" his_1="normal" id="13" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+      <node begin="10" end="11" frame="punct(haak_sluit)" his="normal" his_1="normal" id="14" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+    </node>
+    <sentence sentid="127.0.0.1">( Daar horen dus eigenlijk nog 2 spaarpunten bij ! )</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="du" end="10" id="1" rel="--">
+        <node begin="0" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="dus" pos="comp" postag="BW()" pt="bw" rel="dlink" root="dus" sc="root" sense="dus" word="Dus"/>
+        <node begin="1" cat="smain" end="10" id="3" rel="nucl">
+          <node begin="1" end="2" frame="tmp_adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="mod" root="nu" sense="nu" special="tmp" word="nu"/>
+          <node begin="2" end="3" frame="verb(hebben,sg1,np_np)" his="normal" his_1="normal" id="5" infl="sg1" lcat="smain" lemma="sturen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="stuur" sc="np_np" sense="stuur" stype="declarative" tense="present" word="stuur" wvorm="pv"/>
+          <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="4" case="both" def="def" end="5" frame="pronoun(nwh,je,pl,de,both,def)" gen="de" getal="mv" his="normal" his_1="normal" id="7" lcat="np" lemma="jullie" naamval="stan" num="pl" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,stan,nadr,2v,mv)" pt="vnw" rel="obj2" rnum="sg" root="jullie" sense="jullie" status="nadr" vwtype="pers" wh="nwh" word="jullie"/>
+          <node begin="5" cat="conj" end="10" id="8" rel="obj1">
+            <node begin="5" cat="np" end="7" id="9" rel="cnj">
+              <node begin="5" end="6" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="10" infl="pl_num" lcat="detp" lemma="8" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="8" sense="8" word="8"/>
+              <node begin="6" end="7" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="compound" his_1="2" id="11" lcat="np" lemma="sparen_punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="spaar_punt" sense="spaar_punt" special="meas_mod" word="spaarpunten"/>
+            </node>
+            <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="8" cat="np" end="10" id="13" rel="cnj">
+              <node begin="8" end="9" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="14" infl="pl_num" lcat="detp" lemma="2" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="2" sense="2" word="2"/>
+              <node begin="9" end="10" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="wikkel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="wikkel" sense="wikkel" word="wikkels"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dus nu stuur ik jullie 8 spaarpunten en 2 wikkels .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="5" id="2" rel="--">
+        <node begin="0" end="1" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="advp" lemma="hallo" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="hallo" sense="hallo" word="Hallo"/>
+        <node begin="2" cat="smain" end="5" id="4" rel="nucl">
+          <node begin="2" case="nom" def="def" end="3" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="5" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="3" end="4" frame="verb(unacc,sg1,copula)" his="normal" his_1="normal" id="6" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+          <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="name" his_1="not_begin" id="7" lcat="np" lemma="Natali" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="Natali" sense="Natali" word="Natali"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hallo , ik ben Natali .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="18" id="2" rel="--">
+        <node begin="0" cat="smain" end="4" id="3" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,past(sg),transitive_ndev)" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="heb" sc="transitive_ndev" sense="heb" stype="declarative" tense="past" word="had" wvorm="pv"/>
+          <node begin="2" cat="np" end="4" id="6" rel="obj1">
+            <node begin="2" end="3" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="7" infl="pl_num" lcat="detp" lemma="acht" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="acht" sense="acht" word="acht"/>
+            <node begin="3" end="4" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="compound" his_1="2" id="8" lcat="np" lemma="sparen_punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="spaar_punt" sense="spaar_punt" special="meas_mod" word="spaarpunten"/>
+          </node>
+        </node>
+        <node begin="5" conjtype="neven" end="6" frame="conj(maar)" his="normal" his_1="normal" id="9" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="6" cat="smain" end="18" id="10" rel="cnj">
+          <node begin="6" end="7" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="11" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="7" end="8" frame="verb(unacc,past(pl),intransitive)" his="normal" his_1="normal" id="12" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="past" word="waren" wvorm="pv"/>
+          <node begin="8" cat="np" end="10" id="13" rel="su">
+            <node begin="8" buiging="zonder" end="9" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="14" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+            <node begin="9" end="10" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="compound" his_1="2" id="15" lcat="np" lemma="sparen_punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="spaar_punt" sense="spaar_punt" special="meas_mod" word="spaarpunten"/>
+          </node>
+          <node aform="compar" begin="10" buiging="zonder" end="11" frame="adjective(meer)" graad="comp" his="normal" his_1="normal" id="16" infl="meer" lcat="ap" lemma="veel" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="meer" sense="meer" vform="adj" vwtype="onbep" word="meer"/>
+          <node begin="11" cat="cp" end="18" id="17" rel="mod">
+            <node begin="11" conjtype="onder" end="12" frame="complementizer" his="normal" his_1="normal" id="18" lcat="cp" lemma="terwijl" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="terwijl" sense="terwijl" word="terwijl"/>
+            <node begin="12" cat="ssub" end="18" id="19" rel="body">
+              <node begin="12" end="13" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="20" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+              <node begin="13" end="14" frame="adverb" his="normal" his_1="normal" id="21" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+              <node begin="14" cat="np" end="17" id="22" rel="predc">
+                <node begin="14" buiging="zonder" end="15" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="23" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+                <node begin="15" cat="mwu" end="17" his="normal" his_1="date_expression" id="24" rel="hd">
+                  <node begin="15" end="16" frame="tmp_np" id="25" lcat="np" lemma="30" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="mwp" root="30" sense="30" special="tmp" word="30"/>
+                  <node begin="16" end="17" frame="tmp_np" genus="zijd" getal="ev" graad="basis" id="26" lcat="np" lemma="april" naamval="stan" ntype="eigen" pos="noun" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="mwp" root="april" sense="april" special="tmp" word="april"/>
+                </node>
+              </node>
+              <node begin="17" end="18" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="27" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(uitroep)" his="normal" his_1="normal" id="28" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik had acht spaarpunten , maar er waren geen spaarpunten meer terwijl het nog geen 30 april is !</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="0" cat="conj" end="12" id="1" rel="--">
+        <node begin="0" cat="smain" end="6" id="2" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,modal_not_u,transitive_ndev_ndev)" his="normal" his_1="normal" id="4" infl="modal_not_u" lcat="smain" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="transitive_ndev_ndev" sense="wil" stype="declarative" tense="present" word="wil" wvorm="pv"/>
+          <node begin="2" cat="np" end="4" id="5" rel="mod">
+            <node begin="2" end="3" frame="modal_adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sc="modal" sense="al" word="al"/>
+            <node begin="3" end="4" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+          </node>
+          <node begin="4" cat="np" end="6" id="8" rel="obj1">
+            <node begin="4" end="5" frame="determiner(een)" his="normal" his_1="normal" id="9" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="10" lcat="np" lemma="mobiel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="mobiel_DIM" sense="mobiel_DIM" word="mobieltje"/>
+          </node>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(maar)" his="normal" his_1="normal" id="11" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="7" cat="smain" end="12" id="12" rel="cnj">
+          <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="13" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="8" end="9" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="14" infl="sg1" lcat="smain" lemma="krijgen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="krijg" sc="transitive" sense="krijg" stype="declarative" tense="present" word="krijg" wvorm="pv"/>
+          <node begin="9" end="10" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="15" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+          <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="maar" pos="adv" postag="BW()" pt="bw" rel="mod" root="maar" sense="maar" word="maar"/>
+          <node begin="11" end="12" frame="adverb" his="normal" his_1="normal" id="17" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik wil al jaren een mobieltje maar ik krijg het maar niet .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="16" id="0" rel="top">
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="15" id="2" rel="--">
+        <node begin="0" cat="smain" end="9" id="3" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="weten" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="weet" sc="transitive" sense="weet" tense="past" word="wist" wvorm="pv"/>
+          <node begin="2" end="3" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="6" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+          <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="pas" pos="adv" postag="BW()" pt="bw" rel="mod" root="pas" sense="pas" word="pas"/>
+          <node begin="4" cat="cp" end="9" id="8" rel="mod">
+            <node begin="4" conjtype="onder" end="5" frame="complementizer" his="normal" his_1="normal" id="9" lcat="cp" lemma="toen" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="toen" sense="toen" word="toen"/>
+            <node begin="5" cat="ssub" end="9" id="10" rel="body">
+              <node begin="5" end="6" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="11" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+              <node begin="6" cat="mwu" end="8" his="normal" his_1="date_expression" id="12" rel="predc">
+                <node begin="6" end="7" frame="tmp_np" id="13" lcat="np" lemma="18" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="mwp" root="18" sense="18" special="tmp" word="18"/>
+                <node begin="7" end="8" frame="tmp_np" genus="zijd" getal="ev" graad="basis" id="14" lcat="np" lemma="april" naamval="stan" ntype="eigen" pos="noun" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="mwp" root="april" sense="april" special="tmp" word="april"/>
+              </node>
+              <node begin="8" end="9" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="15" infl="sg" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" tense="past" word="was" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="10" end="11" frame="conj(dus)" his="normal" his_1="normal" id="16" lcat="vg" lemma="dus" pos="vg" postag="BW()" pt="bw" rel="crd" root="dus" sense="dus" word="dus"/>
+        <node begin="0" cat="smain" end="15" id="17" rel="cnj">
+          <node begin="0" end="1" id="18" index="1" rel="su"/>
+          <node begin="11" end="12" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="19" infl="sg" lcat="smain" lemma="kopen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="koop" sc="transitive" sense="koop" tense="past" word="kocht" wvorm="pv"/>
+          <node begin="12" end="13" frame="adverb" his="normal" his_1="normal" id="20" lcat="advp" lemma="meteen" pos="adv" postag="BW()" pt="bw" rel="mod" root="meteen" sense="meteen" word="meteen"/>
+          <node begin="13" cat="np" end="15" id="21" rel="obj1">
+            <node begin="13" end="14" frame="determiner(een)" his="normal" his_1="normal" id="22" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="14" end="15" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="hyphen" id="23" lcat="np" lemma="SMIKKEL_reep" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="SMIKKEL_reep" sense="SMIKKEL_reep" word="SMIKKEL-reep"/>
+          </node>
+        </node>
+      </node>
+      <node begin="15" end="16" frame="punct(punt)" his="normal" his_1="normal" id="24" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik wist het pas toen het 18 april was , dus kocht meteen een SMIKKEL-reep .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="8" end="9" frame="punct(dubb_punt)" his="normal" his_1="normal" id="2" lcat="punct" lemma=":" pos="punct" postag="LET()" pt="let" rel="--" root=":" sense=":" special="dubb_punt" word=":"/>
+      <node begin="0" cat="du" end="18" id="3" rel="--">
+        <node begin="0" cat="smain" end="8" id="4" rel="tag">
+          <node begin="0" cat="cp" end="5" id="5" rel="mod">
+            <node begin="0" conjtype="onder" end="1" frame="complementizer" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="cp" lemma="toen" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="toen" sense="toen" word="Toen"/>
+            <node begin="1" cat="ssub" end="5" id="7" rel="body">
+              <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="8" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node begin="2" cat="np" end="4" id="9" rel="obj1">
+                <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="actie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="actie" sense="actie" word="actie"/>
+              </node>
+              <node begin="4" end="5" frame="verb(hebben,past(sg),transitive_ndev_ndev)" his="normal" his_1="normal" id="12" infl="sg" lcat="ssub" lemma="zien" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" tense="past" word="zag" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="6" end="7" frame="verb(hebben,past(sg),tr_sbar)" his="normal" his_1="normal" id="13" infl="sg" lcat="smain" lemma="denken" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="denk" sc="tr_sbar" sense="denk" stype="declarative" tense="past" word="dacht" wvorm="pv"/>
+          <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="14" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        </node>
+        <node begin="9" cat="smain" end="18" id="15" rel="nucl">
+          <node begin="9" cat="cp" end="12" id="16" rel="mod">
+            <node begin="9" conjtype="onder" end="10" frame="complementizer(als)" his="normal" his_1="normal" id="17" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+            <node begin="10" cat="ssub" end="12" id="18" rel="body">
+              <node begin="10" case="nom" def="def" end="11" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="19" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node begin="11" end="12" frame="verb(hebben,sg1,ninv(intransitive,part_intransitive(mee)))" his="normal" his_1="part-V" id="20" infl="sg1" lcat="ssub" lemma="mee_doen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="doe_mee" sc="part_intransitive(mee)" sense="doe_mee" tense="present" word="meedoe" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="12" end="13" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="21" infl="sg1" lcat="smain" lemma="winnen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="win" sc="transitive" sense="win" stype="declarative" tense="present" word="win" wvorm="pv"/>
+          <node begin="13" case="nom" def="def" end="14" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="22" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="14" end="15" frame="sentence_adverb" his="normal" his_1="normal" id="23" lcat="advp" lemma="misschien" pos="adv" postag="BW()" pt="bw" rel="mod" root="misschien" sense="misschien" special="sentence" word="misschien"/>
+          <node aform="base" begin="15" end="16" frame="adjective(pred(adv))" his="normal" his_1="normal" id="24" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+          <node begin="16" cat="np" end="18" id="25" rel="obj1">
+            <node begin="16" buiging="zonder" end="17" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="26" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+            <node begin="17" end="18" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="27" lcat="np" lemma="telefoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="telefoon" sense="telefoon" word="telefoon"/>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(uitroep)" his="normal" his_1="normal" id="28" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Toen ik de actie zag , dacht ik : als ik meedoe win ik misschien wel die telefoon !</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="23" id="0" rel="top">
+      <node begin="10" end="11" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="13" end="14" frame="punct(haak_open)" his="normal" his_1="normal" id="2" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="16" end="17" frame="punct(haak_sluit)" his="normal" his_1="normal" id="3" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="0" cat="conj" end="22" id="4" rel="--">
+        <node begin="0" cat="smain" end="10" id="5" rel="cnj">
+          <node begin="3" end="4" frame="verb(hebben,past(sg),modifier(aux(inf)))" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="mogen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="mag" sc="modifier(aux(inf))" sense="mag" stype="declarative" tense="past" word="mocht" wvorm="pv"/>
+          <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="0" cat="inf" end="10" id="8" rel="vc">
+            <node begin="0" cat="pp" end="3" id="9" rel="mod">
+              <node begin="0" end="1" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="decap" his_1_1="normal" id="10" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="Van"/>
+              <node begin="1" cat="np" end="3" id="11" rel="obj1">
+                <node begin="1" buiging="zonder" end="2" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="12" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+                <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="moeder" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="moeder" sense="moeder" word="moeder"/>
+              </node>
+            </node>
+            <node begin="4" end="5" id="14" index="1" rel="su"/>
+            <node begin="5" end="6" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="15" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+            <node begin="6" cat="np" end="9" id="16" rel="obj1">
+              <node begin="6" buiging="met-e" end="7" frame="determiner(elke,nwh,mod)" his="normal" his_1="normal" id="17" infl="elke" lcat="detp" lemma="elk" naamval="stan" npagr="evz" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,met-e,evz)" pt="vnw" rel="det" root="elk" sense="elk" vwtype="onbep" wh="nwh" word="elke"/>
+              <node begin="7" end="8" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+              <node begin="8" end="9" frame="number(hoofd(sg_num))" his="normal" his_1="normal" id="19" infl="sg_num" lcat="detp" lemma="één" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="app" root="één" sense="één" word="één"/>
+            </node>
+            <node begin="9" buiging="zonder" end="10" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="20" infl="inf" lcat="inf" lemma="kopen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="koop" sc="transitive" sense="koop" word="kopen" wvorm="inf"/>
+          </node>
+        </node>
+        <node begin="11" conjtype="neven" end="12" frame="conj(maar)" his="normal" his_1="normal" id="21" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="12" cat="smain" end="22" id="22" rel="cnj">
+          <node begin="12" cat="advp" end="16" id="23" rel="mod">
+            <node begin="12" end="13" frame="tmp_adverb" his="normal" his_1="normal" id="24" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="hd" root="nu" sense="nu" special="tmp" word="nu"/>
+            <node begin="14" cat="mwu" end="16" his="normal" his_1="date_expression" id="25" rel="mod">
+              <node begin="14" end="15" frame="tmp_np" id="26" lcat="np" lemma="26" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="mwp" root="26" sense="26" special="tmp" word="26"/>
+              <node begin="15" end="16" frame="tmp_np" genus="zijd" getal="ev" graad="basis" id="27" lcat="np" lemma="april" naamval="stan" ntype="eigen" pos="noun" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="mwp" root="april" sense="april" special="tmp" word="april"/>
+            </node>
+          </node>
+          <node begin="17" end="18" frame="verb(unacc,pl,intransitive)" his="normal" his_1="normal" id="28" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="18" case="both" def="def" end="19" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="29" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="19" end="20" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="30" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="20" cat="advp" end="22" id="31" rel="mod">
+            <node begin="20" end="21" frame="adverb" his="normal" his_1="normal" id="32" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+            <node begin="21" buiging="zonder" end="22" frame="postadv_adverb" graad="comp" his="normal" his_1="normal" id="33" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="meer"/>
+          </node>
+        </node>
+      </node>
+      <node begin="22" end="23" frame="punct(uitroep)" his="normal" his_1="normal" id="34" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Van mijn moeder mocht ik er elke dag één kopen , maar nu ( 26 april ) zijn ze er niet meer !</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/bug2.example.ok
+++ b/tests/bug2.example.ok
@@ -159,26 +159,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.4.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ben</t>
-                <feat class="[zijn]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zijn</t>
-                  <feat class="[zijn]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(koppelww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.999628"/>
           <metric class="prevalenceZ" value="3.37248"/>
@@ -1432,26 +1412,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.1.s.3.w.2.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.3.w.2.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
@@ -5543,28 +5503,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.8.w.3.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>horen</t>
-                <feat class="[[hoor]verb[en]/present-tense/plural/singular]verb" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>hoor</t>
-                  <feat class="[hoor]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>en</t>
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="plural" subset="inflection"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="singular" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/bug3.example.alpino
+++ b/tests/bug3.example.alpino
@@ -1,0 +1,208 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="0" cat="du" end="13" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+        <node begin="1" cat="conj" end="13" id="3" rel="nucl">
+          <node begin="1" cat="smain" end="6" id="4" rel="cnj">
+            <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="2" end="3" frame="verb(hebben,modal_not_u,modifier(aux(inf)))" his="normal" his_1="normal" id="6" infl="modal_not_u" lcat="smain" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" stype="declarative" tense="present" word="wil" wvorm="pv"/>
+            <node begin="1" cat="inf" end="6" id="7" rel="vc">
+              <node begin="1" end="2" id="8" index="1" rel="su"/>
+              <node begin="3" buiging="zonder" end="4" frame="verb(hebben,inf,tr_sbar)" his="normal" his_1="normal" id="9" infl="inf" lcat="inf" lemma="weten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="weet" sc="tr_sbar" sense="weet" word="weten" wvorm="inf"/>
+              <node begin="4" cat="whsub" end="6" id="10" rel="vc">
+                <node begin="4" end="5" frame="waar_adverb(om)" his="normal" his_1="normal" id="11" lcat="pp" lemma="waarom" pos="pp" postag="BW()" pt="bw" rel="whd" root="waarom" sense="waarom" special="waar" word="waarom"/>
+                <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="12" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="body" root="niet" sense="niet" word="niet"/>
+              </node>
+            </node>
+          </node>
+          <node begin="6" conjtype="neven" end="7" frame="conj(want)" his="normal" his_1="normal" id="13" lcat="vg" lemma="want" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="want" sense="want" word="want"/>
+          <node begin="7" cat="smain" end="13" id="14" rel="cnj">
+            <node begin="7" end="8" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="15" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+            <node begin="8" end="9" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="16" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+            <node begin="9" end="10" frame="adverb" his="normal" his_1="normal" id="17" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+            <node begin="10" cat="np" end="13" id="18" rel="predc">
+              <node begin="10" buiging="zonder" end="11" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="19" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+              <node begin="11" cat="mwu" end="13" his="normal" his_1="date_expression" id="20" rel="hd">
+                <node begin="11" end="12" frame="tmp_np" id="21" lcat="np" lemma="30" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="mwp" root="30" sense="30" special="tmp" word="30"/>
+                <node begin="12" end="13" frame="tmp_np" genus="zijd" getal="ev" graad="basis" id="22" lcat="np" lemma="april" naamval="stan" ntype="eigen" pos="noun" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="mwp" root="april" sense="april" special="tmp" word="april"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="23" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">En ik wil weten waarom niet want het is nog geen 30 april .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:16" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="conj" end="10" id="1" rel="--">
+        <node begin="0" cat="smain" end="3" id="2" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(unacc,sg1,copula)" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Romy" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="Romy" sense="Romy" word="Romy"/>
+        </node>
+        <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="4" cat="smain" end="10" id="7" rel="cnj">
+          <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="8" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="5" end="6" frame="verb(hebben,sg1,part_pc_pp(mee,aan))" his="normal" his_1="normal" id="9" infl="sg1" lcat="smain" lemma="mee_doen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="doe_mee" sc="part_pc_pp(mee,aan)" sense="doe_mee-aan" stype="declarative" tense="present" word="doe" wvorm="pv"/>
+          <node begin="6" end="7" frame="particle(mee)" his="normal" his_1="normal" id="10" lcat="part" lemma="mee" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="mee" sense="mee" vztype="fin" word="mee"/>
+          <node begin="7" cat="pp" end="10" id="11" rel="pc">
+            <node begin="7" end="8" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="12" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+            <node begin="8" cat="np" end="10" id="13" rel="obj1">
+              <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="15" lcat="np" lemma="sparen_actie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="spaar_actie" sense="spaar_actie" word="spaaractie"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik ben Romy en ik doe mee aan de spaaractie .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="28" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="18" end="19" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="27" id="3" rel="--">
+        <node begin="0" cat="smain" end="5" id="4" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev)" his="normal" his_1="normal" id="6" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="transitive_ndev" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+          <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+          <node begin="3" cat="np" end="5" id="8" rel="obj1">
+            <node begin="3" end="4" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="9" infl="pl_num" lcat="detp" lemma="8" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="8" sense="8" word="8"/>
+            <node begin="4" end="5" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="punt" sense="punt" special="meas_mod" word="punten"/>
+          </node>
+        </node>
+        <node begin="6" cat="smain" end="18" id="11" rel="cnj">
+          <node begin="13" end="14" frame="verb(hebben,past(sg),modifier(aux(inf)))" his="normal" his_1="normal" id="12" infl="sg" lcat="smain" lemma="willen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" stype="declarative" tense="past" word="wou" wvorm="pv"/>
+          <node begin="14" case="nom" def="def" end="15" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="13" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="6" cat="inf" end="18" id="14" rel="vc">
+            <node begin="6" cat="cp" end="13" id="15" rel="mod">
+              <node begin="6" conjtype="onder" end="7" frame="complementizer" his="normal" his_1="normal" id="16" lcat="cp" lemma="toen" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="toen" sense="toen" word="toen"/>
+              <node begin="7" cat="ssub" end="13" id="17" rel="body">
+                <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="18" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+                <node begin="8" cat="pp" end="12" id="19" rel="ld">
+                  <node begin="8" end="9" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="20" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+                  <node begin="9" cat="np" end="11" id="21" rel="obj1">
+                    <node begin="9" end="10" frame="determiner(de)" his="normal" his_1="normal" id="22" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                    <node begin="10" end="11" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="23" lcat="np" lemma="winkel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="winkel" sense="winkel" word="winkel"/>
+                  </node>
+                  <node begin="11" end="12" frame="particle(toe)" his="normal" his_1="normal" id="24" lcat="part" lemma="toe" pos="part" postag="VZ(fin)" pt="vz" rel="hdf" root="toe" sense="toe" vztype="fin" word="toe"/>
+                </node>
+                <node begin="12" end="13" frame="verb(zijn,past(sg),ld_pp)" his="normal" his_1="normal" id="25" infl="sg" lcat="ssub" lemma="gaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ga" sc="ld_pp" sense="ga" tense="past" word="ging" wvorm="pv"/>
+              </node>
+            </node>
+            <node begin="14" end="15" id="26" index="1" rel="su"/>
+            <node begin="15" cat="np" end="17" id="27" rel="obj1">
+              <node begin="15" end="16" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="28" infl="pl_num" lcat="detp" lemma="2" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="2" sense="2" word="2"/>
+              <node begin="16" end="17" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="29" lcat="np" lemma="reep" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="reep" sense="reep" word="repen"/>
+            </node>
+            <node begin="17" buiging="zonder" end="18" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="30" infl="inf" lcat="inf" lemma="kopen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="koop" sc="transitive" sense="koop" word="kopen" wvorm="inf"/>
+          </node>
+        </node>
+        <node begin="19" conjtype="neven" end="20" frame="conj(maar)" his="normal" his_1="normal" id="31" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="20" cat="smain" end="27" id="32" rel="cnj">
+          <node begin="20" end="21" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="33" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="21" end="22" frame="verb(unacc,past(pl),intransitive)" his="normal" his_1="normal" id="34" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="past" word="waren" wvorm="pv"/>
+          <node begin="22" cat="np" end="27" id="35" rel="su">
+            <node begin="22" buiging="zonder" end="23" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="36" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+            <node begin="23" end="24" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="37" lcat="np" lemma="punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="punt" sense="punt" special="meas_mod" word="punten"/>
+            <node begin="24" cat="pp" end="27" id="38" rel="mod">
+              <node begin="24" end="25" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="39" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+              <node begin="25" cat="np" end="27" id="40" rel="obj1">
+                <node begin="25" end="26" frame="determiner(de)" his="normal" his_1="normal" id="41" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="26" end="27" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="42" lcat="np" lemma="verpakking" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verpakking" sense="verpakking" word="verpakking"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="27" end="28" frame="punct(punt)" his="normal" his_1="normal" id="43" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb al 8 punten , toen ik naar de winkel toe ging wou ik 2 repen kopen , maar er waren geen punten op de verpakking .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="9" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" end="3" frame="sentence_adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="dus" pos="adv" postag="BW()" pt="bw" rel="mod" root="dus" sense="dus" special="sentence" word="dus"/>
+          <node begin="3" cat="conj" end="8" id="7" rel="obj1">
+            <node begin="3" cat="np" end="5" id="8" rel="cnj">
+              <node begin="3" end="4" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="9" infl="pl_num" lcat="detp" lemma="8" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="8" sense="8" word="8"/>
+              <node begin="4" end="5" frame="meas_mod_noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="punt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="punt" sense="punt" special="meas_mod" word="punten"/>
+            </node>
+            <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="11" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="6" cat="np" end="8" id="12" rel="cnj">
+              <node begin="6" end="7" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="13" infl="pl_num" lcat="detp" lemma="2" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="2" sense="2" word="2"/>
+              <node begin="7" end="8" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="reep" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="reep" sense="reep" word="repen"/>
+            </node>
+          </node>
+          <node begin="8" buiging="zonder" end="9" frame="verb(hebben,psp,ninv(transitive,part_transitive(op)))" his="normal" his_1="part-V" id="15" infl="psp" lcat="ppart" lemma="op_sturen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="stuur_op" sc="part_transitive(op)" sense="stuur_op" word="opgestuurd" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb dus 8 punten en 2 repen opgestuurd .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="21" id="0" rel="top">
+      <node begin="0" cat="du" end="20" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="want" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="want" sc="root" sense="want" word="Want"/>
+        <node begin="1" cat="conj" end="20" id="3" rel="nucl">
+          <node begin="1" cat="smain" end="8" id="4" rel="cnj">
+            <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="2" end="3" frame="verb(hebben,modal_not_u,modifier(aux(inf)))" his="normal" his_1="normal" id="6" infl="modal_not_u" lcat="smain" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" tense="present" word="wil" wvorm="pv"/>
+            <node begin="1" cat="inf" end="8" id="7" rel="vc">
+              <node begin="1" end="2" id="8" index="1" rel="su"/>
+              <node begin="3" cat="ap" end="5" id="9" rel="mod">
+                <node begin="3" buiging="zonder" end="4" frame="intensifier" graad="basis" his="normal" his_1="normal" id="10" lcat="advp" lemma="heel" pos="adv" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="heel" sense="heel" special="intensifier" word="heel"/>
+                <node aform="base" begin="4" end="5" frame="adjective(both(osentadv))" his="normal" his_1="normal" id="11" infl="both" lcat="ap" lemma="graag" pos="adj" postag="BW()" pt="bw" rel="hd" root="graag" sense="graag" vform="adj" word="graag"/>
+              </node>
+              <node begin="5" cat="np" end="7" id="12" rel="obj1">
+                <node begin="5" buiging="zonder" end="6" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="13" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+                <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="telefoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="telefoon" sense="telefoon" word="telefoon"/>
+              </node>
+              <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,transitive_ndev)" his="normal" his_1="normal" id="15" infl="inf" lcat="inf" lemma="hebben" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="heb" sc="transitive_ndev" sense="heb" word="hebben" wvorm="inf"/>
+            </node>
+          </node>
+          <node begin="8" end="9" frame="conj(dus)" his="normal" his_1="normal" id="16" lcat="vg" lemma="dus" pos="vg" postag="BW()" pt="bw" rel="crd" root="dus" sense="dus" word="dus"/>
+          <node begin="1" cat="smain" end="20" id="17" rel="cnj">
+            <node begin="1" end="2" id="18" index="1" rel="su"/>
+            <node begin="9" end="10" frame="verb(hebben,sg1,np_np)" his="normal" his_1="normal" id="19" infl="sg1" lcat="smain" lemma="sturen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="stuur" sc="np_np" sense="stuur" tense="present" word="stuur" wvorm="pv"/>
+            <node begin="10" cat="ap" end="13" id="20" rel="mod">
+              <node aform="base" begin="11" buiging="zonder" end="12" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="21" infl="no_e" lcat="ap" lemma="snel" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="snel" sense="snel" vform="adj" word="snel"/>
+              <node begin="10" cat="advp" end="13" id="22" rel="mod">
+                <node begin="10" end="11" frame="zo_mogelijk_zo" his="normal" his_1="normal" id="23" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="hd" root="zo" sc="zo_mogelijk" sense="zo" word="zo"/>
+                <node aform="base" begin="12" buiging="zonder" end="13" frame="zo_mogelijk_mogelijk(no_e)" graad="basis" his="normal" his_1="normal" id="24" infl="no_e" lcat="ap" lemma="mogelijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="obcomp" root="mogelijk" sc="zo_mogelijk" sense="mogelijk" vform="adj" word="mogelijk"/>
+              </node>
+            </node>
+            <node begin="13" cat="np" end="15" id="25" rel="obj2">
+              <node begin="13" end="14" frame="determiner(een)" his="normal" his_1="normal" id="26" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="14" end="15" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="27" lcat="np" lemma="brief" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="brief" sense="brief" word="brief"/>
+            </node>
+            <node begin="15" end="16" frame="loc_adverb" his="normal" his_1="normal" id="28" lcat="advp" lemma="terug" pos="adv" postag="BW()" pt="bw" rel="mod" root="terug" sense="terug" special="loc" word="terug"/>
+            <node begin="16" end="17" frame="adverb" his="normal" his_1="abbreviation" his_1_1="normal" id="29" lcat="advp" lemma="alstublieft" pos="adv" postag="SPEC(afk)" pt="spec" rel="mod" root="alstublieft" sense="alstublieft" spectype="afk" word="a.u.b."/>
+            <node begin="17" cat="np" end="20" id="30" rel="obj1">
+              <node begin="17" end="18" frame="modal_adverb(adv_noun_prep)" his="decap" his_1="not_begin" id="31" lcat="advp" lemma="alvast" pos="adv" postag="BW()" pt="bw" rel="mod" root="alvast" sc="adv_noun_prep" sense="alvast" word="Alvast"/>
+              <node aform="base" begin="18" buiging="zonder" end="19" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="32" infl="no_e" lcat="ap" lemma="hartelijk" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="hartelijk" sense="hartelijk" vform="adj" word="hartelijk"/>
+              <node begin="19" end="20" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="33" lcat="np" lemma="dank" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dank" sense="dank" word="dank"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="20" end="21" frame="punct(punt)" his="normal" his_1="normal" id="34" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Want ik wil heel graag die telefoon hebben dus stuur zo snel mogelijk een brief terug a.u.b. Alvast hartelijk dank .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/bug3.example.ok
+++ b/tests/bug3.example.ok
@@ -120,26 +120,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ben</t>
-                <feat class="[zijn]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zijn</t>
-                  <feat class="[zijn]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(koppelww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.999628"/>
           <metric class="prevalenceZ" value="3.37248"/>
@@ -271,26 +251,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.6.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>doe</t>
-                <feat class="[doe]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>doe</t>
-                  <feat class="[doe]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="full-lemma" value="meedoen"/>
           <metric class="content_word" value="true"/>
@@ -776,26 +736,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.2.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heb</t>
-                <feat class="[heb]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heb</t>
-                  <feat class="[heb]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -2069,26 +2009,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.3.w.3.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
                 <feat class="[wil]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -2775,26 +2695,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.4.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heb</t>
-                <feat class="[heb]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heb</t>
-                  <feat class="[heb]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(tijdww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.994141"/>
           <metric class="prevalenceZ" value="2.52051"/>
@@ -3422,26 +3322,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.5.w.3.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
                 <feat class="[wil]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -3716,26 +3596,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.5.w.10.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>stuur</t>
-                <feat class="[stuur]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>stuur</t>
-                  <feat class="[stuur]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -4074,26 +3934,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.5.w.20.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>dank</t>
-                <feat class="[dank]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>dank</t>
-                  <feat class="[dank]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/bug4.example.alpino
+++ b/tests/bug4.example.alpino
@@ -1,0 +1,890 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="3" skips="1"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="mwu" end="2" his="robust_skip" id="1" rel="--">
+        <node begin="0" end="1" frame="punct(aanhaal_both)" id="2" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+        <node begin="1" end="2" frame="punct(aanhaal_both)" id="3" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+      </node>
+      <node begin="3" end="4" frame="preposition(met,[mee,[en,al]])" his="robust_skip" id="4" lcat="--" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="--" root="met" sense="met" vztype="init" word="met"/>
+      <node begin="5" end="6" frame="punct(hellip)" his="skip" id="5" lcat="--" lemma=".." pos="punct" postag="LET()" pt="let" rel="--" root=".." sense=".." special="hellip" word=".."/>
+      <node begin="6" end="7" frame="punct(vraag)" his="robust_skip" id="6" lcat="--" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+      <node begin="7" end="8" frame="punct(aanhaal_both)" his="robust_skip" id="7" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="2" cat="du" end="10" id="8" rel="--">
+        <node begin="2" end="3" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="9" lcat="advp" lemma="dag" pos="tag" postag="TSW()" pt="tsw" rel="dp" root="dag" sense="dag" word="Dag"/>
+        <node begin="4" case="both" def="indef" end="5" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="w_dia" id="10" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="dp" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" stype="whquestion" vwtype="vb" wh="ywh" word="wàt"/>
+        <node begin="8" cat="sv1" end="10" id="11" rel="dp">
+          <node begin="8" end="9" frame="verb(hebben,sg3,intransitive)" his="normal" his_1="normal" id="12" infl="sg3" lcat="sv1" lemma="vragen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="vraag" sc="intransitive" sense="vraag" stype="ynquestion" tense="present" word="vraagt" wvorm="pv"/>
+          <node begin="9" end="10" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="13" lcat="np" lemma="Leen" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Leen" sense="Leen" word="Leen"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="robust_skip" id="14" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' ' Dag met wàt .. ? ' vraagt Leen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="15" id="0" rel="top">
+      <node begin="0" cat="mwu" end="2" his="robust_skip" id="1" rel="--">
+        <node begin="0" end="1" frame="punct(aanhaal_both)" id="2" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+        <node begin="1" end="2" frame="punct(aanhaal_both)" id="3" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+      </node>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="4" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="2" cat="du" end="14" id="5" rel="--">
+        <node begin="2" cat="smain" end="4" id="6" rel="tag">
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Lieve" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Lieve" sense="Lieve" word="Lieve"/>
+          <node begin="3" end="4" frame="verb(hebben,sg,sbar)" his="normal" his_1="normal" id="8" infl="sg" lcat="smain" lemma="schatten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="schat" sc="sbar" sense="schat" stype="declarative" tense="present" word="schat" wvorm="pv"/>
+        </node>
+        <node begin="5" cat="smain" end="14" id="9" rel="nucl">
+          <node begin="5" end="6" frame="tmp_adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+          <node begin="6" end="7" frame="verb(unacc,sg3,copula_sbar)" his="normal" his_1="normal" id="11" infl="sg3" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="word" sc="copula_sbar" sense="word" stype="declarative" tense="present" word="wordt" wvorm="pv"/>
+          <node begin="7" end="8" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="12" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="sup" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+          <node begin="8" end="9" frame="tmp_noun(de,count,sg,subject_sbar)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="tijd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="tijd" sc="subject_sbar" sense="tijd" special="tmp" word="tijd"/>
+          <node begin="9" cat="cp" end="14" id="14" rel="su">
+            <node begin="9" conjtype="onder" end="10" frame="complementizer(dat)" his="normal" his_1="normal" id="15" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+            <node begin="10" cat="ssub" end="14" id="16" rel="body">
+              <node begin="10" case="both" def="def" end="11" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+              <node begin="11" cat="np" end="13" id="18" rel="obj1">
+                <node begin="11" end="12" frame="determiner(een)" his="normal" his_1="normal" id="19" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="keuze" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="keuze" sense="keuze" word="keuze"/>
+              </node>
+              <node begin="13" end="14" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="21" infl="sg3" lcat="ssub" lemma="maken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="maak" sc="transitive" sense="maak" tense="present" word="maakt" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="14" end="15" frame="punct(punt)" his="robust_skip" id="22" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' ' Lieve schat , dan wordt het tijd dat ze een keuze maakt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="18" id="0" rel="top">
+      <node begin="0" cat="mwu" end="2" his="normal" his_1="longpunct" id="1" rel="--">
+        <node begin="0" end="1" frame="punct(aanhaal_both)" id="2" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+        <node begin="1" end="2" frame="punct(aanhaal_both)" id="3" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+      </node>
+      <node begin="3" end="4" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="4" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="5" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="6" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="2" cat="du" end="17" id="7" rel="--">
+        <node begin="2" end="3" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="8" lcat="advp" lemma="tja" pos="tag" postag="TSW()" pt="tsw" rel="nucl" root="tja" sense="tja" word="Tja"/>
+        <node begin="5" cat="sv1" end="17" id="9" rel="tag">
+          <node begin="5" end="6" frame="verb(hebben,sg1,tr_sbar)" his="normal" his_1="normal" id="10" infl="sg1" lcat="sv1" lemma="zeggen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zeg" sc="tr_sbar" sense="zeg" tense="present" word="zeg" wvorm="pv"/>
+          <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="11" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="8" cat="cp" end="17" id="12" rel="mod">
+            <node begin="8" conjtype="onder" end="9" frame="complementizer" his="normal" his_1="normal" id="13" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+            <node begin="9" cat="ssub" end="17" id="14" rel="body">
+              <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="15" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+              <node begin="11" cat="ap" end="13" id="17" rel="mod">
+                <node begin="11" end="12" frame="adverb" his="normal" his_1="normal" id="18" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="mod" root="zo" sense="zo" word="zo"/>
+                <node aform="base" begin="12" buiging="zonder" end="13" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="19" infl="no_e" lcat="ap" lemma="gauw" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="gauw" sense="gauw" vform="adj" word="gauw"/>
+              </node>
+              <node begin="13" cat="np" end="16" id="20" rel="obj1">
+                <node begin="13" end="14" frame="determiner(een)" his="normal" his_1="normal" id="21" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="compar" begin="14" buiging="met-e" end="15" frame="adjective(ere)" graad="comp" his="normal" his_1="normal" id="22" infl="e" lcat="ap" lemma="goed" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,comp,met-e,stan)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="betere"/>
+                <node begin="15" end="16" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="23" lcat="np" lemma="tekst" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="tekst" sense="tekst" word="tekst"/>
+              </node>
+              <node begin="16" end="17" frame="verb(hebben,sg,transitive)" his="normal" his_1="normal" id="24" infl="sg" lcat="ssub" lemma="weten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="weet" sc="transitive" sense="weet" tense="present" word="weet" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="17" end="18" frame="punct(punt)" his="normal" his_1="normal" id="25" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' ' Tja ' , zeg ik , omdat ik niet zo gauw een betere tekst weet .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="mwu" end="2" his="normal" his_1="longpunct" id="1" rel="--">
+        <node begin="0" end="1" frame="punct(aanhaal_both)" id="2" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+        <node begin="1" end="2" frame="punct(aanhaal_both)" id="3" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+      </node>
+      <node begin="6" end="7" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="4" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="5" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="2" cat="du" end="10" id="6" rel="--">
+        <node begin="2" cat="smain" end="6" id="7" rel="nucl">
+          <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="8" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+          <node begin="3" end="4" frame="verb(zijn,pl,pc_pp(op))" his="normal" his_1="normal" id="9" infl="pl" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ga" sc="pc_pp(op)" sense="ga-op" stype="declarative" tense="present" word="gaan" wvorm="pv"/>
+          <node begin="4" cat="pp" end="6" id="10" rel="pc">
+            <node begin="4" end="5" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="11" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+            <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="winter_sport" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="winter_sport" sense="winter_sport" word="wintersport"/>
+          </node>
+        </node>
+        <node begin="8" cat="sv1" end="10" id="13" rel="tag">
+          <node begin="8" end="9" frame="verb(hebben,sg3,sbar)" his="normal" his_1="normal" id="14" infl="sg3" lcat="sv1" lemma="snikken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="snik" sc="sbar" sense="snik" tense="present" word="snikt" wvorm="pv"/>
+          <node begin="9" case="both" def="def" end="10" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="15" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' ' Ze gaan op wintersport ' , snikt ze .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="8" end="9" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="18" id="3" rel="--">
+        <node begin="1" cat="smain" end="8" id="4" rel="nucl">
+          <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+          <node begin="2" end="3" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="6" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="3" cat="advp" end="5" his="normal" his_1="normal" id="7" rel="mod">
+            <node begin="3" end="4" frame="adverb" id="8" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="4" end="5" frame="adverb" id="9" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="hd" root="helemaal" sense="helemaal" word="helemaal"/>
+          </node>
+          <node begin="5" cat="np" end="8" id="10" rel="predc">
+            <node begin="5" end="6" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="11" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+            <node aform="base" begin="6" buiging="met-e" end="7" frame="adjective(ge_e)" his="normal" his_1="normal" id="12" infl="e" lcat="ppart" lemma="wensen" pos="adj" positie="prenom" postag="WW(vd,prenom,met-e)" pt="ww" rel="mod" root="wensen" sense="wensen" vform="psp" word="gewenste" wvorm="vd"/>
+            <node begin="7" end="8" frame="noun(both,both,both)" gen="both" genus="onz" getal="ev" graad="basis" his="noun" id="13" lcat="np" lemma="antewoord" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="antewoord" sense="antewoord" word="antewoord"/>
+          </node>
+        </node>
+        <node begin="9" cat="sv1" end="18" id="14" rel="tag">
+          <node begin="9" end="10" frame="verb(hebben,sg1,sbar)" his="normal" his_1="normal" id="15" infl="sg1" lcat="sv1" lemma="merken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="merk" sc="sbar" sense="merk" tense="present" word="merk" wvorm="pv"/>
+          <node begin="10" case="nom" def="def" end="11" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="16" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="11" cat="pp" end="18" id="17" rel="mod">
+            <node begin="11" end="12" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="18" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+            <node begin="12" cat="np" end="18" id="19" rel="obj1">
+              <node begin="12" end="13" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="20" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node aform="base" begin="13" buiging="met-e" end="14" frame="adjective(ende(padv))" his="normal" his_1="V-de" his_1_1="part-V" id="21" infl="e" lcat="ppres" lemma="toe_nemen" pos="adj" positie="prenom" postag="WW(od,prenom,met-e)" pt="ww" rel="mod" root="neem_toe" sense="neem_toe" vform="gerund" word="toenemende" wvorm="od"/>
+              <node begin="14" end="15" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="volume" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="volume" sense="volume" word="volume"/>
+              <node begin="15" cat="pp" end="18" id="23" rel="mod">
+                <node begin="15" end="16" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="24" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                <node begin="16" cat="np" end="18" id="25" rel="obj1">
+                  <node begin="16" end="17" frame="name_determiner(pron,'LOC')" getal="ev" graad="basis" his="normal" his_1="gen" his_1_1="names_dictionary" id="26" infl="pron" lcat="detp" lemma="Leens" naamval="gen" neclass="LOC" ntype="eigen" pos="det" postag="N(eigen,ev,basis,gen)" pt="n" rel="det" root="Leens" sense="Leens" special="name" word="Leens"/>
+                  <node begin="17" end="18" frame="ge_v_noun(intransitive)" genus="onz" getal="ev" graad="basis" his="normal" his_1="ge-" id="27" lcat="np" lemma="gesnik" naamval="stan" ntype="soort" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="gesnik" sc="intransitive" sense="gesnik" special="ge_v_noun" word="gesnik"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(punt)" his="normal" his_1="normal" id="28" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Het is niet helemaal het gewenste antewoord , merk ik aan het toenemende volume van Leens gesnik .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="11" id="3" rel="--">
+        <node begin="1" cat="mwu" end="3" his="name" his_1="begin" id="4" rel="tag">
+          <node begin="1" end="2" frame="proper_name(both,'PER')" id="5" lcat="np" lemma="Jezus" neclass="PER" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Jezus" sense="Jezus" spectype="deeleigen" word="Jezus"/>
+          <node begin="2" end="3" frame="proper_name(both,'PER')" id="6" lcat="np" lemma="Leen" neclass="PER" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Leen" sense="Leen" spectype="deeleigen" word="Leen"/>
+        </node>
+        <node begin="4" cat="sv1" end="11" id="7" rel="nucl">
+          <node begin="4" end="5" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="8" infl="sg1" lcat="sv1" lemma="gebruiken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="gebruik" sc="transitive" sense="gebruik" stype="ynquestion" tense="present" word="gebruik" wvorm="pv"/>
+          <node begin="5" case="both" def="def" end="6" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+          <node begin="6" end="7" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="hersens" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="hersens" sense="hersens" word="hersens"/>
+          <node begin="7" end="8" frame="adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="nou" pos="adv" postag="BW()" pt="bw" rel="mod" root="nou" sense="nou" word="nou"/>
+          <node begin="8" end="9" frame="tmp_adverb" his="normal" his_1="normal" id="12" lcat="advp" lemma="eens" pos="adv" postag="BW()" pt="bw" rel="mod" root="eens" sense="eens" special="tmp" word="eens"/>
+          <node begin="9" cat="np" end="11" id="13" rel="mod">
+            <node begin="9" end="10" frame="determiner(een)" his="normal" his_1="normal" id="14" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="10" end="11" frame="tmp_noun(de,count,meas)" gen="de" genus="genus" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="keer" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,genus,stan)" pt="n" rel="hd" rnum="sg" root="keer" sense="keer" special="tmp" word="keer"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Jezus Leen , gebruik je hersens nou eens een keer .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" cat="conj" end="7" id="2" rel="--">
+        <node begin="1" end="2" frame="proper_name(both)" genus="genus" getal="ev" graad="basis" his="name" his_1="begin" id="3" lcat="np" lemma="Liselore" naamval="stan" neclass="MISC" ntype="eigen" num="both" pos="name" postag="N(eigen,ev,basis,genus,stan)" pt="n" rel="cnj" rnum="sg" root="Liselore" sense="Liselore" word="Liselore"/>
+        <node begin="2" conjtype="neven" end="3" frame="conj(en)" his="normal" his_1="normal" id="4" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="3" cat="np" end="7" id="5" rel="cnj">
+          <node begin="3" buiging="zonder" end="4" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="6" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+          <node begin="4" end="5" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="7" lcat="np" lemma="drel" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="drel" sense="drel" word="drel"/>
+          <node begin="5" cat="pp" end="7" id="8" rel="mod">
+            <node begin="5" end="6" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="9" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="6" case="dat_acc" def="def" end="7" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="fem" getal="getal" his="normal" his_1="normal" id="10" lcat="np" lemma="haar" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,getal,fem)" pt="vnw" rel="obj1" rnum="sg" root="haar" sense="haar" status="vol" vwtype="pers" wh="nwh" word="haar"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Liselore en die drel van haar .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" cat="whq" end="5" id="2" rel="--">
+        <node begin="1" case="both" def="indef" end="2" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="whd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="Wat"/>
+        <node begin="1" cat="sv1" end="5" id="4" rel="body">
+          <node begin="1" end="2" id="5" index="1" rel="predc"/>
+          <node begin="2" end="3" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="6" infl="sg_is" lcat="sv1" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="whquestion" tense="present" word="is" wvorm="pv"/>
+          <node begin="3" end="4" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="7" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="8" lcat="np" lemma="Leen" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Leen" sense="Leen" word="Leen"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(vraag)" his="normal" his_1="normal" id="9" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">' Wat is er Leen ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="18" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="1" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="2" end="3" frame="punct(vraag)" his="normal" his_1="normal" id="2" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+      <node begin="3" end="4" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="3" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="4" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="smain" end="17" id="5" rel="--">
+        <node begin="1" case="both" def="indef" end="2" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="vc" rnum="sg" root="wie" sense="wie" status="vol" stype="whquestion" vwtype="vb" wh="ywh" word="Wie"/>
+        <node begin="4" end="5" frame="verb(hebben,sg1,sbar)" his="normal" his_1="normal" id="7" infl="sg1" lcat="smain" lemma="vragen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="vraag" sc="sbar" sense="vraag" stype="declarative" tense="present" word="vraag" wvorm="pv"/>
+        <node begin="5" cat="np" end="17" id="8" rel="su">
+          <node begin="5" case="nom" def="def" end="6" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="hd" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="7" cat="cp" end="17" id="10" rel="mod">
+            <node begin="7" conjtype="onder" end="8" frame="complementizer(al)" his="normal" his_1="normal" id="11" lcat="cp" lemma="al" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="al" sc="al" sense="al" word="al"/>
+            <node begin="8" cat="sv1" end="17" id="12" rel="body">
+              <node begin="8" end="9" frame="verb(hebben,sg1,transitive_ndev)" his="normal" his_1="normal" id="13" infl="sg1" lcat="sv1" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="transitive_ndev" sense="heb" tense="present" word="heb" wvorm="pv"/>
+              <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="14" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node aform="base" begin="10" end="11" frame="adjective(pred(adv))" his="normal" his_1="normal" id="15" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+              <node begin="11" cat="np" end="17" id="16" rel="obj1">
+                <node begin="11" end="12" frame="determiner(een)" his="normal" his_1="normal" id="17" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="12" end="13" frame="noun(both,count,sg,sbar)" gen="both" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="idee" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="idee" sc="sbar" sense="idee" word="idee"/>
+                <node begin="13" cat="whsub" end="17" id="19" rel="vc">
+                  <node begin="13" cat="pp" end="15" id="20" index="1" rel="whd">
+                    <node begin="13" end="14" frame="preposition(om,[heen])" his="normal" his_1="normal" id="21" lcat="pp" lemma="om" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="om" sense="om" vztype="init" word="om"/>
+                    <node begin="14" case="both" def="indef" end="15" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="normal" id="22" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="obj1" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="wie"/>
+                  </node>
+                  <node begin="13" cat="ssub" end="17" id="23" rel="body">
+                    <node begin="13" end="15" id="24" index="1" rel="pc"/>
+                    <node begin="15" end="16" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="25" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+                    <node begin="16" end="17" frame="verb(zijn,sg3,pc_pp(om))" his="normal" his_1="normal" id="26" infl="sg3" lcat="ssub" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="pc_pp(om)" sense="ga-om" tense="present" word="gaat" wvorm="pv"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="17" end="18" frame="punct(punt)" his="normal" his_1="normal" id="27" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Wie ? ' vraag ik , al heb ik wel een idee om wie het gaat .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" cat="smain" end="5" id="2" rel="--">
+        <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+        <node begin="2" end="3" frame="verb(hebben,sg3,pc_pp(van))" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="houden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="houd" sc="pc_pp(van)" sense="houd-van" stype="declarative" tense="present" word="houdt" wvorm="pv"/>
+        <node begin="3" cat="pp" end="5" id="5" rel="pc">
+          <node begin="3" end="4" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="6" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="4" case="dat_acc" def="def" end="5" frame="pronoun(nwh,fir,sg,de,dat_acc,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="me" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,red,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="me" sense="me" special="wkpro" status="red" vwtype="pr" wh="nwh" word="me"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Ze houdt van me .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="Dat"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,ld_pp)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="staan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="sta" sc="ld_pp" sense="sta" stype="declarative" tense="present" word="staat" wvorm="pv"/>
+        <node begin="2" cat="pp" end="6" id="4" rel="ld">
+          <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="5" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="3" cat="np" end="6" id="6" rel="obj1">
+            <node begin="3" cat="detp" end="5" id="7" rel="det">
+              <node begin="3" buiging="zonder" end="4" frame="pre_det_quant(al)" his="normal" his_1="normal" id="8" infl="al" lcat="detp" lemma="al" naamval="stan" pdtype="det" pos="det" positie="vrij" postag="VNW(onbep,det,stan,vrij,zonder)" pt="vnw" rel="mod" root="al" sense="al" special="pre_det_quant" vwtype="onbep" word="al"/>
+              <node begin="4" buiging="zonder" end="5" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="9" infl="pron" lcat="detp" lemma="haar" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="hd" root="haar" sense="haar" status="vol" vwtype="bez" word="haar"/>
+            </node>
+            <node begin="5" end="6" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="10" lcat="np" lemma="sms" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="sms_DIM" sense="sms_DIM" word="smsjes"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat staat in al haar smsjes .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="obj1" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="Dat"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="zeggen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zeg" sc="transitive" sense="zeg" stype="declarative" tense="present" word="zegt" wvorm="pv"/>
+        <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="4" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+        <node begin="3" cat="np" end="5" id="5" rel="mod">
+          <node begin="3" buiging="met-e" end="4" frame="determiner(elke,nwh,mod)" his="normal" his_1="normal" id="6" infl="elke" lcat="detp" lemma="elk" naamval="stan" npagr="evz" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,met-e,evz)" pt="vnw" rel="det" root="elk" sense="elk" vwtype="onbep" wh="nwh" word="elke"/>
+          <node begin="4" end="5" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+        </node>
+        <node begin="5" cat="cp" end="9" id="8" rel="mod">
+          <node begin="5" conjtype="onder" end="6" frame="complementizer(als)" his="normal" his_1="normal" id="9" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="6" cat="ssub" end="9" id="10" rel="body">
+            <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="11" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+            <node begin="7" case="dat_acc" def="def" end="8" frame="pronoun(nwh,thi,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="elkaar" naamval="obl" num="pl" pdtype="pron" per="thi" persoon="persoon" pos="pron" postag="VNW(recip,pron,obl,vol,persoon,mv)" pt="vnw" rel="obj1" rnum="pl" root="elkaar" sense="elkaar" status="vol" vwtype="recip" wh="nwh" word="elkaar"/>
+            <node begin="8" end="9" frame="verb(hebben,pl,transitive)" his="normal" his_1="normal" id="13" infl="pl" lcat="ssub" lemma="bellen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="bel" sc="transitive" sense="bel" tense="present" word="bellen" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat zegt ze elke dag als we elkaar bellen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="34" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="11" end="12" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="33" id="3" rel="--">
+        <node begin="0" cat="np" end="21" id="4" rel="dp">
+          <node begin="0" cat="np" end="2" his="normal" his_1="decap" his_1_1="normal" id="5" rel="det">
+            <node begin="0" end="1" frame="determiner(een)" id="6" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+            <node begin="1" end="2" frame="noun(both,both,sg)" gen="both" genus="onz" getal="ev" graad="basis" id="7" lcat="np" lemma="paar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" root="paar" sense="paar" word="paar"/>
+          </node>
+          <node begin="2" end="3" frame="tmp_noun(de,count,meas)" gen="de" genus="genus" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="keer" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,genus,stan)" pt="n" rel="hd" rnum="sg" root="keer" sense="keer" special="tmp" word="keer"/>
+          <node begin="3" cat="pp" end="21" id="9" rel="mod">
+            <node begin="3" end="4" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="10" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+            <node begin="4" cat="conj" end="21" id="11" rel="obj1">
+              <node begin="4" cat="np" end="7" id="12" rel="cnj">
+                <node begin="4" end="5" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="13" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="strand" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="strand" sense="strand" word="strand"/>
+                <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(ge_no_e(adv))" his="normal" his_1="normal" id="15" infl="no_e" lcat="ppart" lemma="zien" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="mod" root="zien" sense="zien" vform="psp" word="gezien" wvorm="vd"/>
+              </node>
+              <node begin="8" cat="np" end="11" id="16" rel="cnj">
+                <node begin="8" cat="np" end="10" his="normal" his_1="normal" id="17" rel="det">
+                  <node begin="8" end="9" frame="determiner(een)" id="18" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                  <node begin="9" end="10" frame="noun(both,both,sg)" gen="both" genus="onz" getal="ev" graad="basis" id="19" lcat="np" lemma="paar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" root="paar" sense="paar" word="paar"/>
+                </node>
+                <node begin="10" end="11" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="20" lcat="np" lemma="gesprek" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="gesprek_DIM" sense="gesprek_DIM" word="gesprekjes"/>
+              </node>
+              <node begin="12" cat="np" end="21" id="21" rel="cnj">
+                <node begin="12" end="13" frame="determiner(een)" his="normal" his_1="normal" id="22" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="13" end="14" frame="tmp_noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="23" lcat="np" lemma="nacht" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="nacht_DIM" sc="measure" sense="nacht_DIM" special="tmp" word="nachtje"/>
+                <node begin="14" cat="np" end="20" id="24" rel="mod">
+                  <node aform="base" begin="14" buiging="zonder" end="15" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="25" infl="no_e" lcat="ap" lemma="stiekem" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="stiekem" sense="stiekem" vform="adj" word="stiekem"/>
+                  <node begin="15" end="16" frame="noun(both,both,both)" gen="both" genus="onz" getal="ev" graad="basis" his="noun" id="26" lcat="np" lemma="foezelen" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="foezelen" sense="foezelen" word="foezelen"/>
+                  <node begin="16" cat="pp" end="20" id="27" rel="mod">
+                    <node begin="16" end="17" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="28" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+                    <node begin="17" cat="conj" end="20" id="29" rel="obj1">
+                      <node begin="17" case="dat_acc" def="def" end="18" frame="pronoun(nwh,thi,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="30" lcat="np" lemma="elkaar" naamval="obl" num="pl" pdtype="pron" per="thi" persoon="persoon" pos="pron" postag="VNW(recip,pron,obl,vol,persoon,mv)" pt="vnw" rel="cnj" rnum="pl" root="elkaar" sense="elkaar" status="vol" vwtype="recip" wh="nwh" word="elkaar"/>
+                      <node begin="18" conjtype="neven" end="19" frame="conj(en)" his="normal" his_1="normal" id="31" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                      <node begin="19" end="20" frame="proper_name(both)" genus="genus" getal="ev" graad="basis" his="name" his_1="not_begin" id="32" lcat="np" lemma="that's" naamval="stan" neclass="MISC" ntype="eigen" num="both" pos="name" postag="N(eigen,ev,basis,genus,stan)" pt="n" rel="cnj" rnum="sg" root="that's" sense="that's" word="that's"/>
+                    </node>
+                  </node>
+                </node>
+                <node begin="20" end="21" frame="proper_name(both)" his="normal" his_1="url" id="33" lcat="np" lemma="it." neclass="MISC" num="both" pos="name" postag="SPEC(symb)" pt="spec" rel="app" rnum="sg" root="it." sense="it." spectype="symb" word="it."/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="21" cat="smain" end="33" id="34" rel="dp">
+          <node begin="21" end="22" frame="sentence_adverb" his="decap" his_1="not_begin" id="35" lcat="advp" lemma="misschien" pos="adv" postag="BW()" pt="bw" rel="mod" root="misschien" sense="misschien" special="sentence" word="Misschien"/>
+          <node begin="22" end="23" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="36" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="23" case="both" def="def" end="24" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="37" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="24" cat="ap" end="33" id="38" rel="predc">
+            <node aform="base" begin="24" buiging="zonder" end="25" frame="adjective(no_e(both),pp(op))" graad="basis" his="normal" his_1="normal" id="39" infl="no_e" lcat="ap" lemma="gek" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="gek" sc="pp(op)" sense="gek-op" vform="adj" word="gek"/>
+            <node begin="25" cat="pp" end="33" id="40" rel="pc">
+              <node begin="25" end="26" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="41" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+              <node begin="26" cat="np" end="33" id="42" rel="obj1">
+                <node begin="26" end="27" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="43" lcat="np" lemma="spel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="spel_DIM" sense="spel_DIM" word="spelletjes"/>
+                <node begin="27" cat="cp" end="33" id="44" rel="mod">
+                  <node begin="27" conjtype="onder" end="28" frame="complementizer(zoals)" his="normal" his_1="normal" id="45" lcat="cp" lemma="zoals" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zoals" sc="zoals" sense="zoals" word="zoals"/>
+                  <node begin="28" cat="ssub" end="33" id="46" rel="body">
+                    <node begin="28" case="both" def="def" end="29" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="47" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+                    <node begin="29" end="30" frame="tmp_adverb" his="normal" his_1="normal" id="48" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="mod" root="nu" sense="nu" special="tmp" word="nu"/>
+                    <node begin="30" cat="pp" end="32" id="49" rel="pc">
+                      <node begin="30" end="31" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="50" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+                      <node begin="31" case="dat_acc" def="def" end="32" frame="pronoun(nwh,je,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="51" lcat="np" lemma="jou" naamval="obl" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,obl,vol,2v,ev)" pt="vnw" rel="obj1" rnum="sg" root="jou" sense="jou" status="vol" vwtype="pers" wh="nwh" word="jou"/>
+                    </node>
+                    <node begin="32" end="33" frame="verb(hebben,sg3,pc_pp(met))" his="normal" his_1="normal" id="52" infl="sg3" lcat="ssub" lemma="spelen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="speel" sc="pc_pp(met)" sense="speel-met" tense="present" word="speelt" wvorm="pv"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="33" end="34" frame="punct(punt)" his="robust_skip" id="53" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een paar keer op het strand gezien , een paar gesprekjes , een nachtje stiekem foezelen met elkaar en that's it. Misschien is ze gek op spelletjes zoals ze nu met jou speelt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="du" end="6" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+        <node begin="1" cat="smain" end="6" id="3" rel="nucl">
+          <node begin="2" end="3" frame="verb(hebben,sg,aci)" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="laten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="laat" sc="aci" sense="laat" stype="declarative" tense="present" word="laat" wvorm="pv"/>
+          <node begin="3" case="both" def="def" end="4" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="5" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="4" case="dat_acc" def="def" end="5" frame="pronoun(nwh,fir,sg,de,dat_acc,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="6" index="1" lcat="np" lemma="me" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,red,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="me" sense="me" special="wkpro" status="red" vwtype="pr" wh="nwh" word="me"/>
+          <node begin="1" cat="inf" end="6" id="7" rel="vc">
+            <node begin="1" end="2" frame="tmp_adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="mod" root="nu" sense="nu" special="tmp" word="nu"/>
+            <node begin="4" end="5" id="9" index="1" rel="su"/>
+            <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="10" infl="inf" lcat="inf" lemma="zitten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zit" sc="intransitive" sense="zit" word="zitten" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">En nu laat ze me zitten .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="0" cat="conj" end="13" id="1" rel="--">
+        <node begin="0" cat="smain" end="5" id="2" rel="cnj">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+          <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="4" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="2" cat="conj" end="5" id="5" rel="predc">
+            <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="6" lcat="np" lemma="Agnes" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Agnes" sense="Agnes" word="Agnes"/>
+            <node begin="3" conjtype="neven" end="4" frame="conj(of)" his="normal" his_1="normal" id="7" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+            <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="8" lcat="np" lemma="Leen" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Leen" sense="Leen" word="Leen"/>
+          </node>
+        </node>
+        <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="9" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="6" cat="smain" end="13" id="10" rel="cnj">
+          <node aform="compar" begin="6" end="7" frame="adjective(anders)" his="normal" his_1="normal" id="11" infl="anders" lcat="ap" lemma="anders" pos="adj" postag="BW()" pt="bw" rel="predc" root="anders" sense="anders" vform="adj" word="anders"/>
+          <node begin="7" end="8" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="12" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="8" end="9" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="13" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+          <node begin="9" end="10" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+          <node begin="10" cat="pp" end="13" id="15" rel="mod">
+            <node begin="10" end="11" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="16" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="11" cat="np" end="13" id="17" rel="obj1">
+              <node begin="11" end="12" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="18" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="12" end="13" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="19" lcat="np" lemma="hand" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="hand_DIM" sense="hand_DIM" word="handje"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het is Agnes of Leen en anders is het dag met het handje .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="9" id="2" rel="--">
+        <node begin="0" cat="ap" end="3" id="3" rel="sat">
+          <node begin="0" end="1" frame="wh_adjective" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="hd" root="hoe" sense="hoe" wh="ywh" word="Hoe"/>
+          <node begin="1" cat="mwu" end="3" his="normal" his_1="normal" id="5" rel="mod">
+            <node begin="1" end="2" frame="post_wh_adverb" id="6" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mwp" root="dan" sense="dan" special="post_wh" word="dan"/>
+            <node begin="2" end="3" frame="post_wh_adverb" id="7" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mwp" root="ook" sense="ook" special="post_wh" word="ook"/>
+          </node>
+        </node>
+        <node begin="4" cat="sv1" end="9" id="8" rel="nucl">
+          <node begin="4" end="5" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="9" infl="sg1" lcat="sv1" lemma="forceren" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="forceer" sc="transitive" sense="forceer" stype="imparative" tense="present" word="forceer" wvorm="pv"/>
+          <node begin="5" cat="np" end="9" id="10" rel="obj1">
+            <node begin="5" end="6" frame="determiner(een)" his="normal" his_1="normal" id="11" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="uitspraak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="uitspraak" sense="uitspraak" word="uitspraak"/>
+            <node begin="7" cat="pp" end="9" id="13" rel="mod">
+              <node begin="7" end="8" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="14" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+              <node begin="8" case="dat_acc" def="def" end="9" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="fem" getal="getal" his="normal" his_1="normal" id="15" lcat="np" lemma="haar" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,getal,fem)" pt="vnw" rel="obj1" rnum="sg" root="haar" sense="haar" status="vol" vwtype="pers" wh="nwh" word="haar"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hoe dan ook , forceer een uitspraak van haar .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="whq" end="7" id="1" rel="--">
+        <node begin="0" cat="ap" end="2" id="2" index="1" rel="whd">
+          <node begin="0" end="1" frame="wh_adjective" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="mod" root="hoe" sense="hoe" wh="ywh" word="Hoe"/>
+          <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="4" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="goed" sense="goed" vform="adj" word="goed"/>
+        </node>
+        <node begin="0" cat="sv1" end="7" id="5" rel="body">
+          <node begin="0" end="2" id="6" index="1" rel="mod"/>
+          <node begin="2" end="3" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="7" infl="sg1" lcat="sv1" lemma="kennen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ken" sc="transitive" sense="ken" stype="whquestion" tense="present" word="ken" wvorm="pv"/>
+          <node begin="3" case="both" def="def" end="4" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="8" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+          <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="name" his_1="not_begin" id="9" lcat="np" lemma="Liselore" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Liselore" sense="Liselore" word="Liselore"/>
+          <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="nou" pos="adv" postag="BW()" pt="bw" rel="mod" root="nou" sense="nou" word="nou"/>
+          <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(sentadv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="eigenlijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="eigenlijk" sense="eigenlijk" vform="adj" word="eigenlijk"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hoe goed ken je Liselore nou eigenlijk .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="12" id="2" rel="--">
+        <node begin="0" cat="smain" end="3" id="3" rel="cnj">
+          <node begin="0" buiging="zonder" end="1" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="huilen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="su" rnum="sg" root="huil" sc="intransitive" sense="huil" special="v_noun" word="Huilen" wvorm="inf"/>
+          <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="5" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(both(adv))" graad="basis" his="normal" his_1="normal" id="6" infl="both" lcat="ap" lemma="prima" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="prima" sense="prima" vform="adj" word="prima"/>
+        </node>
+        <node begin="4" conjtype="neven" end="5" frame="conj(maar)" his="normal" his_1="normal" id="7" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="5" cat="smain" end="12" id="8" rel="cnj">
+          <node begin="6" end="7" frame="verb('hebben/zijn',sg,modifier(aux(inf)))" his="normal" his_1="normal" id="9" infl="sg" lcat="smain" lemma="moeten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" stype="declarative" tense="present" word="moet" wvorm="pv"/>
+          <node begin="7" case="both" def="def" end="8" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="10" index="1" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="5" cat="inf" end="12" id="11" rel="vc">
+            <node begin="5" end="6" frame="tmp_adverb" his="normal" his_1="normal" id="12" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+            <node begin="7" end="8" id="13" index="1" rel="su"/>
+            <node aform="base" begin="8" end="9" frame="adjective(pred(adv))" his="normal" his_1="normal" id="14" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+            <node begin="9" cat="np" end="11" id="15" rel="obj1">
+              <node begin="9" end="10" frame="determiner(een)" his="normal" his_1="normal" id="16" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="10" end="11" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="publiek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="publiek" sense="publiek" word="publiek"/>
+            </node>
+            <node begin="11" buiging="zonder" end="12" frame="verb(hebben,inf,transitive_ndev)" his="normal" his_1="normal" id="18" infl="inf" lcat="inf" lemma="hebben" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="heb" sc="transitive_ndev" sense="heb" word="hebben" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Huilen is prima , maar dan moet ze wel een publiek hebben .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="smain" end="4" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="kennen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ken" sc="transitive" sense="ken" stype="declarative" tense="present" word="ken" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="verschijnsel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="verschijnsel" sense="verschijnsel" word="verschijnsel"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik ken het verschijnsel .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="0" cat="conj" end="13" id="1" rel="--">
+        <node begin="0" cat="smain" end="5" id="2" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,part_transitive(uit))" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="uit_trekken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="trek_uit" sc="part_transitive(uit)" sense="trek_uit" tense="present" word="trek" wvorm="pv"/>
+          <node begin="2" cat="np" end="4" id="5" rel="obj1">
+            <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="6" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="jas" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="jas" sense="jas" word="jas"/>
+          </node>
+          <node begin="4" end="5" frame="particle(uit)" his="normal" his_1="normal" id="8" lcat="part" lemma="uit" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="uit" sense="uit" vztype="fin" word="uit"/>
+        </node>
+        <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="9" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="13" id="10" rel="cnj">
+          <node begin="0" end="1" id="11" index="1" rel="su"/>
+          <node begin="6" end="7" frame="verb(zijn,sg1,aux(inf))" his="normal" his_1="normal" id="12" infl="sg1" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="aux(inf)" sense="ga" tense="present" word="ga" wvorm="pv"/>
+          <node begin="0" cat="inf" end="13" id="13" rel="vc">
+            <node begin="0" end="1" id="14" index="1" rel="su"/>
+            <node begin="7" cat="pp" end="11" id="15" rel="pc">
+              <node begin="7" end="8" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="16" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+              <node begin="8" cat="np" end="11" id="17" rel="obj1">
+                <node begin="8" end="9" frame="determiner(een)" his="normal" his_1="normal" id="18" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(no_e(both))" graad="basis" his="normal" his_1="normal" id="19" infl="no_e" lcat="ap" lemma="vrij" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="vrij" sense="vrij" vform="adj" word="vrij"/>
+                <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="20" lcat="np" lemma="plek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="plek_DIM" sense="plek_DIM" word="plekje"/>
+              </node>
+            </node>
+            <node begin="11" end="12" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="bank" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="bank" sense="bank" word="bank"/>
+            <node begin="12" buiging="zonder" end="13" frame="verb(hebben,inf,np_pc_pp(op))" his="normal" his_1="normal" id="22" infl="inf" lcat="inf" lemma="zitten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zit" sc="np_pc_pp(op)" sense="zit-op" word="zitten" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="23" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik trek mijn jas uit en ga op een vrij plekje bank zitten .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Leen" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Leen" sense="Leen" word="Leen"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,er_pp_vp(van))" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="houden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="houd" sc="er_pp_vp(van)" sense="houd-van" stype="declarative" tense="present" word="houdt" wvorm="pv"/>
+        <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node begin="0" cat="pp" end="9" id="5" rel="pc">
+          <node begin="2" end="3" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="6" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="pobj1" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="7" lcat="pp" lemma="van" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="van" sense="van" vztype="fin" word="van"/>
+          <node begin="0" cat="oti" end="9" id="8" rel="vc">
+            <node begin="5" end="6" frame="complementizer(om)" his="normal" his_1="normal" id="9" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+            <node begin="0" cat="ti" end="9" id="10" rel="body">
+              <node begin="7" end="8" frame="complementizer(te)" his="normal" his_1="normal" id="11" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+              <node begin="0" cat="inf" end="9" id="12" rel="body">
+                <node begin="0" end="1" id="13" index="1" rel="su"/>
+                <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="energie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="energie" sense="energie" word="energie"/>
+                <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="15" infl="inf" lcat="inf" lemma="verspillen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="verspil" sc="transitive" sense="verspil" word="verspillen" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Leen houdt er niet van om energie te verspillen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Leen" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Leen" sense="Leen" word="Leen"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,intransitive)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="pp" end="4" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="5" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="3" end="4" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="traan" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="traan" sense="traan" word="tranen"/>
+        </node>
+        <node begin="4" cat="cp" end="8" id="7" rel="mod">
+          <node begin="4" conjtype="onder" end="5" frame="complementizer(als)" his="normal" his_1="normal" id="8" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="5" cat="ssub" end="8" id="9" rel="body">
+            <node begin="5" case="nom" def="def" end="6" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="6" end="7" frame="particle(thuis)" his="normal" his_1="normal" id="11" lcat="part" lemma="thuis" pos="part" postag="BW()" pt="bw" rel="svp" root="thuis" sense="thuis" word="thuis"/>
+            <node begin="7" end="8" frame="verb(unacc,sg1,part_intransitive(thuis))" his="normal" his_1="normal" id="12" infl="sg1" lcat="ssub" lemma="thuis_komen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kom_thuis" sc="part_intransitive(thuis)" sense="kom_thuis" tense="present" word="kom" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Leen is in tranen als ik thuis kom .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="21" id="0" rel="top">
+      <node begin="0" cat="conj" end="20" id="1" rel="--">
+        <node begin="0" cat="smain" end="8" id="2" rel="cnj">
+          <node begin="0" end="1" frame="sentence_adverb" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="advp" lemma="misschien" pos="adv" postag="BW()" pt="bw" rel="mod" root="misschien" sense="misschien" special="sentence" word="Misschien"/>
+          <node begin="1" end="2" frame="verb(hebben,sg3,sbar)" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="menen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="meen" sc="sbar" sense="meen" tense="present" word="meent" wvorm="pv"/>
+          <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="5" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="3" cat="whsub" end="8" id="6" rel="vc">
+            <node begin="3" case="both" def="indef" end="4" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="7" index="2" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="whd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="wat"/>
+            <node begin="3" cat="ssub" end="8" id="8" rel="body">
+              <node begin="3" end="4" id="9" index="2" rel="obj1"/>
+              <node begin="4" case="both" def="def" end="5" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+              <node begin="5" cat="pp" end="7" id="11" rel="mod">
+                <node begin="5" end="6" frame="preposition(tegen,[aan,in,op])" his="normal" his_1="normal" id="12" lcat="pp" lemma="tegen" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="tegen" sense="tegen" vztype="init" word="tegen"/>
+                <node begin="6" case="dat_acc" def="def" end="7" frame="pronoun(nwh,je,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="13" lcat="np" lemma="jou" naamval="obl" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,obl,vol,2v,ev)" pt="vnw" rel="obj1" rnum="sg" root="jou" sense="jou" status="vol" vwtype="pers" wh="nwh" word="jou"/>
+              </node>
+              <node begin="7" end="8" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="14" infl="sg3" lcat="ssub" lemma="zeggen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zeg" sc="transitive" sense="zeg" tense="present" word="zegt" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="8" conjtype="neven" end="9" frame="conj(maar)" his="normal" his_1="normal" id="15" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="0" cat="smain" end="20" id="16" rel="cnj">
+          <node begin="0" end="1" id="17" index="1" rel="mod"/>
+          <node begin="9" end="10" frame="verb(hebben,sg3,part_vp_obj(aan))" his="normal" his_1="normal" id="18" infl="sg3" lcat="smain" lemma="aan_durven" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="durf_aan" sc="part_vp_obj(aan)" sense="durf_aan" tense="present" word="durft" wvorm="pv"/>
+          <node begin="10" case="both" def="def" end="11" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="19" index="3" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="11" end="12" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="20" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="pobj1" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+          <node begin="12" end="13" frame="adverb" his="normal" his_1="normal" id="21" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+          <node begin="13" end="14" frame="particle(aan)" his="normal" his_1="normal" id="22" lcat="part" lemma="aan" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="aan" sense="aan" vztype="fin" word="aan"/>
+          <node begin="10" cat="oti" end="20" id="23" rel="vc">
+            <node begin="14" end="15" frame="complementizer(om)" his="normal" his_1="normal" id="24" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+            <node begin="10" cat="ti" end="20" id="25" rel="body">
+              <node begin="18" end="19" frame="complementizer(te)" his="normal" his_1="normal" id="26" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+              <node begin="10" cat="inf" end="20" id="27" rel="body">
+                <node begin="10" end="11" id="28" index="3" rel="su"/>
+                <node begin="15" cat="pp" end="17" id="29" rel="mod">
+                  <node begin="15" end="16" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="30" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="bij"/>
+                  <node begin="16" end="17" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="31" lcat="np" lemma="Agnes" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Agnes" sense="Agnes" word="Agnes"/>
+                </node>
+                <node begin="17" end="18" frame="particle(op)" his="normal" his_1="normal" id="32" lcat="part" lemma="op" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="op" sense="op" vztype="fin" word="op"/>
+                <node begin="19" buiging="zonder" end="20" frame="verb(zijn,inf,part_intransitive(op))" his="normal" his_1="normal" id="33" infl="inf" lcat="inf" lemma="op_stappen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="stap_op" sc="part_intransitive(op)" sense="stap_op" word="stappen" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="20" end="21" frame="punct(punt)" his="normal" his_1="normal" id="34" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Misschien meent ze wat ze tegen jou zegt maar durft ze het niet aan om bij Agnes op te stappen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="18" id="0" rel="top">
+      <node begin="0" cat="du" end="17" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="of" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="of" sc="root" sense="of" word="Of"/>
+        <node begin="1" cat="conj" end="17" id="3" rel="nucl">
+          <node begin="1" cat="smain" end="7" id="4" rel="cnj">
+            <node begin="2" end="3" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="5" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="present" word="heeft" wvorm="pv"/>
+            <node begin="3" case="both" def="def" end="4" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="6" index="1" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+            <node begin="1" cat="ppart" end="7" id="7" rel="vc">
+              <node begin="1" end="2" frame="sentence_adverb" his="normal" his_1="normal" id="8" index="2" lcat="advp" lemma="misschien" pos="adv" postag="BW()" pt="bw" rel="mod" root="misschien" sense="misschien" special="sentence" word="misschien"/>
+              <node begin="3" end="4" id="9" index="1" rel="su"/>
+              <node begin="4" end="5" frame="determiner(de,nwh,nmod,pro,nparg)" getal="getal" his="normal" his_1="normal" id="10" infl="de" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(aanw,pron,stan,vol,3,getal)" pt="vnw" rel="obj1" rnum="sg" root="die" sense="die" status="vol" vwtype="aanw" wh="nwh" word="die"/>
+              <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+              <node begin="6" buiging="zonder" end="7" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="12" infl="psp" lcat="ppart" lemma="maken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="maak" sc="transitive" sense="maak" word="gemaakt" wvorm="vd"/>
+            </node>
+          </node>
+          <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="13" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="1" cat="smain" end="17" id="14" rel="cnj">
+            <node begin="1" end="2" id="15" index="2" rel="mod"/>
+            <node begin="8" end="9" frame="verb(hebben,sg3,sbar)" his="normal" his_1="normal" id="16" infl="sg3" lcat="smain" lemma="betekenen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="beteken" sc="sbar" sense="beteken" tense="present" word="betekent" wvorm="pv"/>
+            <node begin="9" cat="np" end="11" id="17" rel="su">
+              <node begin="9" buiging="zonder" end="10" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="18" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+              <node begin="10" end="11" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="winter_sport" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="winter_sport" sense="winter_sport" word="wintersport"/>
+            </node>
+            <node begin="11" cat="cp" end="17" id="20" rel="vc">
+              <node begin="11" conjtype="onder" end="12" frame="complementizer(dat)" his="normal" his_1="normal" id="21" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+              <node begin="12" cat="ssub" end="17" id="22" rel="body">
+                <node begin="12" case="both" def="def" end="13" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="23" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+                <node begin="13" cat="pp" end="16" id="24" rel="pc">
+                  <node begin="13" end="14" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="25" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="bij"/>
+                  <node begin="14" cat="np" end="16" id="26" rel="obj1">
+                    <node begin="14" buiging="zonder" end="15" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="27" infl="pron" lcat="detp" lemma="haar" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="haar" sense="haar" status="vol" vwtype="bez" word="haar"/>
+                    <node begin="15" end="16" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="vriendin" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vriendin" sense="vriendin" word="vriendin"/>
+                  </node>
+                </node>
+                <node begin="16" end="17" frame="verb(unacc,sg3,pc_pp(bij))" his="normal" his_1="normal" id="29" infl="sg3" lcat="ssub" lemma="blijven" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="blijf" sc="pc_pp(bij)" sense="blijf-bij" tense="present" word="blijft" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="17" end="18" frame="punct(punt)" his="normal" his_1="normal" id="30" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Of misschien heeft ze die al gemaakt en betekent die wintersport dat ze bij haar vriendin blijft .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="30" id="0" rel="top">
+      <node begin="12" end="13" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="29" id="2" rel="--">
+        <node begin="0" cat="whrel" end="12" id="3" rel="sat">
+          <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="rhd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="Wat"/>
+          <node begin="0" cat="ssub" end="12" id="5" rel="body">
+            <node begin="0" end="1" id="6" index="1" rel="su"/>
+            <node begin="3" end="4" frame="verb(hebben,modal_not_u,modifier(aux(inf)))" his="normal" his_1="normal" id="7" infl="modal_not_u" lcat="ssub" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" tense="present" word="wil" wvorm="pv"/>
+            <node begin="0" cat="inf" end="12" id="8" rel="vc">
+              <node begin="0" end="1" id="9" index="1" rel="su"/>
+              <node begin="1" end="2" frame="sentence_adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="trouwens" pos="adv" postag="BW()" pt="bw" rel="mod" root="trouwens" sense="trouwens" special="sentence" word="trouwens"/>
+              <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+              <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,tr_sbar)" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="zeggen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zeg" sc="tr_sbar" sense="zeg" word="zeggen" wvorm="inf"/>
+              <node begin="5" cat="cp" end="12" id="13" rel="vc">
+                <node begin="5" conjtype="onder" end="6" frame="complementizer(dat)" his="normal" his_1="normal" id="14" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+                <node begin="6" cat="ssub" end="12" id="15" rel="body">
+                  <node begin="6" cat="np" end="8" id="16" rel="su">
+                    <node begin="6" buiging="zonder" end="7" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="17" infl="pron" lcat="detp" lemma="haar" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="haar" sense="haar" status="vol" vwtype="bez" word="haar"/>
+                    <node begin="7" end="8" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="verdriet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="verdriet" sense="verdriet" word="verdriet"/>
+                  </node>
+                  <node begin="8" end="9" frame="er_adverb(door)" his="normal" his_1="normal" id="19" lcat="pp" lemma="daardoor" pos="pp" postag="BW()" pt="bw" rel="mod" root="daardoor" sense="daardoor" special="er" word="daardoor"/>
+                  <node begin="9" cat="ap" end="11" id="20" rel="predc">
+                    <node aform="compar" begin="9" buiging="zonder" end="10" frame="adjective(meer)" graad="comp" his="normal" his_1="normal" id="21" infl="meer" lcat="ap" lemma="weinig" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="minder" sense="minder" vform="adj" vwtype="onbep" word="minder"/>
+                    <node aform="base" begin="10" buiging="zonder" end="11" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="22" infl="no_e" lcat="ap" lemma="oprecht" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="oprecht" sense="oprecht" vform="adj" word="oprecht"/>
+                  </node>
+                  <node begin="11" end="12" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="23" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="13" cat="smain" end="29" id="24" rel="nucl">
+          <node begin="13" end="14" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="25" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="pl" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+          <node begin="14" end="15" frame="verb(unacc,pl,cleft)" his="normal" his_1="normal" id="26" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="cleft" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node aform="base" begin="15" buiging="zonder" end="16" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="27" infl="no_e" lcat="ap" lemma="gewoon" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="gewoon" sense="gewoon" vform="adj" word="gewoon"/>
+          <node begin="16" cat="np" end="29" id="28" rel="predc">
+            <node begin="16" end="17" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="29" infl="pl_num" lcat="detp" lemma="twee" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="twee" sense="twee" word="twee"/>
+            <node begin="17" end="18" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="30" lcat="np" lemma="ding" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="ding" sense="ding" word="dingen"/>
+            <node begin="18" cat="rel" end="29" id="31" rel="mod">
+              <node begin="18" case="no_obl" end="19" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="32" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="18" cat="ssub" end="29" id="33" rel="body">
+                <node begin="19" case="both" def="def" end="20" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="34" index="3" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+                <node begin="22" end="23" frame="verb('hebben/zijn',sg,modifier(aux(inf)))" his="normal" his_1="normal" id="35" infl="sg" lcat="ssub" lemma="moeten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" tense="present" word="moet" wvorm="pv"/>
+                <node begin="18" cat="inf" end="29" id="36" rel="vc">
+                  <node begin="18" end="19" id="37" index="2" rel="obj1"/>
+                  <node begin="19" end="20" id="38" index="3" rel="su"/>
+                  <node begin="20" cat="pp" end="22" id="39" rel="ld">
+                    <node begin="20" end="21" frame="preposition(uit,[vandaan])" his="normal" his_1="normal" id="40" lcat="pp" lemma="uit" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="uit" sense="uit" vztype="init" word="uit"/>
+                    <node begin="21" case="dat_acc" def="def" end="22" frame="pronoun(nwh,thi,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="41" lcat="np" lemma="elkaar" naamval="obl" num="pl" pdtype="pron" per="thi" persoon="persoon" pos="pron" postag="VNW(recip,pron,obl,vol,persoon,mv)" pt="vnw" rel="obj1" rnum="pl" root="elkaar" sense="elkaar" status="vol" vwtype="recip" wh="nwh" word="elkaar"/>
+                  </node>
+                  <node begin="23" buiging="zonder" end="24" frame="verb(hebben,inf,np_ld_pp)" his="normal" his_1="normal" id="42" infl="inf" lcat="inf" lemma="houden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="houd" sc="np_ld_pp" sense="houd" word="houden" wvorm="inf"/>
+                  <node begin="24" cat="cp" end="29" id="43" rel="mod">
+                    <node begin="24" conjtype="onder" end="25" frame="complementizer(als)" his="normal" his_1="normal" id="44" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+                    <node begin="25" cat="ssub" end="29" id="45" rel="body">
+                      <node begin="25" case="both" def="def" end="26" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="46" index="4" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+                      <node begin="27" end="28" frame="verb(hebben,sg_hebt,modifier(aux(inf)))" his="normal" his_1="normal" id="47" infl="sg_hebt" lcat="ssub" lemma="willen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" tense="present" word="wilt" wvorm="pv"/>
+                      <node begin="25" cat="inf" end="29" id="48" rel="vc">
+                        <node begin="25" end="26" id="49" index="4" rel="su"/>
+                        <node begin="26" case="dat_acc" def="def" end="27" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="fem" getal="getal" his="normal" his_1="normal" id="50" lcat="np" lemma="haar" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,getal,fem)" pt="vnw" rel="obj1" rnum="sg" root="haar" sense="haar" status="vol" vwtype="pers" wh="nwh" word="haar"/>
+                        <node begin="28" buiging="zonder" end="29" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="51" infl="inf" lcat="inf" lemma="begrijpen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="begrijp" sc="transitive" sense="begrijp" word="begrijpen" wvorm="inf"/>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="29" end="30" frame="punct(punt)" his="normal" his_1="normal" id="52" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wat trouwens niet wil zeggen dat haar verdriet daardoor minder oprecht is , het zijn gewoon twee dingen die je uit elkaar moet houden als je haar wilt begrijpen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="20" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="19" id="2" rel="--">
+        <node begin="0" cat="smain" end="5" id="3" rel="cnj">
+          <node begin="0" case="both" def="def" end="1" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+          <node begin="1" end="2" frame="verb('hebben/zijn',sg3,ld_pp)" his="normal" his_1="normal" id="5" infl="sg3" lcat="smain" lemma="liggen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="lig" sc="ld_pp" sense="lig" stype="declarative" tense="present" word="ligt" wvorm="pv"/>
+          <node begin="2" cat="pp" end="5" id="6" rel="ld">
+            <node begin="2" end="3" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="7" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+            <node begin="3" cat="np" end="5" id="8" rel="obj1">
+              <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="bank" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="bank" sense="bank" word="bank"/>
+            </node>
+          </node>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="11" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="7" cat="smain" end="19" id="12" rel="cnj">
+          <node begin="7" cat="cp" end="14" id="13" rel="mod">
+            <node begin="7" conjtype="onder" end="8" frame="complementizer" his="normal" his_1="normal" id="14" lcat="cp" lemma="zodra" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zodra" sense="zodra" word="zodra"/>
+            <node begin="8" cat="ssub" end="14" id="15" rel="body">
+              <node begin="8" case="both" def="def" end="9" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="16" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+              <node begin="9" case="dat_acc" def="def" end="10" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+              <node begin="10" cat="pp" end="13" id="18" rel="pc">
+                <node begin="10" end="11" frame="preposition(in,[])" his="normal" his_1="normal" id="19" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                <node begin="11" cat="np" end="13" id="20" rel="obj1">
+                  <node begin="11" end="12" frame="determiner(de)" his="normal" his_1="normal" id="21" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="gang" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="gang" sense="gang" word="gang"/>
+                </node>
+              </node>
+              <node begin="13" end="14" frame="verb(hebben,sg3,np_pc_pp(in))" his="normal" his_1="normal" id="23" infl="sg3" lcat="ssub" lemma="horen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="hoor" sc="np_pc_pp(in)" sense="hoor-in" tense="present" word="hoort" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="14" end="15" frame="verb(zijn,sg3,vp)" his="normal" his_1="normal" id="24" infl="sg3" lcat="smain" lemma="beginnen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="begin" sc="vp" sense="begin" stype="declarative" tense="present" word="begint" wvorm="pv"/>
+          <node begin="15" case="both" def="def" end="16" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="25" index="1" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="15" cat="ti" end="19" id="26" rel="vc">
+            <node begin="17" end="18" frame="complementizer(te)" his="normal" his_1="normal" id="27" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="15" cat="inf" end="19" id="28" rel="body">
+              <node begin="15" end="16" id="29" index="1" rel="su"/>
+              <node aform="base" begin="16" buiging="zonder" end="17" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="30" infl="no_e" lcat="ap" lemma="hartverscheurend" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="hartverscheurend" sense="hartverscheurend" vform="adj" word="hartverscheurend"/>
+              <node begin="18" buiging="zonder" end="19" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="31" infl="inf" lcat="inf" lemma="snikken" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="snik" sc="intransitive" sense="snik" word="snikken" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="19" end="20" frame="punct(punt)" his="normal" his_1="normal" id="32" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ze ligt op de bank , en zodra ze mij in de gang hoort begint ze hartverscheurend te snikken .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="sv1" end="5" id="1" rel="--">
+        <node begin="0" dropped_agr="sg" end="1" frame="verb(hebben,sg,transitive)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="sg" lcat="sv1" lemma="zetten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zet" sc="transitive" sense="zet" stype="topic_drop" tense="present" word="Zet" wvorm="pv"/>
+        <node begin="1" case="dat_acc" def="def" end="2" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="fem" getal="getal" his="normal" his_1="normal" id="3" lcat="np" lemma="haar" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,getal,fem)" pt="vnw" rel="obj1" rnum="sg" root="haar" sense="haar" status="vol" vwtype="pers" wh="nwh" word="haar"/>
+        <node begin="2" cat="pp" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="5" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+          <node begin="3" cat="np" end="5" id="6" rel="obj1">
+            <node begin="3" end="4" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="7" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+            <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="blok" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="blok" sense="blok" word="blok"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zet haar voor het blok .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="2" id="0" rel="top">
+      <node begin="0" end="1" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="1" lcat="np" lemma="vrijdag" naamval="stan" ntype="eigen" num="sg" pos="noun" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="--" rnum="sg" root="vrijdag" sense="vrijdag" special="tmp" word="vrijdag"/>
+      <node begin="1" end="2" frame="punct(punt)" his="normal" his_1="normal" id="2" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">vrijdag .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/bug4.example.ok
+++ b/tests/bug4.example.ok
@@ -813,26 +813,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.2.s.1.w.8.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kom</t>
-                <feat class="[kom]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kom</t>
-                  <feat class="[kom]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="full-lemma" value="thuiskomen"/>
           <metric class="content_word" value="true"/>
@@ -2679,26 +2659,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.4.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ken</t>
-                <feat class="[ken]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ken</t>
-                  <feat class="[ken]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -4354,26 +4314,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>moet</t>
-                <feat class="[moet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>moet</t>
-                  <feat class="[moet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.6.s.1.w.7.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>moet</t>
                 <feat class="[moet]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -5232,26 +5172,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.7.s.1.w.4.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
                 <feat class="[wil]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -5984,26 +5904,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.7.s.1.w.23.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>moet</t>
-                <feat class="[moet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>moet</t>
-                  <feat class="[moet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.7.s.1.w.23.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>moet</t>
@@ -7084,26 +6984,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.8.s.1.w.7.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ga</t>
-                <feat class="[ga]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ga</t>
-                  <feat class="[ga]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -11243,7 +11123,7 @@
             <morphology>
               <morpheme class="complex">
                 <t>weet</t>
-                <feat class="[wijt]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
+                <feat class="[wijt]verb/present-tense/singular/1st-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
                   <t>wijt</t>
@@ -11253,8 +11133,7 @@
                 <morpheme class="inflection">
                   <feat class="present-tense" subset="inflection"/>
                   <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
+                  <feat class="1st-person-verb" subset="inflection"/>
                 </morpheme>
               </morpheme>
             </morphology>
@@ -14157,26 +14036,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.15.s.1.w.3.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>laat</t>
-                <feat class="[laat]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>laat</t>
-                  <feat class="[laat]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.15.s.1.w.3.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>laat</t>
@@ -18230,7 +18089,7 @@
           <morphology>
             <morpheme class="complex">
               <t>eens</t>
-              <feat class="[een]adjective/positive" subset="structure"/>
+              <feat class="[een]adjective[s]/positive" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>een</t>
@@ -18238,6 +18097,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>s</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -18581,8 +18441,8 @@
         <metric class="np_modifier_count" value="0"/>
         <metric class="character_count" value="39"/>
         <metric class="character_count_min_names" value="30"/>
-        <metric class="morpheme_count" value="10"/>
-        <metric class="morpheme_count_min_names" value="8"/>
+        <metric class="morpheme_count" value="11"/>
+        <metric class="morpheme_count_min_names" value="9"/>
         <metric class="d_level" value="0"/>
         <metric class="sub_verb_dist" value="0"/>
         <metric class="obj_verb_dist" value="1"/>
@@ -18807,8 +18667,8 @@
       <metric class="np_modifier_count" value="0"/>
       <metric class="character_count" value="39"/>
       <metric class="character_count_min_names" value="30"/>
-      <metric class="morpheme_count" value="10"/>
-      <metric class="morpheme_count_min_names" value="8"/>
+      <metric class="morpheme_count" value="11"/>
+      <metric class="morpheme_count_min_names" value="9"/>
       <metric class="d_level" value="0"/>
       <metric class="sub_verb_dist" value="0"/>
       <metric class="obj_verb_dist" value="1"/>
@@ -22737,26 +22597,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.22.s.1.w.5.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>forceer</t>
-                <feat class="[forceer]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>forceer</t>
-                  <feat class="[forceer]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -23463,26 +23303,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.23.s.1.w.1.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zet</t>
-                <feat class="[zet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zet</t>
-                  <feat class="[zet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.23.s.1.w.1.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>zet</t>
@@ -25866,8 +25686,8 @@
     <metric class="np_modifier_count" value="19"/>
     <metric class="character_count" value="1217"/>
     <metric class="character_count_min_names" value="1152"/>
-    <metric class="morpheme_count" value="373"/>
-    <metric class="morpheme_count_min_names" value="360"/>
+    <metric class="morpheme_count" value="374"/>
+    <metric class="morpheme_count_min_names" value="361"/>
     <metric class="d_level" value="61"/>
     <metric class="d_level_gt4" value="8"/>
     <metric class="question_count" value="3"/>

--- a/tests/bug5.example.alpino
+++ b/tests/bug5.example.alpino
@@ -1,0 +1,856 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="du" end="3" id="1" rel="--">
+        <node begin="0" cat="cp" end="2" id="2" rel="dp">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(np)" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="cp" lemma="behalve" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="behalve" sc="np" sense="behalve" word="Behalve"/>
+          <node begin="1" end="2" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="4" lcat="np" lemma="Britt" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="body" rnum="sg" root="Britt" sense="Britt" word="Britt"/>
+        </node>
+        <node begin="2" end="3" frame="tmp_adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="dp" root="dan" sense="dan" special="tmp" word="dan"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="robust_skip" id="6" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Behalve Britt dan .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="2" skips="1"/>
+    <node begin="0" cat="top" end="28" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(haak_open)" his="normal" his_1="normal" id="1" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="9" end="10" frame="punct(haak_sluit)" his="normal" his_1="normal" id="2" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="10" end="11" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="15" end="16" frame="punct(haak_open)" his="normal" his_1="normal" id="4" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="17" end="18" frame="punct(haak_sluit)" his="normal" his_1="normal" id="5" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="22" end="23" frame="postn_adverb" his="robust_skip" id="6" lcat="--" lemma="tegelijk" pos="adv" postag="BW()" pt="bw" rel="--" root="tegelijk" sense="tegelijk" special="postn" word="tegelijk"/>
+      <node begin="23" end="24" frame="punct(haak_open)" his="robust_skip" id="7" lcat="--" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="0" cat="du" end="26" id="8" rel="--">
+        <node begin="0" cat="cp" end="22" id="9" rel="dp">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(np)" his="normal" his_1="decap" his_1_1="normal" id="10" lcat="cp" lemma="behalve" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="behalve" sc="np" sense="behalve" word="Behalve"/>
+          <node begin="1" cat="conj" end="5" id="11" rel="mod">
+            <node begin="1" cat="ppart" end="3" id="12" rel="cnj">
+              <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="13" index="1" infl="no_e" lcat="ap" lemma="ongelooflijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="ongelooflijk" sense="ongelooflijk" vform="adj" word="ongelooflijk"/>
+              <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(ge_no_e(adv))" his="normal" his_1="normal" id="14" infl="no_e" lcat="ppart" lemma="verwennen" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="verwennen" sense="verwennen" vform="psp" word="verwend" wvorm="vd"/>
+            </node>
+            <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="15" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="1" cat="ap" end="5" id="16" rel="cnj">
+              <node begin="1" end="2" id="17" index="1" rel="mod"/>
+              <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(both(padv))" graad="basis" his="normal" his_1="normal" id="18" infl="both" lcat="ap" lemma="blasé" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="blasé" sense="blasé" vform="adj" word="blasé"/>
+            </node>
+          </node>
+          <node begin="5" cat="conj" end="22" id="19" rel="body">
+            <node begin="5" cat="np" end="17" id="20" rel="cnj">
+              <node begin="5" buiging="zonder" end="6" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="21" index="2" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="7" cat="np" end="9" id="22" index="3" rel="mod">
+                <node aform="base" begin="7" buiging="met-e" end="8" frame="adjective(e)" graad="basis" his="form_of_suffix" his_1="ische" id="23" infl="e" lcat="ap" lemma="gooisch" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="gooisch" sense="gooisch" vform="adj" word="Gooische"/>
+                <node begin="8" end="9" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="decap" his_1="not_begin" id="24" lcat="np" lemma="meisje" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="meisje" sense="meisje" word="Meisjes"/>
+              </node>
+              <node begin="11" cat="conj" end="14" id="25" rel="mod">
+                <node aform="base" begin="11" buiging="zonder" end="12" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="26" infl="no_e" lcat="ap" lemma="ordinair" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="cnj" root="ordinair" sense="ordinair" vform="adj" word="ordinair"/>
+                <node begin="12" conjtype="neven" end="13" frame="conj(en)" his="normal" his_1="normal" id="27" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                <node aform="base" begin="13" buiging="zonder" end="14" frame="adjective(no_e(padv))" graad="basis" his="compound" his_1="2" id="28" infl="no_e" lcat="ap" lemma="laag_begaafd" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="cnj" root="laag_begaafd" sense="laag_begaafd" vform="adj" word="laagbegaafd"/>
+              </node>
+              <node begin="14" buiging="zonder" end="15" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="29" lcat="np" lemma="doen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="hd" rnum="sg" root="doe" sc="intransitive" sense="doe" special="v_noun" word="doen" wvorm="inf"/>
+              <node begin="16" end="17" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="30" lcat="np" lemma="Barbie" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="Barbie" sense="Barbie" word="Barbie"/>
+            </node>
+            <node begin="18" conjtype="neven" end="19" frame="conj(of)" his="normal" his_1="normal" id="31" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+            <node begin="5" cat="np" end="22" id="32" rel="cnj">
+              <node begin="5" end="6" id="33" index="2" rel="det"/>
+              <node begin="7" end="9" id="34" index="3" rel="mod"/>
+              <node begin="19" end="20" frame="adverb" his="normal" his_1="normal" id="35" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+              <node begin="20" end="21" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="36" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+              <node aform="base" begin="21" buiging="met-e" end="22" frame="adjective(ende(padv),transitive)" his="normal" his_1="V-de" his_1_1="part-V" id="37" infl="e" lcat="np" lemma="voor_gaan" pos="adj" positie="prenom" postag="WW(od,prenom,met-e)" pt="ww" rel="hd" rnum="sg" root="ga_voor" sc="transitive" sense="ga_voor" vform="gerund" word="voorgaande" wvorm="od"/>
+            </node>
+          </node>
+        </node>
+        <node begin="24" cat="mwu" end="26" his="normal" his_1="names_dictionary" id="38" rel="dp">
+          <node begin="24" end="25" frame="proper_name(sg,'PER')" id="39" lcat="np" lemma="Kim" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Kim" sense="Kim" spectype="deeleigen" word="Kim"/>
+          <node begin="25" end="26" frame="proper_name(sg,'PER')" id="40" lcat="np" lemma="Kardashian" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Kardashian" sense="Kardashian" spectype="deeleigen" word="Kardashian"/>
+        </node>
+      </node>
+      <node begin="26" end="27" frame="punct(haak_sluit)" his="robust_skip" id="41" lcat="--" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="27" end="28" frame="punct(punt)" his="robust_skip" id="42" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Behalve ongelooflijk verwend en blasé zijn ( Gooische Meisjes ) , ordinair en laagbegaafd doen ( Barbie ) of al het voorgaande tegelijk ( Kim Kardashian ) .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="20" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(dubb_punt)" his="normal" his_1="normal" id="1" lcat="punct" lemma=":" pos="punct" postag="LET()" pt="let" rel="--" root=":" sense=":" special="dubb_punt" word=":"/>
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="8" end="9" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="10" end="11" frame="punct(komma)" his="normal" his_1="normal" id="4" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="12" end="13" frame="punct(komma)" his="normal" his_1="normal" id="5" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="14" end="15" frame="punct(komma)" his="normal" his_1="normal" id="6" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="19" id="7" rel="--">
+        <node begin="0" cat="np" end="2" id="8" rel="nucl">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="ingrediënt" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="ingrediënt" sense="ingrediënt" word="ingrediënten"/>
+        </node>
+        <node begin="3" cat="conj" end="19" id="11" rel="sat">
+          <node begin="3" cat="np" end="6" id="12" rel="cnj">
+            <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="13" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="14" infl="no_e" lcat="ap" lemma="fictief" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="fictief" sense="fictief" vform="adj" word="fictief"/>
+            <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="land" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="land" sense="land" word="land"/>
+          </node>
+          <node begin="7" end="8" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="kasteel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="cnj" rnum="pl" root="kasteel" sense="kasteel" word="kastelen"/>
+          <node begin="9" end="10" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="ridder" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="cnj" rnum="pl" root="ridder" sense="ridder" word="ridders"/>
+          <node begin="11" end="12" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="seks" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="seks" sense="seks" word="sex"/>
+          <node begin="13" end="14" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="macht" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="macht" sense="macht" word="macht"/>
+          <node begin="15" end="16" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="geweld" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="geweld" sense="geweld" word="geweld"/>
+          <node begin="16" conjtype="neven" end="17" frame="conj(en)" his="normal" his_1="normal" id="21" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="17" cat="mwu" end="19" his="name" his_1="not_begin" id="22" rel="cnj">
+            <node begin="17" end="18" frame="proper_name(sg,'PER')" id="23" lcat="np" lemma="Jason" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Jason" sense="Jason" spectype="deeleigen" word="Jason"/>
+            <node begin="18" end="19" frame="proper_name(sg,'PER')" id="24" lcat="np" lemma="Momoa" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Momoa" sense="Momoa" spectype="deeleigen" word="Momoa"/>
+          </node>
+        </node>
+      </node>
+      <node begin="19" end="20" frame="punct(punt)" his="normal" his_1="normal" id="25" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De ingrediënten : een fictief land , kastelen , ridders , sex , macht , geweld en Jason Momoa .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(aanw,pron,stan,vol,3,getal)" pt="vnw" rel="su" rnum="sg" root="die" sense="die" status="vol" vwtype="aanw" wh="nwh" word="Die"/>
+        <node begin="1" end="2" frame="verb(unacc,sg3,intransitive)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="bederven" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="bederf" sc="intransitive" sense="bederf" stype="declarative" tense="present" word="bederft" wvorm="pv"/>
+        <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node begin="3" cat="ap" end="5" id="5" rel="mod">
+          <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="mod" root="zo" sense="zo" word="zo"/>
+          <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="snel" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="snel" sense="snel" vform="adj" word="snel"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Die bederft niet zo snel .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="sv1" end="5" id="1" rel="--">
+        <node begin="0" dropped_agr="sg" dropped_prs="fir" end="1" frame="verb(hebben,sg1,fixed([{[acc(voordeel),pc(met)]}],no_passive))" his="normal" his_1="decap" his_1_1="normal" id="2" infl="sg1" lcat="sv1" lemma="doen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="doe" sc="fixed([{[acc(voordeel),pc(met)]}],no_passive)" sense="voordeel-doe-met" stype="topic_drop" tense="present" word="Doe" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="3" rel="obj1">
+          <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="4" infl="pron" lcat="detp" lemma="je" naamval="stan" npagr="agr" pdtype="det" persoon="2v" pos="det" positie="prenom" postag="VNW(bez,det,stan,red,2v,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="je" sense="je" status="red" vwtype="bez" word="je"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="voordeel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="voordeel" sense="voordeel" word="voordeel"/>
+        </node>
+        <node begin="1" cat="pp" end="5" id="6" rel="pc">
+          <node begin="1" end="2" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="7" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="obj1" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="4" end="5" frame="preposition(met,[mee],extracted_np)" his="normal" his_1="normal" id="8" lcat="pp" lemma="mee" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="mee" sc="extracted_np" sense="mee" vztype="fin" word="mee"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Doe er je voordeel mee .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="36" id="0" rel="top">
+      <node begin="11" end="12" frame="punct(haak_open)" his="normal" his_1="normal" id="1" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="17" end="18" frame="punct(haak_sluit)" his="normal" his_1="normal" id="2" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="18" end="19" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="20" end="21" frame="punct(haak_open)" his="normal" his_1="normal" id="4" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="26" end="27" frame="punct(haak_sluit)" his="normal" his_1="normal" id="5" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="29" end="30" frame="punct(haak_open)" his="normal" his_1="normal" id="6" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="0" cat="smain" end="34" id="7" rel="--">
+        <node begin="0" end="1" frame="sentence_adverb" his="normal" his_1="decap" his_1_1="normal" id="8" lcat="advp" lemma="dus" pos="adv" postag="BW()" pt="bw" rel="mod" root="dus" sense="dus" special="sentence" word="Dus"/>
+        <node begin="1" end="2" frame="verb(hebben,pl,transitive)" his="normal" his_1="normal" id="9" infl="pl" lcat="smain" lemma="ontwikkelen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ontwikkel" sc="transitive" sense="ontwikkel" stype="declarative" tense="present" word="ontwikkelen" wvorm="pv"/>
+        <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="10" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+        <node begin="3" cat="pp" end="7" id="11" rel="mod">
+          <node begin="3" end="4" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="12" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+          <node begin="4" cat="np" end="7" id="13" rel="obj1">
+            <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node aform="base" begin="5" buiging="met-e" end="6" frame="adjective(ende(padv))" his="normal" his_1="V-de" his_1_1="normal" id="15" infl="e" lcat="ppres" lemma="lopen" pos="adj" positie="prenom" postag="WW(od,prenom,met-e)" pt="ww" rel="mod" root="loop" sense="loop" vform="gerund" word="lopende" wvorm="od"/>
+            <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="band" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="band" sense="band" word="band"/>
+          </node>
+        </node>
+        <node begin="7" cat="np" end="34" id="17" rel="obj1">
+          <node aform="base" begin="7" buiging="met-e" end="8" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="18" infl="e" lcat="ap" lemma="akelig" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="akelig" sense="akelig" vform="adj" word="akelige"/>
+          <node begin="8" end="9" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="aandoening" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="aandoening" sense="aandoening" word="aandoeningen"/>
+          <node begin="9" cat="cp" end="34" id="20" rel="mod">
+            <node begin="9" conjtype="onder" end="10" frame="complementizer(als)" his="normal" his_1="normal" id="21" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+            <node begin="10" cat="conj" end="34" id="22" rel="body">
+              <node begin="10" cat="np" end="17" id="23" rel="cnj">
+                <node begin="10" end="11" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="24" lcat="np" lemma="bleachorexia" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="bleachorexia" sense="bleachorexia" word="bleachorexia"/>
+                <node begin="12" cat="pp" end="17" id="25" rel="mod">
+                  <node begin="12" end="13" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="26" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+                  <node begin="13" cat="np" end="17" id="27" rel="obj1">
+                    <node begin="13" cat="detp" end="15" his="normal" his_1="normal" id="28" rel="det">
+                      <node begin="13" end="14" frame="preposition(van,[])" id="29" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="mod" root="van" sense="van" vztype="init" word="van"/>
+                      <node begin="14" buiging="met-e" end="15" frame="determiner(de,nwh,nmod,pro,nparg)" id="30" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="hd" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+                    </node>
+                    <node aform="base" begin="15" buiging="met-e" end="16" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="31" infl="e" lcat="ap" lemma="leuk" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="leuk" sense="leuk" vform="adj" word="leuke"/>
+                    <node begin="16" end="17" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="compound" his_1="hyphen" id="32" lcat="np" lemma="glow-in-the-dark_tand" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="glow-in-the-dark_tand" sense="glow-in-the-dark_tand" word="glow-in-the-dark-tanden"/>
+                  </node>
+                </node>
+              </node>
+              <node begin="19" cat="np" end="26" id="33" rel="cnj">
+                <node begin="19" end="20" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="34" lcat="np" lemma="tanorexia" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="tanorexia" sense="tanorexia" word="tanorexia"/>
+                <node begin="21" cat="pp" end="26" id="35" rel="mod">
+                  <node begin="21" end="22" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="36" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+                  <node begin="22" cat="np" end="26" id="37" rel="obj1">
+                    <node begin="22" end="23" frame="determiner(de)" his="normal" his_1="normal" id="38" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                    <node aform="compar" begin="23" buiging="met-e" end="24" frame="adjective(ere)" graad="comp" his="normal" his_1="normal" id="39" infl="e" lcat="ap" lemma="goed" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,comp,met-e,stan)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="betere"/>
+                    <node begin="24" cat="mwu" end="26" his="double_compound" id="40" rel="hd">
+                      <node begin="24" end="25" frame="noun(de,mass,sg)" gen="de" id="41" lcat="np" lemma="Rachel" num="sg" pos="noun" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Rachel" sense="Rachel" spectype="deeleigen" word="Rachel"/>
+                      <node begin="25" end="26" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" id="42" lcat="np" lemma="Hazes_teint" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mwp" rnum="sg" root="Hazes_teint" sense="Hazes_teint" word="Hazes-teint"/>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node begin="27" conjtype="neven" end="28" frame="conj(en)" his="normal" his_1="normal" id="43" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="28" cat="np" end="34" id="44" rel="cnj">
+                <node begin="28" end="29" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="45" lcat="np" lemma="botoxia" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="botoxia" sense="botoxia" word="botoxia"/>
+                <node begin="30" cat="pp" end="34" id="46" rel="mod">
+                  <node begin="30" end="31" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="47" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+                  <node begin="31" cat="np" end="34" id="48" rel="obj1">
+                    <node begin="31" end="32" frame="determiner(een)" his="normal" his_1="normal" id="49" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                    <node aform="base" begin="32" buiging="zonder" end="33" frame="adjective(end(both))" his="normal" his_1="normal" id="50" infl="no_e" lcat="ppres" lemma="leven" pos="adj" positie="prenom" postag="WW(od,prenom,zonder)" pt="ww" rel="mod" root="leven" sense="leven" vform="gerund" word="levend" wvorm="od"/>
+                    <node begin="33" end="34" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="compound" his_1="2" id="51" lcat="np" lemma="dode_masker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="dode_masker" sense="dode_masker" word="dodenmasker"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="34" end="35" frame="punct(haak_sluit)" his="normal" his_1="normal" id="52" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="35" end="36" frame="punct(punt)" his="normal" his_1="normal" id="53" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dus ontwikkelen ze aan de lopende band akelige aandoeningen als bleachorexia ( voor van die leuke glow-in-the-dark-tanden ) , tanorexia ( voor de betere Rachel Hazes-teint ) en botoxia ( voor een levend dodenmasker ) .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="2" skips="1"/>
+    <node begin="0" cat="top" end="25" id="0" rel="top">
+      <node begin="2" end="3" frame="verb(unacc,sg3,copula)" his="robust_skip" id="1" infl="sg3" lcat="--" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="--" root="word" sc="copula" sense="word" tense="present" word="wordt" wvorm="pv"/>
+      <node begin="3" end="4" frame="punct(aanhaal_both)" his="robust_skip" id="2" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="12" end="13" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="24" id="4" rel="--">
+        <node begin="0" cat="du" end="2" id="5" rel="dp">
+          <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+          <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="7" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="nucl" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+        </node>
+        <node begin="4" cat="du" end="24" id="8" rel="dp">
+          <node begin="4" cat="np" end="8" id="9" rel="dp">
+            <node begin="4" cat="mwu" end="7" his="name" his_1="begin" id="10" rel="hd">
+              <node begin="4" end="5" frame="proper_name(both)" id="11" lcat="np" lemma="Game" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Game" sense="Game" spectype="deeleigen" word="Game"/>
+              <node begin="5" end="6" frame="proper_name(both)" id="12" lcat="np" lemma="of" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="of" sense="of" spectype="deeleigen" word="of"/>
+              <node begin="6" end="7" frame="proper_name(both)" id="13" lcat="np" lemma="thrones" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="thrones" sense="thrones" spectype="deeleigen" word="thrones"/>
+            </node>
+            <node begin="7" end="8" frame="number(hoofd(both))" his="normal" his_1="number_expression" id="14" infl="both" lcat="detp" lemma="':" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="app" root="':" sense="':" word="':"/>
+          </node>
+          <node begin="8" cat="np" end="24" id="15" rel="dp">
+            <node begin="8" end="9" frame="determiner(de)" his="w_dia" id="16" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="dé"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="hyphen" id="17" lcat="np" lemma="HBO_hit" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="HBO_hit" sense="HBO_hit" word="HBO-hit"/>
+            <node begin="10" cat="pp" end="12" id="18" rel="mod">
+              <node begin="10" end="11" frame="preposition(in,[])" his="normal" his_1="normal" id="19" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="11" end="12" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="20" lcat="np" lemma="Amerika" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Amerika" sense="Amerika" word="Amerika"/>
+            </node>
+            <node begin="13" cat="rel" end="24" id="21" rel="mod">
+              <node begin="13" case="no_obl" end="14" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="22" index="1" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="13" cat="ssub" end="24" id="23" rel="body">
+                <node begin="13" end="14" id="24" index="1" rel="su"/>
+                <node begin="22" end="23" frame="verb(hebben,modal_not_u,aux(inf))" his="normal" his_1="normal" id="25" infl="modal_not_u" lcat="ssub" lemma="zullen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="present" word="zal" wvorm="pv"/>
+                <node begin="13" cat="inf" end="24" id="26" rel="vc">
+                  <node begin="13" end="14" id="27" index="1" rel="su"/>
+                  <node begin="13" cat="ti" end="22" id="28" rel="vc">
+                    <node begin="20" end="21" frame="complementizer(te)" his="normal" his_1="normal" id="29" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                    <node begin="13" cat="inf" end="22" id="30" rel="body">
+                      <node begin="13" end="14" id="31" index="1" rel="obj1"/>
+                      <node begin="14" end="15" frame="sentence_adverb" his="normal" his_1="normal" id="32" lcat="advp" lemma="ongetwijfeld" pos="adv" postag="BW()" pt="bw" rel="mod" root="ongetwijfeld" sense="ongetwijfeld" special="sentence" word="ongetwijfeld"/>
+                      <node begin="15" end="16" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="33" lcat="advp" lemma="ergens" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(onbep,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="mod" root="ergens" sense="ergens" special="er_loc" status="vol" vwtype="onbep" word="ergens"/>
+                      <node begin="16" cat="pp" end="18" id="34" rel="mod">
+                        <node begin="16" end="17" frame="preposition(in,[])" his="normal" his_1="normal" id="35" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                        <node begin="17" end="18" frame="np(year)" his="normal" his_1="date_year" id="36" lcat="np" lemma="2012" neclass="year" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="obj1" root="2012" sense="2012" word="2012"/>
+                      </node>
+                      <node begin="18" cat="pp" end="20" id="37" rel="mod">
+                        <node begin="18" end="19" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="38" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="bij"/>
+                        <node begin="19" case="dat_acc" def="def" end="20" frame="pronoun(nwh,fir,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="39" lcat="np" lemma="ons" naamval="obl" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,mv)" pt="vnw" rel="obj1" rnum="pl" root="ons" sense="ons" status="vol" vwtype="pr" wh="nwh" word="ons"/>
+                      </node>
+                      <node begin="21" buiging="zonder" end="22" frame="verb(hebben,inf(no_e),transitive_ndev_ndev)" his="normal" his_1="normal" id="40" infl="inf(no_e)" lcat="inf" lemma="zien" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" word="zien" wvorm="inf"/>
+                    </node>
+                  </node>
+                  <node begin="23" buiging="zonder" end="24" frame="verb(unacc,inf,te_passive)" his="normal" his_1="normal" id="41" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="te_passive" sense="ben" word="zijn" wvorm="inf"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="24" end="25" frame="punct(punt)" his="robust_skip" id="42" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">En dat wordt ' Game of thrones ': dé HBO-hit in Amerika , die ongetwijfeld ergens in 2012 bij ons te zien zal zijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="26" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(ligg_streep)" his="normal" his_1="normal" id="1" lcat="punct" lemma="-" pos="punct" postag="LET()" pt="let" rel="--" root="-" sense="-" special="ligg_streep" word="-"/>
+      <node begin="12" end="13" frame="punct(ligg_streep)" his="normal" his_1="normal" id="2" lcat="punct" lemma="-" pos="punct" postag="LET()" pt="let" rel="--" root="-" sense="-" special="ligg_streep" word="-"/>
+      <node begin="14" end="15" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="19" end="20" frame="punct(komma)" his="normal" his_1="normal" id="4" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="25" id="5" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+        <node begin="1" cat="du" end="25" id="7" rel="nucl">
+          <node begin="1" cat="sv1" end="19" id="8" rel="sat">
+            <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev)" his="normal" his_1="normal" id="9" infl="sg1" lcat="sv1" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="transitive_ndev" sense="heb" tense="present" word="heb" wvorm="pv"/>
+            <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="3" cat="np" end="14" id="11" rel="obj1">
+              <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="12" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="13" lcat="np" lemma="spleet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="spleet_DIM" sense="spleet_DIM" word="spleetje"/>
+              <node begin="5" cat="pp" end="14" id="14" rel="mod">
+                <node begin="5" end="6" frame="preposition(tussen,[door,in,vandaan])" his="normal" his_1="normal" id="15" lcat="pp" lemma="tussen" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="tussen" sense="tussen" vztype="init" word="tussen"/>
+                <node begin="6" cat="np" end="14" id="16" rel="obj1">
+                  <node begin="6" end="7" frame="determiner(de)" his="normal" his_1="normal" id="17" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="8" cat="ap" end="12" id="18" rel="mod">
+                    <node begin="8" end="9" frame="adverb" his="normal" his_1="normal" id="19" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+                    <node begin="9" cat="advp" end="11" his="normal" his_1="normal" id="20" rel="mod">
+                      <node begin="9" end="10" frame="adverb" id="21" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+                      <node begin="10" end="11" frame="intensifier" id="22" lcat="advp" lemma="te" pos="adv" postag="BW()" pt="bw" rel="hd" root="te" sense="te" special="intensifier" word="te"/>
+                    </node>
+                    <node aform="base" begin="11" buiging="met-e" end="12" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="23" infl="e" lcat="ap" lemma="wit" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="hd" root="wit" sense="wit" vform="adj" word="witte"/>
+                  </node>
+                  <node begin="13" end="14" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="24" lcat="np" lemma="tand" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="tand" sense="tand" word="tanden"/>
+                </node>
+              </node>
+            </node>
+            <node begin="15" cat="cp" end="19" id="25" rel="mod">
+              <node begin="15" end="16" frame="modal_adverb" his="normal" his_1="normal" id="26" lcat="advp" lemma="net" pos="adv" postag="BW()" pt="bw" rel="mod" root="net" sc="modal" sense="net" word="net"/>
+              <node begin="16" conjtype="onder" end="17" frame="complementizer(als)" his="normal" his_1="normal" id="27" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+              <node begin="17" cat="mwu" end="19" his="name" his_1="not_begin" id="28" rel="body">
+                <node begin="17" end="18" frame="proper_name(sg,'PER')" id="29" lcat="np" lemma="Lara" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Lara" sense="Lara" spectype="deeleigen" word="Lara"/>
+                <node begin="18" end="19" frame="proper_name(sg,'PER')" id="30" lcat="np" lemma="Stone" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Stone" sense="Stone" spectype="deeleigen" word="Stone"/>
+              </node>
+            </node>
+          </node>
+          <node begin="20" cat="smain" end="25" id="31" rel="nucl">
+            <node begin="20" end="21" frame="tmp_adverb" his="normal" his_1="normal" id="32" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+            <node begin="21" end="22" frame="verb(unacc,sg1,copula)" his="normal" his_1="normal" id="33" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+            <node begin="22" case="both" def="def" end="23" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="34" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="23" end="24" frame="adverb" his="w_dia" id="35" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nóg"/>
+            <node aform="compar" begin="24" buiging="zonder" end="25" frame="adjective(er(adv))" graad="comp" his="normal" his_1="normal" id="36" infl="no_e" lcat="ap" lemma="hip" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="predc" root="hip" sense="hip" vform="adj" word="hipper"/>
+          </node>
+        </node>
+      </node>
+      <node begin="25" end="26" frame="punct(punt)" his="normal" his_1="normal" id="37" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">En heb je een spleetje tussen de - niet al te witte - tanden , net als Lara Stone , dan ben je nóg hipper .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="du" end="8" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+        <node begin="1" cat="whq" end="8" id="3" rel="nucl">
+          <node begin="1" end="2" frame="er_wh_loc_adverb" getal="getal" his="normal" his_1="normal" id="4" index="1" lcat="advp" lemma="waar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(vb,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="whd" root="waar" sense="waar" special="er_loc" status="vol" vwtype="vb" wh="ywh" word="waar"/>
+          <node begin="1" cat="sv1" end="8" id="5" rel="body">
+            <node begin="2" end="3" frame="verb(hebben,pl,refl_pc_pp(op))" his="normal" his_1="normal" id="6" infl="pl" lcat="sv1" lemma="verheugen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="verheug" sc="refl_pc_pp(op)" sense="zich-verheug-op" stype="whquestion" tense="present" word="verheugen" wvorm="pv"/>
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="7" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+            <node begin="4" end="5" frame="reflexive(fir,pl)" getal="mv" his="normal" his_1="normal" id="8" lcat="np" lemma="ons" naamval="obl" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,mv)" pt="vnw" refl="refl" rel="se" root="ons" sense="ons" status="vol" vwtype="pr" word="ons"/>
+            <node begin="5" end="6" frame="tmp_adverb" his="normal" his_1="normal" id="9" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="mod" root="nu" sense="nu" special="tmp" word="nu"/>
+            <node begin="6" end="7" frame="adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+            <node begin="1" cat="pp" end="8" id="11" rel="pc">
+              <node begin="1" end="2" id="12" index="1" rel="obj1"/>
+              <node begin="7" end="8" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="13" lcat="pp" lemma="op" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="op" sense="op" vztype="fin" word="op"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(vraag)" his="normal" his_1="normal" id="14" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">En waar verheugen we ons nu al op ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="mwu" end="3" his="name" his_1="begin" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(both)" id="2" lcat="np" lemma="Game" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Game" sense="Game" spectype="deeleigen" word="Game"/>
+        <node begin="1" end="2" frame="proper_name(both)" id="3" lcat="np" lemma="of" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="of" sense="of" spectype="deeleigen" word="of"/>
+        <node begin="2" end="3" frame="proper_name(both)" id="4" lcat="np" lemma="thrones" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="thrones" sense="thrones" spectype="deeleigen" word="thrones"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Game of thrones .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="3" id="0" rel="top">
+      <node begin="0" cat="np" end="2" id="1" rel="--">
+        <node aform="base" begin="0" buiging="met-e" end="1" frame="adjective(ge_e)" his="decap_and_compound" his_1="2" id="2" infl="e" lcat="ppart" lemma="glad_polijsten" pos="adj" positie="prenom" postag="WW(vd,prenom,met-e)" pt="ww" rel="mod" root="glad_polijsten" sense="glad_polijsten" vform="psp" word="Gladgepolijste" wvorm="vd"/>
+        <node begin="1" end="2" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="mens" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="mens" sense="mens" word="mensen"/>
+      </node>
+      <node begin="2" end="3" frame="punct(punt)" his="normal" his_1="normal" id="4" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Gladgepolijste mensen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="22" id="0" rel="top">
+      <node begin="0" cat="conj" end="21" id="1" rel="--">
+        <node begin="0" cat="smain" end="10" id="2" rel="cnj">
+          <node begin="0" cat="np" end="2" id="3" rel="su">
+            <node begin="0" buiging="zonder" end="1" frame="determiner(pron)" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="4" infl="pron" lcat="detp" lemma="hun" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,mv,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="hun" sense="hun" status="vol" vwtype="bez" word="Hun"/>
+            <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="houdbaarheid_datum" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="houdbaarheid_datum" sense="houdbaarheid_datum" word="houdbaarheidsdatum"/>
+          </node>
+          <node begin="2" end="3" frame="verb(unacc,sg3,ld_adv)" his="normal" his_1="normal" id="6" infl="sg3" lcat="smain" lemma="komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom" sc="ld_adv" sense="kom" stype="declarative" tense="present" word="komt" wvorm="pv"/>
+          <node begin="3" cat="mwu" end="6" his="normal" his_1="normal" id="7" rel="mod">
+            <node begin="3" end="4" frame="er_adverb([in,plaats,van])" id="8" lcat="pp" lemma="in" pos="pp" postag="BW()" pt="bw" rel="mwp" root="in" sense="in" special="er" word="in"/>
+            <node begin="4" end="5" frame="er_adverb([in,plaats,van])" id="9" lcat="pp" lemma="plaats" pos="pp" postag="BW()" pt="bw" rel="mwp" root="plaats" sense="plaats" special="er" word="plaats"/>
+            <node begin="5" end="6" frame="er_adverb([in,plaats,van])" id="10" lcat="pp" lemma="daarvan" pos="pp" postag="BW()" pt="bw" rel="mwp" root="daarvan" sense="daarvan" special="er" word="daarvan"/>
+          </node>
+          <node begin="6" cat="pp" end="9" id="11" rel="mod">
+            <node begin="6" end="7" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="12" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="7" cat="np" end="9" id="13" rel="obj1">
+              <node begin="7" end="8" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="8" end="9" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+            </node>
+          </node>
+          <node aform="compar" begin="9" buiging="zonder" end="10" frame="adjective(er(locadv))" graad="comp" his="normal" his_1="normal" id="16" infl="no_e" lcat="ap" lemma="dichtbij" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="ld" root="dichtbij" sense="dichtbij" vform="adj" word="dichterbij"/>
+        </node>
+        <node begin="10" conjtype="neven" end="11" frame="conj(en)" his="normal" his_1="normal" id="17" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="11" cat="smain" end="21" id="18" rel="cnj">
+          <node begin="11" cat="whrel" end="14" id="19" rel="mod">
+            <node begin="11" case="both" def="indef" end="12" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="20" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="rhd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="wat"/>
+            <node begin="11" cat="ssub" end="14" id="21" rel="body">
+              <node begin="11" end="12" id="22" index="1" rel="su"/>
+              <node begin="12" case="dat_acc" def="def" end="13" frame="pronoun(nwh,fir,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="23" lcat="np" lemma="ons" naamval="obl" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,mv)" pt="vnw" rel="obj1" rnum="pl" root="ons" sense="ons" status="vol" vwtype="pr" wh="nwh" word="ons"/>
+              <node begin="13" end="14" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="24" infl="sg3" lcat="ssub" lemma="betreffen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="betref" sc="transitive" sense="betref" tense="present" word="betreft" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="14" end="15" frame="verb(unacc,pl,copula)" his="normal" his_1="normal" id="25" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="15" case="both" def="def" end="16" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="26" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="16" end="17" frame="tmp_adverb" his="normal" his_1="normal" id="27" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="mod" root="nu" sense="nu" special="tmp" word="nu"/>
+          <node begin="17" cat="ap" end="21" id="28" rel="predc">
+            <node begin="17" end="18" frame="adverb" his="normal" his_1="normal" id="29" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+            <node aform="base" begin="18" buiging="zonder" end="19" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="30" infl="no_e" lcat="ap" lemma="hopeloos" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="hopeloos" sense="hopeloos" vform="adj" word="hopeloos"/>
+            <node begin="19" cat="pp" end="21" id="31" rel="mod">
+              <node begin="19" end="20" frame="preposition(over,[heen])" his="normal" his_1="normal" id="32" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sense="over" vztype="init" word="over"/>
+              <node begin="20" end="21" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="33" lcat="np" lemma="datum" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="datum" sense="datum" special="tmp" word="datum"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="21" end="22" frame="punct(punt)" his="normal" his_1="normal" id="34" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hun houdbaarheidsdatum komt in plaats daarvan met de dag dichterbij en wat ons betreft zijn ze nu al hopeloos over datum .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="name" his_1="begin" id="2" lcat="np" lemma="Imperfectie" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Imperfectie" sense="Imperfectie" word="Imperfectie"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="4" infl="no_e" lcat="ap" lemma="heet" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="heet" sense="heet" vform="adj" word="heet"/>
+        <node begin="3" cat="pp" end="6" id="5" rel="mod">
+          <node begin="3" end="4" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="6" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+          <node begin="4" cat="np" end="6" id="7" rel="obj1">
+            <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="catwalk" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="catwalk" sense="catwalk" word="catwalk"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(uitroep)" his="normal" his_1="normal" id="10" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Imperfectie is heet op de catwalk !</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" cat="pp" end="2" id="2" rel="mod">
+          <node begin="0" end="1" frame="preposition(in,[])" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="In"/>
+          <node begin="1" end="2" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="4" lcat="np" lemma="Hollywood" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Hollywood" sense="Hollywood" word="Hollywood"/>
+        </node>
+        <node begin="2" end="3" frame="verb(hebben,pl,part_intransitive(achter))" his="normal" his_1="normal" id="5" infl="pl" lcat="smain" lemma="achter_lopen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="loop_achter" sc="part_intransitive(achter)" sense="loop_achter" stype="declarative" tense="present" word="lopen" wvorm="pv"/>
+        <node begin="3" case="both" def="def" end="4" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="6" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+        <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="onbedoeld" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="onbedoeld" sense="onbedoeld" vform="adj" word="onbedoeld"/>
+        <node begin="5" end="6" frame="sentence_adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="altijd" pos="adv" postag="BW()" pt="bw" rel="mod" root="altijd" sense="altijd" special="sentence" word="altijd"/>
+        <node begin="6" cat="np" end="8" id="9" rel="mod">
+          <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="10" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="7" end="8" frame="mod_noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="11" lcat="np" lemma="beetje" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="beetje" sense="beetje" special="mod" word="beetje"/>
+        </node>
+        <node begin="8" end="9" frame="particle(achter)" his="normal" his_1="normal" id="12" lcat="part" lemma="achter" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="achter" sense="achter" vztype="fin" word="achter"/>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">In Hollywood lopen ze onbedoeld altijd een beetje achter .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="6" id="2" rel="--">
+        <node begin="0" end="1" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="advp" lemma="ja" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="ja" sense="ja" word="Ja"/>
+        <node begin="2" cat="np" end="6" id="4" rel="nucl">
+          <node begin="2" end="3" frame="determiner(de,nwh,nmod,pro,nparg)" getal="getal" his="normal" his_1="normal" id="5" infl="de" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(aanw,pron,stan,vol,3,getal)" pt="vnw" rel="hd" rnum="sg" root="die" sense="die" status="vol" vwtype="aanw" wh="nwh" word="die"/>
+          <node begin="3" cat="pp" end="6" id="6" rel="mod">
+            <node begin="3" end="4" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="7" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+            <node begin="4" cat="np" end="6" id="8" rel="obj1">
+              <node begin="4" end="5" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="9" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="10" lcat="np" lemma="plaat" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="plaat_DIM" sense="plaat_DIM" word="plaatje"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ja , die op het plaatje .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="6" id="2" rel="--">
+        <node begin="0" cat="inf" end="5" id="3" rel="nucl">
+          <node begin="0" end="1" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="jongen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="jongen" sense="jongen" word="Jongens"/>
+          <node begin="2" cat="advp" end="4" id="5" rel="mod">
+            <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+            <node begin="3" buiging="zonder" end="4" frame="postadv_adverb" graad="comp" his="normal" his_1="normal" id="7" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="meer"/>
+          </node>
+          <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf(no_e),transitive_ndev)" his="normal" his_1="normal" id="8" infl="inf(no_e)" lcat="inf" lemma="doen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="doe" sc="transitive_ndev" sense="doe" word="doen" wvorm="inf"/>
+        </node>
+        <node begin="5" end="6" frame="tag" his="normal" his_1="normal" id="9" lcat="advp" lemma="hoor" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="hoor" sense="hoor" word="hoor"/>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jongens , niet meer doen hoor .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="sv1" end="11" id="2" rel="--">
+        <node begin="0" dropped_agr="sg" end="1" frame="verb(hebben,sg,aci)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="sg" lcat="sv1" lemma="laten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="laat" sc="aci" sense="laat" stype="topic_drop" tense="present" word="Laat" wvorm="pv"/>
+        <node begin="1" cat="np" end="3" id="4" index="1" rel="obj1">
+          <node begin="1" buiging="zonder" end="2" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+          <node begin="2" end="3" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="wenkbrauw" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="wenkbrauw" sense="wenkbrauw" word="wenkbrauwen"/>
+        </node>
+        <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="maar" pos="adv" postag="BW()" pt="bw" rel="mod" root="maar" sense="maar" word="maar"/>
+        <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="lekker" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="lekker" sense="lekker" vform="adj" word="lekker"/>
+        <node begin="1" cat="inf" end="6" id="9" rel="vc">
+          <node begin="1" end="3" id="10" index="1" rel="su"/>
+          <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="11" infl="inf" lcat="inf" lemma="woekeren" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="woeker" sc="intransitive" sense="woeker" word="woekeren" wvorm="inf"/>
+        </node>
+        <node begin="7" cat="cp" end="11" id="12" rel="mod">
+          <node begin="7" end="8" frame="modal_adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="net" pos="adv" postag="BW()" pt="bw" rel="mod" root="net" sc="modal" sense="net" word="net"/>
+          <node begin="8" conjtype="onder" end="9" frame="complementizer(als)" his="normal" his_1="normal" id="14" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="9" cat="np" end="11" id="15" rel="body">
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="hyphen" id="16" lcat="np" lemma="HNTM_winnares" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="HNTM_winnares" sense="HNTM_winnares" word="HNTM-winnares"/>
+            <node begin="10" end="11" frame="proper_name(sg,'ORG')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="17" lcat="np" lemma="Tamara" naamval="stan" neclass="ORG" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="Tamara" sense="Tamara" word="Tamara"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(uitroep)" his="normal" his_1="normal" id="18" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Laat die wenkbrauwen maar lekker woekeren , net als HNTM-winnares Tamara !</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="37" id="0" rel="top">
+      <node begin="12" end="13" frame="punct(haak_open)" his="normal" his_1="normal" id="1" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="17" end="18" frame="punct(haak_sluit)" his="normal" his_1="normal" id="2" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="21" end="22" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="3" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="24" end="25" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="4" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="25" end="26" frame="punct(komma)" his="normal" his_1="normal" id="5" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="36" id="6" rel="--">
+        <node begin="0" cat="du" end="24" id="7" rel="dp">
+          <node begin="0" cat="pp" end="4" id="8" rel="dp">
+            <node begin="0" end="1" frame="preposition(na,[])" his="normal" his_1="decap" his_1_1="normal" id="9" lcat="pp" lemma="na" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="na" sense="na" vztype="init" word="Na"/>
+            <node begin="1" cat="np" end="4" id="10" rel="obj1">
+              <node begin="1" buiging="met-e" end="2" frame="determiner(onze)" getal="mv" his="normal" his_1="normal" id="11" infl="onze" lcat="detp" lemma="ons" naamval="stan" npagr="rest" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,mv,prenom,met-e,rest)" pt="vnw" rel="det" root="ons" sense="ons" status="vol" vwtype="bez" word="onze"/>
+              <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="12" infl="e" lcat="ap" lemma="jaar_lang" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="jaar_lang" sense="jaar_lang" vform="adj" word="jarenlange"/>
+              <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="obsessie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="obsessie" sense="obsessie" word="obsessie"/>
+            </node>
+          </node>
+          <node begin="4" cat="pp" end="19" id="14" rel="dp">
+            <node begin="4" end="5" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="15" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="5" cat="conj" end="19" id="16" rel="obj1">
+              <node begin="5" cat="np" end="7" id="17" rel="cnj">
+                <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="18" lcat="np" lemma="knuffel_serie_moordenaar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="knuffel_serie_moordenaar" sense="knuffel_serie_moordenaar" word="knuffelseriemoordenaar"/>
+                <node begin="6" end="7" frame="proper_name(sg)" genus="genus" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="19" lcat="np" lemma="Dexter" naamval="stan" neclass="MISC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,genus,stan)" pt="n" rel="app" rnum="sg" root="Dexter" sense="Dexter" word="Dexter"/>
+              </node>
+              <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="20" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="8" cat="np" end="19" id="21" rel="cnj">
+                <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="22" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="9" cat="conj" end="17" id="23" rel="mod">
+                  <node begin="9" cat="ap" end="12" id="24" rel="cnj">
+                    <node begin="9" cat="ap" end="11" id="25" rel="mod">
+                      <node begin="9" end="10" frame="meas_mod_noun(het,mass,sg)" gen="het" getal="ev" his="normal" his_1="normal" id="26" lcat="np" lemma="iets" naamval="stan" num="sg" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="me" rnum="sg" root="iets" sense="iets" special="meas_mod" status="vol" vwtype="onbep" word="iets"/>
+                      <node aform="compar" begin="10" buiging="zonder" end="11" frame="adjective(meer)" graad="comp" his="normal" his_1="normal" id="27" infl="meer" lcat="ap" lemma="weinig" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="hd" root="minder" sense="minder" vform="adj" vwtype="onbep" word="minder"/>
+                    </node>
+                    <node aform="base" begin="11" buiging="met-e" end="12" frame="adjective(e)" graad="basis" his="form_of_suffix" his_1="bare" id="28" infl="e" lcat="ap" lemma="knuffelbaar" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="hd" root="knuffelbaar" sense="knuffelbaar" vform="adj" word="knuffelbare"/>
+                  </node>
+                  <node begin="13" conjtype="neven" end="14" frame="conj(maar)" his="normal" his_1="normal" id="29" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+                  <node begin="14" cat="ap" end="17" id="30" rel="cnj">
+                    <node begin="14" cat="ap" end="16" id="31" rel="mod">
+                      <node aform="base" begin="14" end="15" frame="adjective(pred(adv))" his="normal" his_1="normal" id="32" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+                      <node aform="base" begin="15" buiging="zonder" end="16" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="33" infl="no_e" lcat="ap" lemma="ongelooflijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="ongelooflijk" sense="ongelooflijk" vform="adj" word="ongelooflijk"/>
+                    </node>
+                    <node aform="base" begin="16" buiging="met-e" end="17" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="34" infl="e" lcat="ap" lemma="geil" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="hd" root="geil" sense="geil" vform="adj" word="geile"/>
+                  </node>
+                </node>
+                <node begin="18" end="19" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="35" lcat="np" lemma="vampier" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vampier" sense="vampier" word="vampier"/>
+              </node>
+            </node>
+          </node>
+          <node begin="19" cat="np" end="24" id="36" rel="dp">
+            <node begin="19" end="20" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="37" lcat="np" lemma="Eric" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Eric" sense="Eric" word="Eric"/>
+            <node begin="20" cat="pp" end="24" id="38" rel="mod">
+              <node begin="20" end="21" frame="preposition(in,[])" his="normal" his_1="normal" id="39" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="22" cat="mwu" end="24" his="quoted_name" his_1="'" his_2="'" id="40" rel="obj1">
+                <node begin="22" end="23" frame="proper_name(both)" id="41" lcat="np" lemma="True" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="True" sense="True" spectype="deeleigen" word="True"/>
+                <node begin="23" end="24" frame="proper_name(both)" id="42" lcat="np" lemma="blood" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="blood" sense="blood" spectype="deeleigen" word="blood"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="26" cat="sv1" end="36" id="43" rel="dp">
+          <node begin="26" end="27" frame="verb(unacc,sg3,copula)" his="normal" his_1="normal" id="44" infl="sg3" lcat="sv1" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" tense="present" word="wordt" wvorm="pv"/>
+          <node begin="27" end="28" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="45" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+          <node aform="base" begin="28" end="29" frame="adjective(pred(adv))" his="normal" his_1="normal" id="46" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+          <node begin="29" end="30" frame="adverb" his="normal" his_1="normal" id="47" lcat="advp" lemma="weer" pos="adv" postag="BW()" pt="bw" rel="mod" root="weer" sense="weer" word="weer"/>
+          <node begin="30" end="31" frame="tmp_adverb" his="normal" his_1="normal" id="48" lcat="advp" lemma="eens" pos="adv" postag="BW()" pt="bw" rel="mod" root="eens" sense="eens" special="tmp" word="eens"/>
+          <node begin="31" cat="np" end="36" id="49" rel="predc">
+            <node begin="31" end="32" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="50" lcat="np" lemma="tijd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="tijd" sense="tijd" special="tmp" word="tijd"/>
+            <node begin="32" cat="pp" end="36" id="51" rel="mod">
+              <node begin="32" end="33" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="52" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+              <node begin="33" cat="np" end="36" id="53" rel="obj1">
+                <node begin="33" end="34" frame="determiner(een)" his="normal" his_1="normal" id="54" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="base" begin="34" buiging="met-e" end="35" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="55" infl="e" lcat="ap" lemma="vers" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="vers" sense="vers" vform="adj" word="verse"/>
+                <node begin="35" end="36" frame="noun(de,both,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="56" lcat="np" lemma="verslaving" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verslaving" sense="verslaving" word="verslaving"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="36" end="37" frame="punct(punt)" his="normal" his_1="normal" id="57" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Na onze jarenlange obsessie met knuffelseriemoordenaar Dexter en de iets minder knuffelbare ( maar wel ongelooflijk geile ) vampier Eric in ' True blood ' , wordt het wel weer eens tijd voor een verse verslaving .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="27" id="0" rel="top">
+      <node begin="11" end="12" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="18" end="19" frame="punct(dubb_punt)" his="normal" his_1="normal" id="2" lcat="punct" lemma=":" pos="punct" postag="LET()" pt="let" rel="--" root=":" sense=":" special="dubb_punt" word=":"/>
+      <node begin="0" cat="du" end="26" id="3" rel="--">
+        <node begin="0" cat="du" end="20" id="4" rel="dp">
+          <node begin="0" cat="smain" end="18" id="5" rel="tag">
+            <node begin="12" end="13" frame="verb('hebben/zijn',sg,modifier(aux(inf)))" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="moeten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" stype="declarative" tense="present" word="moet" wvorm="pv"/>
+            <node begin="0" cat="inf" end="18" id="7" rel="vc">
+              <node begin="0" cat="ppart" end="17" id="8" rel="vc">
+                <node begin="0" cat="cp" end="11" id="9" rel="mod">
+                  <node begin="0" conjtype="onder" end="1" frame="complementizer" his="normal" his_1="decap" his_1_1="normal" id="10" lcat="cp" lemma="nu" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="nu" sense="nu" word="Nu"/>
+                  <node begin="1" cat="ssub" end="11" id="11" rel="body">
+                    <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+                    <node begin="2" cat="np" end="6" id="13" rel="ld">
+                      <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                      <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="drempel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="drempel" sense="drempel" word="drempel"/>
+                      <node begin="4" cat="pp" end="6" id="16" rel="mod">
+                        <node begin="4" end="5" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="17" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+                        <node begin="5" end="6" frame="np(year)" his="normal" his_1="date_year" id="18" lcat="np" lemma="2012" neclass="year" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="obj1" root="2012" sense="2012" word="2012"/>
+                      </node>
+                    </node>
+                    <node begin="6" cat="conj" end="9" id="19" rel="mod">
+                      <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="20" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="cnj" root="goed" sense="goed" vform="adj" word="goed"/>
+                      <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="21" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                      <node aform="base" begin="8" buiging="zonder" end="9" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="22" infl="no_e" lcat="ap" lemma="veilig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="cnj" root="veilig" sense="veilig" vform="adj" word="veilig"/>
+                    </node>
+                    <node begin="9" end="10" frame="particle(over)" his="normal" his_1="normal" id="23" lcat="part" lemma="over" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="over" sense="over" vztype="fin" word="over"/>
+                    <node begin="10" end="11" frame="verb(unacc,pl,part_ld_transitive(over))" his="normal" his_1="normal" id="24" infl="pl" lcat="ssub" lemma="over_zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben_over" sc="part_ld_transitive(over)" sense="ben_over" tense="present" word="zijn" wvorm="pv"/>
+                  </node>
+                </node>
+                <node begin="13" end="14" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="25" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj2" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+                <node begin="14" end="15" frame="adverb" his="normal" his_1="normal" id="26" lcat="advp" lemma="maar" pos="adv" postag="BW()" pt="bw" rel="mod" root="maar" sense="maar" word="maar"/>
+                <node begin="15" end="16" frame="tmp_adverb" his="normal" his_1="normal" id="27" lcat="advp" lemma="eens" pos="adv" postag="BW()" pt="bw" rel="mod" root="eens" sense="eens" special="tmp" word="eens"/>
+                <node begin="16" buiging="zonder" end="17" frame="verb(hebben,psp,np_sbar)" his="normal" his_1="normal" id="28" infl="psp" lcat="ppart" lemma="zeggen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="zeg" sc="np_sbar" sense="zeg" word="gezegd" wvorm="vd"/>
+              </node>
+              <node begin="17" buiging="zonder" end="18" frame="verb(unacc,inf,passive)" his="normal" his_1="normal" id="29" infl="inf" lcat="inf" lemma="worden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="word" sc="passive" sense="word" word="worden" wvorm="inf"/>
+            </node>
+          </node>
+          <node begin="19" case="both" def="indef" end="20" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="30" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="nucl" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" stype="whquestion" vwtype="vb" wh="ywh" word="wat"/>
+        </node>
+        <node begin="20" cat="sv1" end="26" id="31" rel="dp">
+          <node begin="20" end="21" frame="verb(hebben,pl,modifier(aux(inf)))" his="normal" his_1="normal" id="32" infl="pl" lcat="sv1" lemma="willen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" stype="ynquestion" tense="present" word="willen" wvorm="pv"/>
+          <node begin="21" case="nom" def="def" end="22" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="33" index="1" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+          <node begin="21" cat="inf" end="26" id="34" rel="vc">
+            <node begin="21" end="22" id="35" index="1" rel="su"/>
+            <node begin="22" end="23" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="36" lcat="np" lemma="ab-so-luut" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="ab-so-luut" sense="ab-so-luut" word="ab-so-luut"/>
+            <node begin="23" cat="advp" end="25" id="37" rel="mod">
+              <node begin="23" end="24" frame="adverb" his="normal" his_1="normal" id="38" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+              <node begin="24" buiging="zonder" end="25" frame="postadv_adverb" graad="comp" his="normal" his_1="normal" id="39" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="meer"/>
+            </node>
+            <node begin="25" buiging="zonder" end="26" frame="verb(hebben,inf(no_e),ninv(transitive,part_transitive(terug)))" his="normal" his_1="part-V" id="40" infl="inf(no_e)" lcat="inf" lemma="terug_zien" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zie_terug" sc="part_transitive(terug)" sense="zie_terug" word="terugzien" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="26" end="27" frame="punct(vraag)" his="robust_skip" id="41" lcat="--" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">Nu we de drempel naar 2012 goed en veilig over zijn , moet het maar eens gezegd worden : wat willen we ab-so-luut niet meer terugzien ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="2" id="0" rel="top">
+      <node begin="0" end="1" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="compound" his_1="hyphen" id="1" lcat="np" lemma="Reality_ster" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="--" rnum="pl" root="Reality_ster" sense="Reality_ster" word="Reality-sterren"/>
+      <node begin="1" end="2" frame="punct(punt)" his="normal" his_1="normal" id="2" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Reality-sterren .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="18" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(dubb_punt)" his="normal" his_1="normal" id="1" lcat="punct" lemma=":" pos="punct" postag="LET()" pt="let" rel="--" root=":" sense=":" special="dubb_punt" word=":"/>
+      <node begin="0" cat="du" end="17" id="2" rel="--">
+        <node aform="base" begin="0" buiging="zonder" end="1" frame="adjective(ge_both(adv))" his="normal" his_1="decap" his_1_1="normal" id="3" infl="both" lcat="ppart" lemma="toe_geven" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="nucl" root="toe_geven" sense="toe_geven" vform="psp" word="Toegegeven" wvorm="vd"/>
+        <node begin="2" cat="smain" end="17" id="4" rel="sat">
+          <node begin="2" case="nom" def="def" end="3" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+          <node begin="3" end="4" frame="verb(hebben,pl,aux_psp_hebben)" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="hebben" wvorm="pv"/>
+          <node begin="2" cat="ppart" end="17" id="7" rel="vc">
+            <node begin="2" end="3" id="8" index="1" rel="su"/>
+            <node begin="4" end="5" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="pobj1" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+            <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(tmpadv))" graad="basis" his="normal" his_1="normal" id="10" infl="no_e" lcat="ap" lemma="lang" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="lang" sense="lang" vform="adj" word="lang"/>
+            <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv),subject_vp)" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="leuk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="leuk" sc="subject_vp" sense="leuk" vform="adj" word="leuk"/>
+            <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,pred_np_vp)" his="normal" his_1="normal" id="12" infl="psp" lcat="ppart" lemma="vinden" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="vind" sc="pred_np_vp" sense="vind" word="gevonden" wvorm="vd"/>
+            <node begin="8" cat="oti" end="17" id="13" rel="vc">
+              <node begin="8" end="9" frame="complementizer(om)" his="normal" his_1="normal" id="14" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+              <node begin="9" cat="ti" end="17" id="15" rel="body">
+                <node begin="11" end="12" frame="complementizer(te)" his="normal" his_1="normal" id="16" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="9" cat="inf" end="17" id="17" rel="body">
+                  <node begin="12" buiging="zonder" end="13" frame="verb(hebben,inf,ld_pp)" his="normal" his_1="normal" id="18" infl="inf" lcat="inf" lemma="kijken" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="kijk" sc="ld_pp" sense="kijk" word="kijken" wvorm="inf"/>
+                  <node begin="9" cat="pp" end="17" id="19" rel="ld">
+                    <node begin="9" end="10" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="20" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+                    <node begin="10" cat="np" end="17" id="21" rel="obj1">
+                      <node begin="10" end="11" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="mens" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="mens" sense="mens" word="mensen"/>
+                      <node begin="13" cat="rel" end="17" id="23" rel="mod">
+                        <node begin="13" case="no_obl" end="14" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="24" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+                        <node begin="13" cat="ssub" end="17" id="25" rel="body">
+                          <node begin="13" end="14" id="26" index="2" rel="su"/>
+                          <node begin="14" cat="np" end="16" his="normal" his_1="normal" id="27" rel="obj1">
+                            <node begin="14" end="15" frame="adverb" id="28" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="mod" root="helemaal" sense="helemaal" word="helemaal"/>
+                            <node begin="15" end="16" frame="noun(het,mass,sg)" gen="het" getal="ev" id="29" lcat="np" lemma="niets" naamval="stan" num="sg" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="hd" rnum="sg" root="niets" sense="niets" status="vol" vwtype="onbep" word="niets"/>
+                          </node>
+                          <node begin="16" end="17" frame="verb(hebben,pl,transitive_ndev_ndev)" his="normal" his_1="normal" id="30" infl="pl" lcat="ssub" lemma="kunnen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="kan" sc="transitive_ndev_ndev" sense="kan" tense="present" word="kunnen" wvorm="pv"/>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="17" end="18" frame="punct(punt)" his="normal" his_1="normal" id="31" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Toegegeven : we hebben het lang leuk gevonden om naar mensen te kijken die helemaal niets kunnen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="conj" end="7" id="1" rel="--">
+        <node begin="0" cat="whq" end="3" id="2" rel="cnj">
+          <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="whd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="Wat"/>
+          <node begin="0" cat="sv1" end="3" id="4" rel="body">
+            <node begin="0" end="1" id="5" index="1" rel="su"/>
+            <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="6" infl="sg_is" lcat="sv1" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="whquestion" tense="present" word="is" wvorm="pv"/>
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(nonadv))" graad="basis" his="special" his_1="decap" his_1_1="normal" id="7" infl="no_e" lcat="ap" lemma="hot" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="hot" sense="hot" vform="adj" word="HOT"/>
+          </node>
+        </node>
+        <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="8" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="4" cat="du" end="7" id="9" rel="cnj">
+          <node begin="4" end="5" frame="adverb" getal="ev" his="normal" his_1="normal" id="10" lcat="advp" lemma="wat" naamval="stan" pdtype="pron" persoon="3o" pos="adv" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="dp" root="wat" sense="wat" status="vol" vwtype="onbep" word="wat"/>
+          <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="dp" root="helemaal" sense="helemaal" word="helemaal"/>
+          <node begin="6" end="7" frame="proper_name(both,'ORG')" genus="zijd" getal="ev" graad="basis" his="name" his_1="not_begin" id="12" lcat="np" lemma="NOT" naamval="stan" neclass="ORG" ntype="eigen" num="both" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="dp" rnum="sg" root="NOT" sense="NOT" word="NOT"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(vraag)" his="normal" his_1="normal" id="13" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">Wat is HOT en wat helemaal NOT ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="both" def="def" end="1" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+        <node begin="1" end="2" frame="verb(unacc,pl,aux(inf))" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="blijven" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="blijf" sc="aux(inf)" sense="blijf" stype="declarative" tense="present" word="blijven" wvorm="pv"/>
+        <node begin="0" cat="inf" end="8" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" end="3" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="6" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="mod" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          <node begin="3" end="4" frame="sentence_adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="namelijk" pos="adv" postag="BW()" pt="bw" rel="mod" root="namelijk" sense="namelijk" special="sentence" word="namelijk"/>
+          <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="hardnekkig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="hardnekkig" sense="hardnekkig" vform="adj" word="hardnekkig"/>
+          <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,pc_pp(in))" his="normal" his_1="normal" id="9" infl="inf" lcat="inf" lemma="geloven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="geloof" sc="pc_pp(in)" sense="geloof-in" word="geloven" wvorm="inf"/>
+          <node begin="6" cat="pp" end="8" id="10" rel="pc">
+            <node begin="6" end="7" frame="preposition(in,[])" his="normal" his_1="normal" id="11" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+            <node begin="7" end="8" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="perfectie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="perfectie" sense="perfectie" word="perfectie"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ze blijven daar namelijk hardnekkig geloven in perfectie .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="2" skips="1"/>
+    <node begin="0" cat="top" end="28" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="16" conjtype="neven" end="17" frame="conj(en)" his="robust_skip" id="3" lcat="--" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="--" root="en" sense="en" word="en"/>
+      <node begin="0" cat="du" end="27" id="4" rel="--">
+        <node begin="0" cat="du" end="16" id="5" rel="dp">
+          <node begin="0" cat="smain" end="2" id="6" rel="dp">
+            <node begin="0" case="both" def="def" end="1" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="7" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+            <node begin="1" end="2" frame="verb(hebben,pl,intransitive)" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="zuipen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="zuip" sc="intransitive" sense="zuip" stype="declarative" tense="present" word="zuipen" wvorm="pv"/>
+          </node>
+          <node begin="3" cat="du" end="16" id="9" rel="dp">
+            <node begin="3" cat="conj" end="9" id="10" rel="dp">
+              <node begin="3" buiging="zonder" end="4" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="11" lcat="np" lemma="schreeuwen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="cnj" rnum="sg" root="schreeuw" sc="intransitive" sense="schreeuw" special="v_noun" word="schreeuwen" wvorm="inf"/>
+              <node begin="5" buiging="zonder" end="6" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="12" lcat="np" lemma="trouwen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="cnj" rnum="sg" root="trouw" sc="intransitive" sense="trouw" special="v_noun" word="trouwen" wvorm="inf"/>
+              <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="w_dia" id="13" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="én"/>
+              <node begin="7" cat="np" end="9" id="14" rel="cnj">
+                <node begin="7" buiging="zonder" end="8" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="15" lcat="np" lemma="scheiden" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="hd" rnum="sg" root="scheid" sc="intransitive" sense="scheid" special="v_noun" word="scheiden" wvorm="inf"/>
+                <node begin="8" end="9" frame="er_adverb(op)" his="normal" his_1="normal" id="16" lcat="pp" lemma="erop" pos="pp" postag="BW()" pt="bw" rel="mod" root="erop" sense="erop" special="er" word="erop"/>
+              </node>
+            </node>
+            <node begin="9" cat="ap" end="16" id="17" rel="dp">
+              <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="18" infl="no_e" lcat="ap" lemma="los" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="los" sense="los" vform="adj" word="los"/>
+              <node begin="10" cat="pp" end="16" id="19" rel="mod">
+                <node begin="10" end="11" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="20" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+                <node begin="11" cat="np" end="16" id="21" rel="obj1">
+                  <node begin="11" end="12" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="22" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                  <node begin="12" end="13" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="23" lcat="np" lemma="oog" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="oog" sense="oog" word="oog"/>
+                  <node begin="13" cat="pp" end="16" id="24" rel="mod">
+                    <node begin="13" end="14" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="25" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                    <node begin="14" cat="np" end="16" id="26" rel="obj1">
+                      <node begin="14" end="15" frame="determiner(de)" his="normal" his_1="normal" id="27" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                      <node begin="15" end="16" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="camera" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="camera" sense="camera" word="camera"/>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="17" cat="sv1" end="27" id="29" rel="dp">
+          <node begin="17" dropped_agr="pl" end="18" frame="verb(zijn,pl,aux(te_inf))" his="normal" his_1="normal" id="30" infl="pl" lcat="sv1" lemma="beginnen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="begin" sc="aux(te_inf)" sense="begin" stype="topic_drop" tense="present" word="beginnen" wvorm="pv"/>
+          <node begin="19" end="20" frame="predm_adverb" his="normal" his_1="normal" id="31" lcat="advp" lemma="zelf" pos="adv" postag="BW()" pt="bw" rel="predm" root="zelf" sense="zelf" special="predm" word="zelf"/>
+          <node begin="18" cat="ti" end="27" id="32" rel="vc">
+            <node begin="21" end="22" frame="complementizer(te)" his="normal" his_1="normal" id="33" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="18" cat="inf" end="27" id="34" rel="body">
+              <node begin="18" end="19" frame="sentence_adverb" his="normal" his_1="normal" id="35" lcat="advp" lemma="ondertussen" pos="adv" postag="BW()" pt="bw" rel="mod" root="ondertussen" sense="ondertussen" special="sentence" word="ondertussen"/>
+              <node begin="20" end="21" frame="sentence_adverb" his="normal" his_1="normal" id="36" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+              <node begin="22" buiging="zonder" end="23" frame="verb(hebben,inf,sbar)" his="normal" his_1="normal" id="37" infl="inf" lcat="inf" lemma="geloven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="geloof" sc="sbar" sense="geloof" word="geloven" wvorm="inf"/>
+              <node begin="23" cat="cp" end="27" id="38" rel="vc">
+                <node begin="23" conjtype="onder" end="24" frame="complementizer(dat)" his="normal" his_1="normal" id="39" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+                <node begin="24" cat="ssub" end="27" id="40" rel="body">
+                  <node begin="24" case="both" def="def" end="25" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="41" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+                  <node aform="base" begin="25" buiging="zonder" end="26" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="42" infl="no_e" lcat="ap" lemma="bijzonder" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="bijzonder" sense="bijzonder" vform="adj" word="bijzonder"/>
+                  <node begin="26" end="27" frame="verb(unacc,pl,copula)" his="normal" his_1="normal" id="43" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="27" end="28" frame="punct(punt)" his="robust_skip" id="44" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ze zuipen , schreeuwen , trouwen én scheiden erop los voor het oog van de camera en beginnen ondertussen zelf ook te geloven dat ze bijzonder zijn .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/bug5.example.ok
+++ b/tests/bug5.example.ok
@@ -1217,26 +1217,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>moet</t>
-                <feat class="[moet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>moet</t>
-                  <feat class="[moet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.2.s.1.w.13.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>moet</t>
                 <feat class="[moet]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -1342,7 +1322,7 @@
           <morphology>
             <morpheme class="complex">
               <t>eens</t>
-              <feat class="[een]adjective/positive" subset="structure"/>
+              <feat class="[een]adjective[s]/positive" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>een</t>
@@ -1350,6 +1330,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>s</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -2025,8 +2006,8 @@
         <metric class="np_modifier_count" value="1"/>
         <metric class="character_count" value="106"/>
         <metric class="character_count_min_names" value="106"/>
-        <metric class="morpheme_count" value="31"/>
-        <metric class="morpheme_count_min_names" value="31"/>
+        <metric class="morpheme_count" value="32"/>
+        <metric class="morpheme_count_min_names" value="32"/>
         <metric class="d_level" value="5"/>
         <metric class="d_level_gt4" value="1"/>
         <metric class="question_count" value="1"/>
@@ -2257,8 +2238,8 @@
       <metric class="np_modifier_count" value="1"/>
       <metric class="character_count" value="106"/>
       <metric class="character_count_min_names" value="106"/>
-      <metric class="morpheme_count" value="31"/>
-      <metric class="morpheme_count_min_names" value="31"/>
+      <metric class="morpheme_count" value="32"/>
+      <metric class="morpheme_count_min_names" value="32"/>
       <metric class="d_level" value="5"/>
       <metric class="d_level_gt4" value="1"/>
       <metric class="question_count" value="1"/>
@@ -5060,7 +5041,7 @@
           <morphology>
             <morpheme class="complex">
               <t>laagbegaafd</t>
-              <feat class="[[laag]adjective[be][gaaf]adjective/positive]adjective" subset="structure"/>
+              <feat class="[[laag]adjective[be][gaaf]adjective[d]/positive]adjective" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>laag</t>
@@ -5077,6 +5058,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>d</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -5738,8 +5720,8 @@
         <metric class="np_modifier_count" value="6"/>
         <metric class="character_count" value="121"/>
         <metric class="character_count_min_names" value="87"/>
-        <metric class="morpheme_count" value="30"/>
-        <metric class="morpheme_count_min_names" value="25"/>
+        <metric class="morpheme_count" value="31"/>
+        <metric class="morpheme_count_min_names" value="26"/>
         <metric class="d_level" value="5"/>
         <metric class="d_level_gt4" value="1"/>
         <metric class="imperative_count" value="1"/>
@@ -5967,8 +5949,8 @@
       <metric class="np_modifier_count" value="6"/>
       <metric class="character_count" value="121"/>
       <metric class="character_count_min_names" value="87"/>
-      <metric class="morpheme_count" value="30"/>
-      <metric class="morpheme_count_min_names" value="25"/>
+      <metric class="morpheme_count" value="31"/>
+      <metric class="morpheme_count_min_names" value="26"/>
       <metric class="d_level" value="5"/>
       <metric class="d_level_gt4" value="1"/>
       <metric class="imperative_count" value="1"/>
@@ -6851,26 +6833,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.7.s.1.w.26.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>bijzonder</t>
-                <feat class="[bijzonder]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>bijzonder</t>
-                  <feat class="[bijzonder]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
           <metric class="prevalenceP" value="0.999467"/>
@@ -14205,26 +14167,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.15.s.1.w.6.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>hoor</t>
-                <feat class="[hoor]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>hoor</t>
-                  <feat class="[hoor]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -14871,26 +14813,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.16.s.1.w.3.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heet</t>
-                <feat class="[heet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heet</t>
-                  <feat class="[heet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.16.s.1.w.3.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>heet</t>
@@ -15549,26 +15471,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.17.s.1.w.1.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>laat</t>
-                <feat class="[laat]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>laat</t>
-                  <feat class="[laat]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.17.s.1.w.1.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>laat</t>
@@ -20010,7 +19912,7 @@
           <morphology>
             <morpheme class="complex">
               <t>eens</t>
-              <feat class="[een]adjective/positive" subset="structure"/>
+              <feat class="[een]adjective[s]/positive" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>een</t>
@@ -20018,6 +19920,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>s</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -20550,8 +20453,8 @@
         <metric class="np_modifier_count" value="6"/>
         <metric class="character_count" value="171"/>
         <metric class="character_count_min_names" value="161"/>
-        <metric class="morpheme_count" value="46"/>
-        <metric class="morpheme_count_min_names" value="44"/>
+        <metric class="morpheme_count" value="47"/>
+        <metric class="morpheme_count_min_names" value="45"/>
         <metric class="d_level" value="2"/>
         <metric class="sub_verb_dist" value="0"/>
         <metric class="obj_verb_dist" value="NA"/>
@@ -20776,8 +20679,8 @@
       <metric class="np_modifier_count" value="6"/>
       <metric class="character_count" value="171"/>
       <metric class="character_count_min_names" value="161"/>
-      <metric class="morpheme_count" value="46"/>
-      <metric class="morpheme_count_min_names" value="44"/>
+      <metric class="morpheme_count" value="47"/>
+      <metric class="morpheme_count_min_names" value="45"/>
       <metric class="d_level" value="2"/>
       <metric class="sub_verb_dist" value="0"/>
       <metric class="obj_verb_dist" value="NA"/>
@@ -21533,26 +21436,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zal</t>
-                <feat class="[zal]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zal</t>
-                  <feat class="[zal]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.22.s.1.w.23.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zal</t>
                 <feat class="[zal]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -22290,7 +22173,7 @@
           <morphology>
             <morpheme class="complex">
               <t>fictief</t>
-              <feat class="[fictie]adjective/positive" subset="structure"/>
+              <feat class="[fictie]adjective[f]/positive" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>fictie</t>
@@ -22298,6 +22181,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>f</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -22971,8 +22855,8 @@
         <metric class="np_modifier_count" value="1"/>
         <metric class="character_count" value="69"/>
         <metric class="character_count_min_names" value="59"/>
-        <metric class="morpheme_count" value="17"/>
-        <metric class="morpheme_count_min_names" value="15"/>
+        <metric class="morpheme_count" value="18"/>
+        <metric class="morpheme_count_min_names" value="16"/>
         <metric class="d_level" value="2"/>
         <metric class="sub_verb_dist" value="NA"/>
         <metric class="obj_verb_dist" value="NA"/>
@@ -23197,8 +23081,8 @@
       <metric class="np_modifier_count" value="1"/>
       <metric class="character_count" value="69"/>
       <metric class="character_count_min_names" value="59"/>
-      <metric class="morpheme_count" value="17"/>
-      <metric class="morpheme_count_min_names" value="15"/>
+      <metric class="morpheme_count" value="18"/>
+      <metric class="morpheme_count_min_names" value="16"/>
       <metric class="d_level" value="2"/>
       <metric class="sub_verb_dist" value="NA"/>
       <metric class="obj_verb_dist" value="NA"/>
@@ -24090,8 +23974,8 @@
     <metric class="np_modifier_count" value="35"/>
     <metric class="character_count" value="1482"/>
     <metric class="character_count_min_names" value="1344"/>
-    <metric class="morpheme_count" value="408"/>
-    <metric class="morpheme_count_min_names" value="388"/>
+    <metric class="morpheme_count" value="412"/>
+    <metric class="morpheme_count_min_names" value="392"/>
     <metric class="d_level" value="48"/>
     <metric class="d_level_gt4" value="5"/>
     <metric class="question_count" value="3"/>

--- a/tests/concreet1.example.alpino
+++ b/tests/concreet1.example.alpino
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" cat="np" end="2" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="4" lcat="np" lemma="das_hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="das_hond" sense="das_hond" word="dashond"/>
+        </node>
+        <node begin="2" end="3" frame="verb(hebben,past(sg),ld_pp)" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="snuffelen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="snuffel" sc="ld_pp" sense="snuffel" stype="declarative" tense="past" word="snuffelde" wvorm="pv"/>
+        <node begin="3" cat="pp" end="6" id="6" rel="ld">
+          <node begin="3" end="4" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="7" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+          <node begin="4" cat="np" end="6" id="8" rel="obj1">
+            <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="10" lcat="np" lemma="klap_roos" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="klap_roos" sense="klap_roos" word="klaproos"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De dashond snuffelde aan de klaproos .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/concreet2.example.alpino
+++ b/tests/concreet2.example.alpino
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="drinken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="drink" sc="transitive" sense="drink" stype="declarative" tense="present" word="drink" wvorm="pv"/>
+        <node begin="2" cat="np" end="11" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(een)" his="normal" his_1="normal" id="5" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="3" end="4" frame="noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="glas" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="glas" sc="measure" sense="glas" word="glas"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="bourgogne" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="bourgogne" sense="bourgogne" word="bourgogne"/>
+          <node begin="5" cat="pp" end="11" id="8" rel="mod">
+            <node begin="5" end="6" frame="preposition(uit,[vandaan])" his="normal" his_1="normal" id="9" lcat="pp" lemma="uit" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="uit" sense="uit" vztype="init" word="uit"/>
+            <node begin="6" cat="np" end="11" id="10" rel="obj1">
+              <node begin="6" end="7" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="11" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="7" end="8" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="noorden" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="noorden" sense="noorden" word="noorden"/>
+              <node begin="8" cat="pp" end="11" id="13" rel="mod">
+                <node begin="8" end="9" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="14" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                <node begin="9" cat="np" end="11" id="15" rel="obj1">
+                  <node begin="9" end="10" frame="determiner(de)" his="normal" his_1="normal" id="16" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="10" end="11" frame="proper_name(sg,'LOC')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="17" lcat="np" lemma="Bourgogne" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Bourgogne" sense="Bourgogne" word="Bourgogne"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik drink een glas bourgogne uit het noorden van de Bourgogne .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/concreet2.example.ok
+++ b/tests/concreet2.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>drink</t>
-                <feat class="[drink]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>drink</t>
-                  <feat class="[drink]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/concreet3.example.alpino
+++ b/tests/concreet3.example.alpino
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="ruiken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ruik" sc="transitive" sense="ruik" stype="declarative" tense="present" word="ruik" wvorm="pv"/>
+        <node begin="2" cat="np" end="7" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="geur" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="geur" sense="geur" word="geur"/>
+          <node begin="4" cat="pp" end="7" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="5" cat="np" end="7" id="9" rel="obj1">
+              <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(ge_no_e(padv))" his="normal" his_1="normal" id="10" infl="no_e" lcat="ppart" lemma="aan_branden" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="mod" root="aan_branden" sense="aan_branden" vform="psp" word="aangebrand" wvorm="vd"/>
+              <node begin="6" end="7" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="vlees" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="vlees" sense="vlees" word="vlees"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik ruik de geur van aangebrand vlees .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/concreet3.example.ok
+++ b/tests/concreet3.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ruik</t>
-                <feat class="[ruik]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ruik</t>
-                  <feat class="[ruik]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/connective1.example.alpino
+++ b/tests/connective1.example.alpino
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" cat="cp" end="4" id="2" rel="mod">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(als)" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="Als"/>
+          <node begin="1" cat="ssub" end="4" id="4" rel="body">
+            <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="5" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="goed" sense="goed" vform="adj" word="goed"/>
+            <node begin="3" end="4" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="7" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="4" end="5" frame="verb(unacc,sg1,ld_adv)" his="normal" his_1="normal" id="8" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="ld_adv" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+        <node begin="5" case="nom" def="def" end="6" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="6" cat="pp" end="8" id="10" rel="mod">
+          <node begin="6" end="7" frame="preposition(om,[heen])" his="normal" his_1="normal" id="11" lcat="pp" lemma="om" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="om" sense="om" vztype="init" word="om"/>
+          <node begin="7" end="8" frame="tmp_np" his="normal" his_1="temporal_expression" id="12" lcat="np" lemma="18:30" pos="noun" postag="SPEC(symb)" pt="spec" rel="obj1" root="18:30" sense="18:30" special="tmp" spectype="symb" word="18:30"/>
+        </node>
+        <node begin="8" end="9" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="13" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="ld" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Als het goed is ben ik om 18:30 daar .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(unacc,sg1,ld_pp)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="vertrekken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="vertrek" sc="ld_pp" sense="vertrek" stype="declarative" tense="present" word="vertrek" wvorm="pv"/>
+        <node begin="2" cat="pp" end="4" id="4" rel="ld">
+          <node begin="2" end="3" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="5" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="3" end="4" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="6" lcat="np" lemma="Ede" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Ede" sense="Ede" word="Ede"/>
+        </node>
+        <node begin="4" cat="cp" end="9" id="7" rel="mod">
+          <node begin="4" conjtype="onder" end="5" frame="complementizer" his="normal" his_1="normal" id="8" lcat="cp" lemma="aangezien" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="aangezien" sense="aangezien" word="aangezien"/>
+          <node begin="5" cat="ssub" end="9" id="9" rel="body">
+            <node begin="5" end="6" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="10" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+            <node begin="6" cat="mwu" end="8" his="normal" his_1="temporal_expression" id="11" rel="predc">
+              <node begin="6" end="7" frame="tmp_np" id="12" lcat="np" lemma="5" numtype="hoofd" pos="noun" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="mwp" root="5" sense="5" special="tmp" word="5"/>
+              <node begin="7" end="8" frame="tmp_np" genus="onz" getal="ev" graad="basis" id="13" lcat="np" lemma="uur" naamval="stan" ntype="soort" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="mwp" root="uur" sense="uur" special="tmp" word="uur"/>
+            </node>
+            <node begin="8" end="9" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="14" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik vertrek naar Ede aangezien het 5 uur is .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/connective2.example.alpino
+++ b/tests/connective2.example.alpino
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="cp" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="modal_adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="net" pos="adv" postag="BW()" pt="bw" rel="mod" root="net" sc="modal" sense="net" word="net"/>
+          <node begin="3" conjtype="onder" end="4" frame="complementizer(als)" his="normal" his_1="normal" id="6" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="body" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        </node>
+        <node begin="5" cat="np" end="7" id="8" rel="predc">
+          <node begin="5" end="6" frame="determiner(een)" his="normal" his_1="normal" id="9" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="10" lcat="np" lemma="niet_roker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="niet_roker" sense="niet_roker" word="nietroker"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan is net als Piet een nietroker .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/connective3.example.alpino
+++ b/tests/connective3.example.alpino
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="18" id="2" rel="--">
+        <node begin="0" cat="pp" end="4" id="3" rel="mod">
+          <node begin="0" cat="mwu" end="3" his="normal" his_1="decap" his_1_1="normal" id="4" rel="hd">
+            <node begin="0" end="1" frame="preposition([met,behulp,van],[])" id="5" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="mwp" root="met" sense="met" vztype="init" word="Met"/>
+            <node begin="1" end="2" frame="preposition([met,behulp,van],[])" genus="onz" getal="ev" graad="basis" id="6" lcat="pp" lemma="behulp" naamval="stan" ntype="soort" pos="prep" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="mwp" root="behulp" sense="behulp" word="behulp"/>
+            <node begin="2" end="3" frame="preposition([met,behulp,van],[])" id="7" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="mwp" root="van" sense="van" vztype="init" word="van"/>
+          </node>
+          <node begin="3" end="4" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="8" lcat="np" lemma="Rogier" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Rogier" sense="Rogier" word="Rogier"/>
+        </node>
+        <node begin="4" end="5" frame="verb(unacc,sg3,ld_pp)" his="normal" his_1="normal" id="9" infl="sg3" lcat="smain" lemma="komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom" sc="ld_pp" sense="kom" stype="declarative" tense="present" word="komt" wvorm="pv"/>
+        <node begin="5" end="6" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="10" lcat="np" lemma="Ko" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Ko" sense="Ko" word="Ko"/>
+        <node aform="base" begin="7" end="8" frame="adjective(pred(adv))" his="normal" his_1="normal" id="11" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+        <node begin="6" cat="pp" end="9" id="12" rel="ld">
+          <node begin="6" end="7" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="13" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="obj1" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="8" end="9" frame="preposition(uit,[vandaan])" his="normal" his_1="normal" id="14" lcat="pp" lemma="uit" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="uit" sense="uit" vztype="fin" word="uit"/>
+        </node>
+        <node begin="10" cat="cp" end="18" id="15" rel="mod">
+          <node begin="10" conjtype="onder" end="11" frame="complementizer" his="normal" his_1="normal" id="16" lcat="cp" lemma="alhoewel" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="alhoewel" sense="alhoewel" word="alhoewel"/>
+          <node begin="11" cat="ssub" end="18" id="17" rel="body">
+            <node begin="11" end="12" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="18" index="1" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+            <node begin="16" end="17" frame="verb(hebben,modal_not_u,aux(inf))" his="normal" his_1="normal" id="19" infl="modal_not_u" lcat="ssub" lemma="zullen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="present" word="zal" wvorm="pv"/>
+            <node begin="11" cat="inf" end="18" id="20" rel="vc">
+              <node begin="11" end="12" id="21" index="1" rel="su"/>
+              <node begin="12" end="13" frame="adverb" his="normal" his_1="normal" id="22" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+              <node begin="13" cat="mwu" end="16" his="normal" his_1="variant" his_1_1="variant" his_1_1_1="à" his_1_1_2="a" his_1_2="normal" id="23" rel="mod">
+                <node begin="13" end="14" frame="adverb" id="24" lcat="advp" lemma="à" pos="adv" postag="SPEC(vreemd)" pt="spec" rel="mwp" root="à" sense="à" spectype="vreemd" word="a"/>
+                <node begin="14" end="15" frame="adverb" id="25" lcat="advp" lemma="la" pos="adv" postag="SPEC(vreemd)" pt="spec" rel="mwp" root="la" sense="la" spectype="vreemd" word="la"/>
+                <node begin="15" end="16" frame="adverb" id="26" lcat="advp" lemma="minute" pos="adv" postag="SPEC(vreemd)" pt="spec" rel="mwp" root="minute" sense="minute" spectype="vreemd" word="minute"/>
+              </node>
+              <node begin="17" buiging="zonder" end="18" frame="verb(unacc,inf,intransitive)" his="normal" his_1="normal" id="27" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="intransitive" sense="ben" word="zijn" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(uitroep)" his="normal" his_1="normal" id="28" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Met behulp van Rogier komt Ko er wel uit , alhoewel het niet a la minute zal zijn !</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/connective3.example.ok
+++ b/tests/connective3.example.ok
@@ -611,26 +611,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zal</t>
-                <feat class="[zal]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zal</t>
-                  <feat class="[zal]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.1.w.17.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zal</t>
                 <feat class="[zal]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">

--- a/tests/connective4.example.alpino
+++ b/tests/connective4.example.alpino
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="3" cat="np" end="5" id="4" rel="predc">
+          <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="5" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="roker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="roker" sense="roker" word="roker"/>
+        </node>
+        <node begin="2" cat="ap" end="7" id="7" rel="mod">
+          <node aform="base" begin="2" end="3" frame="als_adjective(both(adv))" his="normal" his_1="normal" id="8" infl="both" lcat="ap" lemma="evenmin" pos="adj" postag="BW()" pt="bw" rel="hd" root="evenmin" sc="als" sense="evenmin" vform="adj" word="evenmin"/>
+          <node begin="5" cat="cp" end="7" id="9" rel="obcomp">
+            <node begin="5" conjtype="onder" end="6" frame="comparative(als)" his="normal" his_1="normal" id="10" lcat="comparative" lemma="als" pos="comparative" postag="VG(onder)" pt="vg" rel="cmp" root="als" sense="als" word="als"/>
+            <node begin="6" end="7" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="11" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="body" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan is evenmin een roker als Piet .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/connective5.example.alpino
+++ b/tests/connective5.example.alpino
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="zomin" pos="adv" postag="BW()" pt="bw" rel="mod" root="zomin" sense="zomin" word="zomin"/>
+        <node begin="3" cat="np" end="5" id="5" rel="predc">
+          <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="6" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="roker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="roker" sense="roker" word="roker"/>
+        </node>
+        <node begin="5" cat="cp" end="9" id="8" rel="mod">
+          <node begin="5" conjtype="onder" end="6" frame="complementizer(als)" his="normal" his_1="normal" id="9" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="6" cat="ssub" end="9" id="10" rel="body">
+            <node begin="6" end="7" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="11" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+            <node begin="7" end="8" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="12" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="predc" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+            <node begin="8" end="9" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="13" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan is zomin een roker als Piet dat is .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/connective6.example.alpino
+++ b/tests/connective6.example.alpino
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" cat="pp" end="4" id="2" rel="mod">
+          <node begin="0" end="1" frame="preposition(ondanks,[])" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="pp" lemma="ondanks" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="ondanks" sense="ondanks" vztype="init" word="Ondanks"/>
+          <node begin="1" cat="np" end="4" id="4" rel="obj1">
+            <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+            <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="6" infl="e" lcat="ap" lemma="slecht" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="slecht" sense="slecht" vform="adj" word="slechte"/>
+            <node begin="3" end="4" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="weer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="weer" sense="weer" word="weer"/>
+          </node>
+        </node>
+        <node begin="4" end="5" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="8" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node begin="5" end="6" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="9" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+        <node begin="6" cat="np" end="9" id="10" rel="predc">
+          <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="11" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="7" buiging="met-e" end="8" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="12" infl="e" lcat="ap" lemma="mooi" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="mooi" sense="mooi" vform="adj" word="mooie"/>
+          <node begin="8" end="9" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ondanks het slechte weer was het een mooie dag .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d0.example.alpino
+++ b/tests/d0.example.alpino
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" cat="np" end="4" id="2" rel="su">
+          <node begin="0" buiging="zonder" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="detp" lemma="dat" naamval="stan" npagr="evon" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,evon)" pt="vnw" rel="det" root="dat" sense="dat" vwtype="aanw" wh="nwh" word="Dat"/>
+          <node begin="1" end="2" frame="noun(both,count,sg,measure)" gen="both" genus="genus" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="soort" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,genus,stan)" pt="n" rel="hd" rnum="sg" root="soort" sc="measure" sense="soort" word="soort"/>
+          <node begin="2" cat="np" end="4" id="5" rel="mod">
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(stof)" graad="basis" his="normal" his_1="normal" id="6" infl="stof" lcat="ap" lemma="stenen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="stenen" sense="stenen" vform="adj" word="stenen"/>
+            <node begin="3" end="4" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="begraaf_plaats" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="begraaf_plaats" sense="begraaf_plaats" word="begraafplaatsen"/>
+          </node>
+        </node>
+        <node begin="4" end="5" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="8" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node begin="5" cat="pp" end="8" id="9" rel="mod">
+          <node begin="5" end="6" frame="preposition(in,[])" his="normal" his_1="normal" id="10" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="6" cat="np" end="8" id="11" rel="obj1">
+            <node begin="6" buiging="zonder" end="7" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="12" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+            <node begin="7" end="8" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="tijd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="tijd" sense="tijd" special="tmp" word="tijd"/>
+          </node>
+        </node>
+        <node begin="8" end="9" frame="adverb" his="normal" his_1="normal" id="14" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="15" infl="no_e" lcat="ap" lemma="ongewoon" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="ongewoon" sense="ongewoon" vform="adj" word="ongewoon"/>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat soort stenen begraafplaatsen was in die tijd niet ongewoon .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="smain" end="4" id="1" rel="--">
+        <node begin="0" case="both" def="def" end="1" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+        <node begin="1" end="2" frame="verb(hebben,past(pl),als_copula)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="dienen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="dien" sc="als_copula" sense="dien" stype="declarative" tense="past" word="dienden" wvorm="pv"/>
+        <node begin="2" cat="cp" end="4" id="4" rel="predc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(als)" his="normal" his_1="normal" id="5" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="begraaf_plaats" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="body" rnum="sg" root="begraaf_plaats" sense="begraaf_plaats" word="begraafplaats"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ze dienden als begraafplaats .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d1.example.alpino
+++ b/tests/d1.example.alpino
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Frans" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Frans" sense="Frans" word="Frans"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),vp)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="denken" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="denk" sc="vp" sense="denk" stype="declarative" tense="past" word="dacht" wvorm="pv"/>
+        <node begin="0" cat="ti" end="11" id="4" rel="vc">
+          <node begin="2" end="3" frame="complementizer(te)" his="normal" his_1="normal" id="5" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="0" cat="inf" end="11" id="6" rel="body">
+            <node begin="0" end="1" id="7" index="1" rel="su"/>
+            <node begin="3" buiging="zonder" end="4" frame="verb('hebben/zijn',inf,aux(inf))" his="normal" his_1="normal" id="8" infl="inf" lcat="inf" lemma="kunnen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="kan" sc="aux(inf)" sense="kan" word="kunnen" wvorm="inf"/>
+            <node begin="0" cat="inf" end="11" id="9" rel="vc">
+              <node begin="0" end="1" id="10" index="1" rel="su"/>
+              <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="11" infl="inf" lcat="inf" lemma="scoren" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="scoor" sc="intransitive" sense="scoor" word="scoren" wvorm="inf"/>
+              <node begin="5" cat="pp" end="11" id="12" rel="mod">
+                <node begin="5" end="6" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="13" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+                <node begin="6" cat="np" end="11" id="14" rel="obj1">
+                  <node begin="6" buiging="zonder" end="7" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="15" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+                  <node aform="base" begin="7" buiging="met-e" end="8" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="16" infl="e" lcat="ap" lemma="goedkoop" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="goedkoop" sense="goedkoop" vform="adj" word="goedkope"/>
+                  <node begin="8" end="9" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="17" lcat="np" lemma="songtekstjes" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="songtekstjes" sense="songtekstjes" word="songtekstjes"/>
+                  <node begin="9" cat="pp" end="11" id="18" rel="mod">
+                    <node begin="9" end="10" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="19" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                    <node begin="10" case="dat_acc" def="def" end="11" frame="pronoun(nwh,thi,sg,de,dat_acc,def,wkpro)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="20" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,red,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" special="wkpro" status="red" vwtype="pers" wh="nwh" word="'m"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Frans dacht te kunnen scoren met die goedkope songtekstjes van 'm .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        <node begin="1" end="2" frame="verb('hebben/zijn',past(sg),vp)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="vergeten" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="vergeet" sc="vp" sense="vergeet" stype="declarative" tense="past" word="vergat" wvorm="pv"/>
+        <node begin="0" cat="ti" end="6" id="4" rel="vc">
+          <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="5" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="0" cat="inf" end="6" id="6" rel="body">
+            <node begin="0" end="1" id="7" index="1" rel="su"/>
+            <node begin="2" cat="np" end="4" id="8" rel="obj1">
+              <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="9" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="3" end="4" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="haar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="haar" sense="haar" word="haar"/>
+            </node>
+            <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="11" infl="inf" lcat="inf" lemma="kammen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="kam" sc="transitive" sense="kam" word="kammen" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Piet vergat zijn haar te kammen .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d2.example.alpino
+++ b/tests/d2.example.alpino
@@ -1,0 +1,199 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="11" id="2" rel="--">
+        <node begin="0" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" infl="de" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(aanw,pron,stan,vol,3,getal)" pt="vnw" rel="su" rnum="pl" root="die" sense="die" status="vol" vwtype="aanw" wh="nwh" word="Die"/>
+        <node begin="1" end="2" frame="verb(unacc,past(pl),te_passive)" his="normal" his_1="normal" id="4" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ben" sc="te_passive" sense="ben" stype="declarative" tense="past" word="waren" wvorm="pv"/>
+        <node begin="0" cat="ti" end="11" id="5" rel="vc">
+          <node begin="3" end="4" frame="complementizer(te)" his="normal" his_1="normal" id="6" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="0" cat="inf" end="11" id="7" rel="body">
+            <node begin="0" end="1" id="8" index="1" rel="obj1"/>
+            <node aform="base" begin="2" end="3" frame="adjective(pred(both))" his="normal" his_1="normal" id="9" infl="pred" lcat="ap" lemma="alleen" pos="adj" postag="BW()" pt="bw" rel="mod" root="alleen" sense="alleen" vform="adj" word="alleen"/>
+            <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,np_ld_pp)" his="normal" his_1="normal" id="10" infl="inf" lcat="inf" lemma="vinden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="vind" sc="np_ld_pp" sense="vind" word="vinden" wvorm="inf"/>
+            <node begin="5" cat="pp" end="11" id="11" rel="ld">
+              <node begin="5" end="6" frame="preposition(in,[])" his="normal" his_1="normal" id="12" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="6" cat="conj" end="11" id="13" rel="obj1">
+                <node begin="6" end="7" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="14" lcat="np" lemma="Drenthe" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="Drenthe" sense="Drenthe" word="Drenthe"/>
+                <node begin="8" end="9" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="15" lcat="np" lemma="Denemarken" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="Denemarken" sense="Denemarken" word="Denemarken"/>
+                <node begin="9" conjtype="neven" end="10" frame="conj(en)" his="normal" his_1="normal" id="16" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                <node begin="10" end="11" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="17" lcat="np" lemma="Noord-Duitsland" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="Noord-Duitsland" sense="Noord-Duitsland" word="Noord-Duitsland"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Die waren alleen te vinden in Drenthe , Denemarken en Noord-Duitsland .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="16" id="2" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="verb(zijn,sg3,pc_pp(om))" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="pc_pp(om)" sense="ga-om" stype="declarative" tense="present" word="gaat" wvorm="pv"/>
+        <node begin="2" cat="pp" end="16" id="5" rel="pc">
+          <node begin="2" end="3" frame="preposition(om,[heen])" his="normal" his_1="normal" id="6" lcat="pp" lemma="om" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="om" sense="om" vztype="init" word="om"/>
+          <node begin="3" cat="np" end="16" id="7" rel="obj1">
+            <node begin="3" end="4" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="hunebed" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hunebed" sense="hunebed" word="hunebedden"/>
+            <node begin="5" cat="np" end="16" id="9" rel="app">
+              <node aform="base" begin="5" buiging="met-e" end="6" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="10" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="grote"/>
+              <node begin="6" end="7" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="compound" his_1="2" id="11" lcat="np" lemma="steen_formatie" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="steen_formatie" sense="steen_formatie" word="steenformaties"/>
+              <node begin="7" cat="rel" end="16" id="12" rel="mod">
+                <node begin="7" case="no_obl" end="8" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="13" index="1" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+                <node begin="7" cat="ssub" end="16" id="14" rel="body">
+                  <node begin="7" end="8" id="15" index="1" rel="su"/>
+                  <node begin="7" cat="conj" end="15" id="16" rel="vc">
+                    <node begin="7" cat="ppart" end="11" id="17" rel="cnj">
+                      <node begin="7" end="8" id="18" index="1" rel="obj1"/>
+                      <node begin="8" cat="pp" end="10" id="19" index="2" rel="mod">
+                        <node begin="8" end="9" frame="preposition(door,[heen])" his="normal" his_1="normal" id="20" lcat="pp" lemma="door" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="door" sense="door" vztype="init" word="door"/>
+                        <node begin="9" end="10" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="mensenhand" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="mensenhand" sense="mensenhand" word="mensenhanden"/>
+                      </node>
+                      <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="22" infl="psp" lcat="ppart" lemma="ordenen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="orden" sc="transitive" sense="orden" word="geordend" wvorm="vd"/>
+                    </node>
+                    <node begin="11" conjtype="neven" end="12" frame="conj(en)" his="normal" his_1="normal" id="23" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                    <node begin="7" cat="ppart" end="15" id="24" rel="cnj">
+                      <node begin="7" end="8" id="25" index="1" rel="obj1"/>
+                      <node begin="8" end="10" id="26" index="2" rel="mod"/>
+                      <node begin="12" cat="pp" end="14" id="27" rel="mod">
+                        <node begin="12" end="13" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="28" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                        <node begin="13" case="dat_acc" def="def" end="14" frame="pronoun(nwh,thi,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="29" lcat="np" lemma="elkaar" naamval="obl" num="pl" pdtype="pron" per="thi" persoon="persoon" pos="pron" postag="VNW(recip,pron,obl,vol,persoon,mv)" pt="vnw" rel="obj1" rnum="pl" root="elkaar" sense="elkaar" status="vol" vwtype="recip" wh="nwh" word="elkaar"/>
+                      </node>
+                      <node begin="14" buiging="zonder" end="15" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="30" infl="psp" lcat="ppart" lemma="stapelen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="stapel" sc="transitive" sense="stapel" word="gestapeld" wvorm="vd"/>
+                    </node>
+                  </node>
+                  <node begin="15" end="16" frame="verb(unacc,pl,passive)" his="normal" his_1="normal" id="31" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="32" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het gaat om hunebedden , grote steenformaties die door mensenhanden geordend en op elkaar gestapeld zijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="0" cat="du" end="12" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="maar" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="maar" sc="root" sense="maar" word="Maar"/>
+        <node begin="1" cat="smain" end="12" id="3" rel="nucl">
+          <node begin="1" cat="pp" end="5" id="4" rel="mod">
+            <node begin="1" end="2" frame="preposition(in,[])" his="normal" his_1="normal" id="5" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+            <node begin="2" cat="np" end="5" id="6" rel="obj1">
+              <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="provincie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="provincie" sense="provincie" word="provincie"/>
+              <node begin="4" end="5" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="9" lcat="np" lemma="Drenthe" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="app" rnum="sg" root="Drenthe" sense="Drenthe" word="Drenthe"/>
+            </node>
+          </node>
+          <node begin="5" end="6" frame="verb('hebben/zijn',pl,ld_pp)" his="normal" his_1="normal" id="10" infl="pl" lcat="smain" lemma="liggen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="lig" sc="ld_pp" sense="lig" stype="declarative" tense="present" word="liggen" wvorm="pv"/>
+          <node begin="6" cat="np" end="8" id="11" rel="su">
+            <node begin="6" buiging="zonder" end="7" frame="determiner(pron)" getal="mv" his="normal" his_1="normal" id="12" infl="pron" lcat="detp" lemma="hun" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,mv,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="hun" sense="hun" status="vol" vwtype="bez" word="hun"/>
+            <node begin="7" end="8" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="rest" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="rest" sense="rest" special="tmp" word="resten"/>
+          </node>
+          <node aform="base" begin="8" buiging="zonder" end="9" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="14" infl="no_e" lcat="ap" lemma="gewoon" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="gewoon" sense="gewoon" vform="adj" word="gewoon"/>
+          <node begin="9" cat="pp" end="12" id="15" rel="ld">
+            <node begin="9" end="10" frame="preposition(boven,[uit])" his="normal" his_1="normal" id="16" lcat="pp" lemma="boven" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="boven" sense="boven" vztype="init" word="boven"/>
+            <node begin="10" cat="np" end="12" id="17" rel="obj1">
+              <node begin="10" end="11" frame="determiner(de)" his="normal" his_1="normal" id="18" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="11" end="12" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="grond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="grond" sense="grond" word="grond"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Maar in de provincie Drenthe liggen hun resten gewoon boven de grond .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="0" cat="du" end="12" id="1" rel="--">
+        <node begin="0" cat="du" end="3" id="2" rel="dp">
+          <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="du" lemma="maar" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="maar" sc="root" sense="maar" word="Maar"/>
+          <node begin="1" cat="advp" end="3" his="normal" his_1="normal" id="4" rel="nucl">
+            <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(tmpadv))" graad="basis" id="5" infl="no_e" lcat="ap" lemma="lang" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="lang" sense="lang" vform="adj" word="lang"/>
+            <node begin="2" end="3" frame="adverb" id="6" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+          </node>
+        </node>
+        <node begin="3" cat="smain" end="12" id="7" rel="dp">
+          <node begin="4" end="5" frame="verb(unacc,pl,passive)" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="5" cat="np" end="7" id="9" index="1" rel="su">
+            <node begin="5" buiging="met-e" end="6" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+            <node begin="6" end="7" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="begraaf_plaats" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="begraaf_plaats" sense="begraaf_plaats" word="begraafplaatsen"/>
+          </node>
+          <node begin="3" cat="ppart" end="12" id="12" rel="vc">
+            <node begin="3" end="4" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="13" lcat="advp" lemma="overal" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(onbep,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="mod" root="overal" sense="overal" special="er_loc" status="vol" vwtype="onbep" word="overal"/>
+            <node begin="5" end="7" id="14" index="1" rel="obj1"/>
+            <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="15" infl="psp" lcat="ppart" lemma="bouwen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="bouw" sc="transitive" sense="bouw" word="gebouwd" wvorm="vd"/>
+            <node begin="8" cat="pp" end="12" id="16" rel="mod">
+              <node begin="8" end="9" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="17" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="9" cat="np" end="12" id="18" rel="obj1">
+                <node begin="9" buiging="zonder" end="10" frame="determiner(zulke,nwh,nmod,pro,yparg)" his="normal" his_1="normal" id="19" infl="zulke" lcat="detp" lemma="zulk" naamval="stan" npagr="evon" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,evon)" pt="vnw" rel="det" root="zulk" sense="zulk" vwtype="aanw" wh="nwh" word="zulke"/>
+                <node aform="base" begin="10" buiging="met-e" end="11" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="20" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="grote"/>
+                <node begin="11" end="12" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="compound" his_1="2" id="21" lcat="np" lemma="zwerven_kei" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="zwerf_kei" sense="zwerf_kei" word="zwerfkeien"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="robust_skip" id="22" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Maar lang niet overal zijn deze begraafplaatsen gebouwd met zulke grote zwerfkeien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:17" cats="3" skips="2"/>
+    <node begin="0" cat="top" end="21" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="15" end="16" frame="complementizer(om)" his="robust_skip" id="2" lcat="--" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="--" root="om" sc="om" sense="om" vztype="init" word="om"/>
+      <node begin="17" end="18" frame="particle(in)" his="robust_skip" id="3" lcat="--" lemma="in" pos="part" postag="VZ(init)" pt="vz" rel="--" root="in" sense="in" vztype="init" word="in"/>
+      <node begin="0" cat="du" end="20" id="4" rel="--">
+        <node begin="0" cat="conj" end="15" id="5" rel="dp">
+          <node begin="0" cat="smain" end="5" id="6" rel="cnj">
+            <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,both,de,nom,def)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="7" index="1" lcat="np" lemma="zij" naamval="nomin" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,vol,3p,mv)" pt="vnw" rel="su" rnum="pl" root="zij" sense="zij" status="vol" vwtype="pers" wh="nwh" word="Zij"/>
+            <node begin="1" end="2" frame="verb(hebben,past(pl),ld_pp)" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="wonen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="woon" sc="ld_pp" sense="woon" tense="past" word="woonden" wvorm="pv"/>
+            <node begin="2" cat="pp" end="5" id="9" rel="ld">
+              <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="10" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="3" cat="np" end="5" id="11" rel="obj1">
+                <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(both(nonadv))" graad="basis" his="normal" his_1="normal" id="12" infl="both" lcat="ap" lemma="lemen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="lemen" sense="lemen" vform="adj" word="lemen"/>
+                <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="boerderij" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="boerderij" sense="boerderij" word="boerderijen"/>
+              </node>
+            </node>
+          </node>
+          <node begin="0" cat="smain" end="11" id="14" rel="cnj">
+            <node begin="0" end="1" id="15" index="1" rel="su"/>
+            <node begin="6" end="7" frame="verb(hebben,past(pl),transitive)" his="normal" his_1="normal" id="16" infl="pl" lcat="smain" lemma="gebruiken" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="gebruik" sc="transitive" sense="gebruik" tense="past" word="gebruikten" wvorm="pv"/>
+            <node begin="7" cat="np" end="11" id="17" rel="obj1">
+              <node begin="7" cat="conj" end="10" id="18" rel="mod">
+                <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(stof)" graad="basis" his="normal" his_1="normal" id="19" infl="stof" lcat="ap" lemma="houten" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="cnj" root="houten" sense="houten" vform="adj" word="houten"/>
+                <node begin="8" conjtype="neven" end="9" frame="conj(en)" his="normal" his_1="normal" id="20" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(stof)" graad="basis" his="normal" his_1="normal" id="21" infl="stof" lcat="ap" lemma="stenen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="cnj" root="stenen" sense="stenen" vform="adj" word="stenen"/>
+              </node>
+              <node begin="10" end="11" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="werktuig" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="werktuig" sense="werktuig" word="werktuigen"/>
+            </node>
+          </node>
+          <node begin="11" conjtype="neven" end="12" frame="conj(en)" his="normal" his_1="normal" id="23" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="0" cat="smain" end="15" id="24" rel="cnj">
+            <node begin="0" end="1" id="25" index="1" rel="su"/>
+            <node begin="12" end="13" frame="verb(hebben,past(pl),transitive)" his="normal" his_1="normal" id="26" infl="pl" lcat="smain" lemma="maken" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="maak" sc="transitive" sense="maak" tense="past" word="maakten" wvorm="pv"/>
+            <node begin="13" end="14" frame="sentence_adverb" his="normal" his_1="normal" id="27" lcat="advp" lemma="dus" pos="adv" postag="BW()" pt="bw" rel="mod" root="dus" sense="dus" special="sentence" word="dus"/>
+            <node begin="14" end="15" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="pot" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="pot" sense="pot" special="tmp" word="potten"/>
+          </node>
+        </node>
+        <node begin="16" end="17" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="29" lcat="np" lemma="voorraad" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="dp" rnum="pl" root="voorraad" sense="voorraad" word="voorraden"/>
+        <node begin="18" cat="ti" end="20" id="30" rel="dp">
+          <node begin="18" end="19" frame="complementizer(te)" his="normal" his_1="normal" id="31" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="19" buiging="zonder" end="20" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="32" infl="inf" lcat="inf" lemma="bewaren" pos="verb" positie="prenom" postag="WW(inf,prenom,zonder)" pt="ww" rel="body" root="bewaar" sc="transitive" sense="bewaar" word="bewaren" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="20" end="21" frame="punct(punt)" his="robust_skip" id="33" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zij woonden in lemen boerderijen , gebruikten houten en stenen werktuigen en maakten dus potten om voorraden in te bewaren .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d3.example.alpino
+++ b/tests/d3.example.alpino
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="11" id="2" rel="--">
+        <node begin="6" end="7" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="4" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="0" cat="ppart" end="11" id="5" rel="vc">
+          <node begin="0" cat="np" end="5" id="6" rel="obj1">
+            <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+            <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+            <node begin="2" cat="rel" end="5" id="9" rel="mod">
+              <node begin="2" case="no_obl" end="3" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="10" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="2" cat="ssub" end="5" id="11" rel="body">
+                <node begin="2" end="3" id="12" index="2" rel="su"/>
+                <node begin="3" end="4" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="13" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="mod" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+                <node begin="4" end="5" frame="verb('hebben/zijn',sg3,intransitive)" his="normal" his_1="normal" id="14" infl="sg3" lcat="ssub" lemma="lopen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="loop" sc="intransitive" sense="loop" tense="present" word="loopt" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+          <node begin="7" end="8" id="15" index="1" rel="su"/>
+          <node begin="8" cat="advp" end="10" id="16" rel="mod">
+            <node begin="8" end="9" frame="modal_adverb" his="normal" his_1="normal" id="17" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sc="modal" sense="nog" word="nog"/>
+            <node begin="9" end="10" frame="tmp_adverb" his="normal" his_1="normal" id="18" lcat="advp" lemma="nooit" pos="adv" postag="BW()" pt="bw" rel="hd" root="nooit" sense="nooit" special="tmp" word="nooit"/>
+          </node>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,transitive_ndev_ndev)" his="normal" his_1="normal" id="19" infl="psp" lcat="ppart" lemma="zien" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" word="gezien" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De man die daar loopt , heb ik nog nooit gezien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="24" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="1" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="9" end="10" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="2" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="11" end="12" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="23" id="4" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="np" lemma="men" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,red,3p,ev,masc)" pt="vnw" rel="su" rnum="sg" root="men" sense="men" status="red" vwtype="pers" wh="nwh" word="Men"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,tr_sbar)" his="normal" his_1="normal" id="6" infl="sg3" lcat="smain" lemma="denken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="denk" sc="tr_sbar" sense="denk" stype="declarative" tense="present" word="denkt" wvorm="pv"/>
+        <node begin="2" cat="cp" end="23" id="7" rel="vc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="8" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="3" cat="conj" end="23" id="9" rel="body">
+            <node begin="3" cat="ssub" end="11" id="10" rel="cnj">
+              <node begin="3" case="both" def="def" end="4" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="11" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+              <node begin="4" cat="pp" end="6" id="12" rel="pc">
+                <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="13" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="grond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="grond" sense="grond" word="grond"/>
+              </node>
+              <node begin="6" cat="np" end="9" id="15" rel="obj1">
+                <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="16" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="8" end="9" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="oprit" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="oprit" sense="oprit" word="oprit"/>
+              </node>
+              <node begin="10" end="11" frame="verb(hebben,past(pl),np_pc_pp(van))" his="normal" his_1="normal" id="18" infl="pl" lcat="ssub" lemma="maken" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="maak" sc="np_pc_pp(van)" sense="maak-van" tense="past" word="maakten" wvorm="pv"/>
+            </node>
+            <node begin="12" conjtype="neven" end="13" frame="conj(en)" his="normal" his_1="normal" id="19" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="13" cat="ssub" end="23" id="20" rel="cnj">
+              <node begin="15" end="16" frame="verb(hebben,past(pl),intransitive)" his="normal" his_1="normal" id="21" infl="pl" lcat="ssub" lemma="gebruiken" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="gebruik" sc="intransitive" sense="gebruik" tense="past" word="gebruikten" wvorm="pv"/>
+              <node begin="13" cat="np" end="23" id="22" rel="su">
+                <node aform="base" begin="13" buiging="met-e" end="14" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="23" infl="e" lcat="ap" lemma="rond" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="rond" sense="rond" vform="adj" word="ronde"/>
+                <node begin="14" end="15" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="24" lcat="np" lemma="stam" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="stam_DIM" sense="stam_DIM" word="stammetjes"/>
+                <node begin="16" cat="oti" end="23" id="25" rel="mod">
+                  <node begin="16" end="17" frame="complementizer(om)" his="normal" his_1="normal" id="26" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+                  <node begin="17" cat="ti" end="23" id="27" rel="body">
+                    <node begin="20" end="21" frame="complementizer(te)" his="normal" his_1="normal" id="28" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                    <node begin="17" cat="inf" end="23" id="29" rel="body">
+                      <node begin="17" cat="np" end="19" id="30" index="1" rel="obj1">
+                        <node begin="17" end="18" frame="determiner(de)" his="normal" his_1="normal" id="31" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                        <node begin="18" end="19" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="32" lcat="np" lemma="steen" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="steen" sense="steen" word="steen"/>
+                      </node>
+                      <node begin="21" buiging="zonder" end="22" frame="verb(hebben,inf,aci)" his="normal" his_1="normal" id="33" infl="inf" lcat="inf" lemma="laten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="laat" sc="aci" sense="laat" word="laten" wvorm="inf"/>
+                      <node begin="17" cat="inf" end="23" id="34" rel="vc">
+                        <node begin="17" end="19" id="35" index="1" rel="su"/>
+                        <node begin="19" end="20" frame="preposition(overheen,[],extracted_np)" his="normal" his_1="normal" id="36" lcat="pp" lemma="overheen" pos="prep" postag="VZ(fin)" pt="vz" rel="ld" root="overheen" sc="extracted_np" sense="overheen" vztype="fin" word="overheen"/>
+                        <node begin="22" buiging="zonder" end="23" frame="verb(zijn,inf,ld_pp)" his="normal" his_1="normal" id="37" infl="inf" lcat="inf" lemma="rollen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="rol" sc="ld_pp" sense="rol" word="rollen" wvorm="inf"/>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="23" end="24" frame="punct(punt)" his="normal" his_1="normal" id="38" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Men denkt dat ze van grond een ' oprit ' maakten , en ronde stammetjes gebruikten om de steen overheen te laten rollen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="20" id="0" rel="top">
+      <node begin="10" end="11" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="15" end="16" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="19" id="3" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="men" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,red,3p,ev,masc)" pt="vnw" rel="su" rnum="sg" root="men" sense="men" status="red" vwtype="pers" wh="nwh" word="Men"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,tr_sbar)" his="normal" his_1="normal" id="5" infl="sg3" lcat="smain" lemma="denken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="denk" sc="tr_sbar" sense="denk" stype="declarative" tense="present" word="denkt" wvorm="pv"/>
+        <node begin="2" cat="cp" end="19" id="6" rel="vc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="7" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="3" cat="ssub" end="19" id="8" rel="body">
+            <node begin="3" cat="np" end="15" id="9" index="1" rel="su">
+              <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,both,de,nom,def)" gen="de" getal="mv" his="normal" his_1="normal" id="10" lcat="np" lemma="zij" naamval="nomin" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,vol,3p,mv)" pt="vnw" rel="hd" rnum="pl" root="zij" sense="zij" status="vol" vwtype="pers" wh="nwh" word="zij"/>
+              <node begin="4" cat="advp" end="15" id="11" rel="mod">
+                <node begin="4" end="5" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="12" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="hd" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+                <node begin="5" cat="pp" end="15" id="13" rel="mod">
+                  <node begin="5" end="6" frame="preposition(tijdens,[])" his="normal" his_1="normal" id="14" lcat="pp" lemma="tijdens" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="tijdens" sense="tijdens" vztype="init" word="tijdens"/>
+                  <node begin="6" cat="np" end="15" id="15" rel="obj1">
+                    <node begin="6" case="both" def="indef" end="7" frame="pronoun(nwh,thi,sg,de,both,indef,strpro)" gen="de" getal-n="zonder-n" graad="dim" his="normal" his_1="normal" id="16" lcat="np" lemma="één" num="sg" numtype="hoofd" per="thi" pos="pron" positie="nom" postag="TW(hoofd,nom,zonder-n,dim)" pt="tw" rel="hd" rnum="sg" root="één" sense="één" special="strpro" wh="nwh" word="een"/>
+                    <node begin="7" cat="pp" end="15" id="17" rel="mod">
+                      <node begin="7" end="8" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="18" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                      <node begin="8" cat="np" end="15" id="19" rel="obj1">
+                        <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="20" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                        <node begin="9" end="10" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="ijs_tijd" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="ijs_tijd" sense="ijs_tijd" special="tmp" word="ijstijden"/>
+                        <node begin="11" cat="ap" end="15" id="22" rel="mod">
+                          <node begin="11" cat="np" end="14" id="23" rel="me">
+                            <node begin="11" cat="detp" end="13" id="24" rel="det">
+                              <node begin="11" buiging="zonder" end="12" frame="pre_num_adv(pl_indef)" his="normal" his_1="normal" id="25" infl="pl_indef" lcat="advp" lemma="zo'n" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,agr)" pt="vnw" rel="mod" root="zo'n" sense="zo'n" special="pre_num_adv" vwtype="aanw" word="zo'n"/>
+                              <node begin="12" end="13" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="26" infl="pl_num" lcat="detp" lemma="150.000" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="hd" root="150.000" sense="150.000" word="150.000"/>
+                            </node>
+                            <node begin="13" end="14" frame="tmp_noun(het,count,bare_meas)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="27" lcat="np" lemma="jaar" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="jaar" sense="jaar" special="tmp" word="jaar"/>
+                          </node>
+                          <node begin="14" end="15" frame="pred_np_me_adjective(tmpadv)" his="normal" his_1="normal" id="28" lcat="ap" lemma="geleden" pos="adj" postag="BW()" pt="bw" rel="hd" root="geleden" sc="pred_np_me" sense="geleden" word="geleden"/>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node begin="17" end="18" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="29" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+            <node begin="3" cat="ppart" end="19" id="30" rel="vc">
+              <node begin="3" end="15" id="31" index="1" rel="su"/>
+              <node begin="16" buiging="zonder" end="17" frame="particle(terecht)" graad="basis" his="normal" his_1="normal" id="32" lcat="part" lemma="terecht" pos="part" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="svp" root="terecht" sense="terecht" word="terecht"/>
+              <node begin="18" buiging="zonder" end="19" frame="verb(unacc,psp,part_intransitive(terecht))" his="normal" his_1="normal" id="33" infl="psp" lcat="ppart" lemma="terecht_komen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="kom_terecht" sc="part_intransitive(terecht)" sense="kom_terecht" word="gekomen" wvorm="vd"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="19" end="20" frame="punct(punt)" his="normal" his_1="normal" id="34" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Men denkt dat zij daar tijdens een van de ijstijden , zo'n 150.000 jaar geleden , terecht zijn gekomen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="16" id="0" rel="top">
+      <node begin="0" cat="smain" end="15" id="1" rel="--">
+        <node begin="6" end="7" frame="verb(hebben,pl,aux_psp_hebben)" his="normal" his_1="normal" id="2" infl="pl" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="hebben" wvorm="pv"/>
+        <node begin="7" end="8" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="3" index="1" lcat="np" lemma="onderzoeker" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="su" rnum="pl" root="onderzoeker" sense="onderzoeker" word="onderzoekers"/>
+        <node begin="0" cat="ppart" end="15" id="4" rel="vc">
+          <node begin="0" cat="pp" end="6" id="5" rel="mod">
+            <node begin="0" end="1" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="Met"/>
+            <node begin="1" cat="np" end="6" id="7" rel="obj1">
+              <node begin="1" buiging="zonder" end="2" frame="determiner(zulke,nwh,nmod,pro,yparg)" his="normal" his_1="normal" id="8" infl="zulke" lcat="detp" lemma="zulk" naamval="stan" npagr="evon" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,evon)" pt="vnw" rel="det" root="zulk" sense="zulk" vwtype="aanw" wh="nwh" word="zulke"/>
+              <node begin="2" end="3" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="rest" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="rest" sense="rest" special="tmp" word="resten"/>
+              <node begin="3" cat="pp" end="6" id="10" rel="mod">
+                <node begin="3" end="4" frame="preposition(in,[])" his="normal" his_1="normal" id="11" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                <node begin="4" cat="np" end="6" id="12" rel="obj1">
+                  <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="13" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="grond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="grond" sense="grond" word="grond"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="7" end="8" id="15" index="1" rel="su"/>
+          <node begin="8" buiging="zonder" end="9" frame="verb(hebben,psp,sbar)" his="normal" his_1="normal" id="16" infl="psp" lcat="ppart" lemma="achterhalen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="achterhaal" sc="sbar" sense="achterhaal" word="achterhaald" wvorm="vd"/>
+          <node begin="9" cat="whsub" end="15" id="17" rel="vc">
+            <node begin="9" end="10" frame="wh_adjective" his="normal" his_1="normal" id="18" index="2" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="whd" root="hoe" sense="hoe" wh="ywh" word="hoe"/>
+            <node begin="9" cat="ssub" end="15" id="19" rel="body">
+              <node begin="9" end="10" id="20" index="2" rel="mod"/>
+              <node begin="10" cat="np" end="14" id="21" rel="su">
+                <node begin="10" end="11" frame="determiner(de)" his="normal" his_1="normal" id="22" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="11" end="12" frame="number(rang)" his="normal" his_1="normal" id="23" lcat="ap" lemma="één" naamval="stan" numtype="rang" pos="num" positie="prenom" postag="TW(rang,prenom,stan)" pt="tw" rel="mod" root="één" sense="één" word="eerste"/>
+                <node begin="12" end="13" frame="tmp_noun(de,count,pl,measure)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="24" lcat="np" lemma="generatie" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="generatie" sc="measure" sense="generatie" special="tmp" word="generaties"/>
+                <node begin="13" end="14" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="landbouwer" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="mod" rnum="pl" root="landbouwer" sense="landbouwer" word="landbouwers"/>
+              </node>
+              <node begin="14" end="15" frame="verb(hebben,past(pl),intransitive)" his="normal" his_1="normal" id="26" infl="pl" lcat="ssub" lemma="leven" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="leef" sc="intransitive" sense="leef" tense="past" word="leefden" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="15" end="16" frame="punct(punt)" his="normal" his_1="normal" id="27" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Met zulke resten in de grond hebben onderzoekers achterhaald hoe de eerste generaties landbouwers leefden .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d4.example.alpino
+++ b/tests/d4.example.alpino
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Pietje" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Pietje" sense="Pietje" word="Pietje"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="ap" end="5" id="4" rel="predc">
+          <node aform="compar" begin="2" buiging="zonder" end="3" frame="adjective(er(adv))" graad="comp" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="groot" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="hd" root="groot" sense="groot" vform="adj" word="groter"/>
+          <node begin="3" cat="cp" end="5" id="6" rel="obcomp">
+            <node begin="3" conjtype="onder" end="4" frame="comparative(dan)" his="normal" his_1="normal" id="7" lcat="comparative" lemma="dan" pos="comparative" postag="VG(onder)" pt="vg" rel="cmp" root="dan" sense="dan" word="dan"/>
+            <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="8" lcat="np" lemma="Jantje" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="body" rnum="sg" root="Jantje" sense="Jantje" word="Jantje"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Pietje is groter dan Jantje .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d5.example.alpino
+++ b/tests/d5.example.alpino
@@ -1,0 +1,173 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="8" end="9" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="16" id="2" rel="--">
+        <node begin="0" cat="cp" end="8" id="3" rel="mod">
+          <node begin="0" end="1" frame="modal_adverb" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sc="modal" sense="ook" word="Ook"/>
+          <node begin="1" conjtype="onder" end="2" frame="complementizer" his="normal" his_1="normal" id="5" lcat="cp" lemma="toen" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="toen" sense="toen" word="toen"/>
+          <node begin="2" cat="ssub" end="8" id="6" rel="body">
+            <node begin="2" cat="np" end="4" id="7" rel="su">
+              <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="wereld" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wereld" sense="wereld" word="wereld"/>
+            </node>
+            <node begin="4" cat="ap" end="7" id="10" rel="predc">
+              <node begin="4" cat="np" end="6" id="11" rel="me">
+                <node begin="4" end="5" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="12" infl="pl_num" lcat="detp" lemma="vijfduizend" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="vijfduizend" sense="vijfduizend" word="vijfduizend"/>
+                <node begin="5" end="6" frame="tmp_noun(het,count,bare_meas)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="jaar" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="jaar" sense="jaar" special="tmp" word="jaar"/>
+              </node>
+              <node aform="compar" begin="6" buiging="zonder" end="7" frame="adjective(er(padv))" graad="comp" his="normal" his_1="normal" id="14" infl="no_e" lcat="ap" lemma="jong" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="hd" root="jong" sense="jong" vform="adj" word="jonger"/>
+            </node>
+            <node begin="7" end="8" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="15" infl="sg" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" tense="past" word="was" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="9" end="10" frame="verb(hebben,past(pl),ld_pp)" his="normal" his_1="normal" id="16" infl="pl" lcat="smain" lemma="wonen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="woon" sc="ld_pp" sense="woon" stype="declarative" tense="past" word="woonden" wvorm="pv"/>
+        <node begin="10" end="11" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="17" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+        <node begin="11" end="12" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="mens" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="su" rnum="pl" root="mens" sense="mens" word="mensen"/>
+        <node begin="12" cat="pp" end="16" id="19" rel="ld">
+          <node begin="12" end="13" frame="preposition(in,[])" his="normal" his_1="normal" id="20" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="13" cat="np" end="16" id="21" rel="obj1">
+            <node begin="13" end="14" frame="determiner(de)" his="normal" his_1="normal" id="22" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="14" cat="mwu" end="16" his="normal" his_1="names_dictionary" id="23" rel="hd">
+              <node begin="14" end="15" frame="proper_name(both)" id="24" lcat="np" lemma="Lage" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Lage" sense="Lage" spectype="deeleigen" word="Lage"/>
+              <node begin="15" end="16" frame="proper_name(both)" id="25" lcat="np" lemma="Landen" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Landen" sense="Landen" spectype="deeleigen" word="Landen"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="26" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ook toen de wereld vijfduizend jaar jonger was , woonden er mensen in de Lage Landen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="29" id="0" rel="top">
+      <node begin="10" end="11" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="20" end="21" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="28" id="3" rel="--">
+        <node begin="0" cat="smain" end="10" id="4" rel="cnj">
+          <node begin="0" case="both" def="def" end="1" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="5" index="1" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="Ze"/>
+          <node begin="1" end="2" frame="verb(hebben,pl,aux_psp_hebben)" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="hebben" wvorm="pv"/>
+          <node begin="0" cat="ppart" end="10" id="7" rel="vc">
+            <node begin="0" end="1" id="8" index="1" rel="su"/>
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="9" infl="no_e" lcat="ap" lemma="zeker" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="zeker" sense="zeker" vform="adj" word="zeker"/>
+            <node begin="3" end="4" frame="sentence_adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+            <node begin="5" buiging="zonder" end="6" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="11" infl="psp" lcat="ppart" lemma="maken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="maak" sc="transitive" sense="maak" word="gemaakt" wvorm="vd"/>
+            <node begin="4" cat="np" end="10" id="12" rel="obj1">
+              <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="afspraak" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="afspraak" sense="afspraak" word="afspraken"/>
+              <node begin="6" cat="pp" end="10" id="14" rel="mod">
+                <node begin="6" end="7" frame="preposition(over,[heen])" his="normal" his_1="normal" id="15" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sense="over" vztype="init" word="over"/>
+                <node begin="7" cat="conj" end="10" id="16" rel="obj1">
+                  <node begin="7" end="8" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="bezit" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="bezit" sense="bezit" word="bezit"/>
+                  <node begin="8" conjtype="neven" end="9" frame="conj(en)" his="normal" his_1="normal" id="18" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                  <node begin="9" end="10" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="rechtspraak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="rechtspraak" sense="rechtspraak" word="rechtspraak"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="11" conjtype="neven" end="12" frame="conj(maar)" his="normal" his_1="normal" id="20" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="12" cat="smain" end="28" id="21" rel="cnj">
+          <node begin="12" cat="whrel" end="15" id="22" index="2" rel="su">
+            <node begin="12" buiging="met-e" end="13" frame="determiner(welke,rwh,nmod,pro,yparg)" getal-n="zonder-n" his="normal" his_1="normal" id="23" index="3" infl="welke" lcat="np" lemma="welk" naamval="stan" pdtype="det" pos="det" positie="nom" postag="VNW(vb,det,stan,nom,met-e,zonder-n)" pt="vnw" rel="rhd" rnum="sg" root="welk" sense="welk" vwtype="vb" wh="rwh" word="welke"/>
+            <node begin="12" cat="ssub" end="15" id="24" rel="body">
+              <node begin="12" end="13" id="25" index="3" rel="predc"/>
+              <node begin="13" end="14" frame="cleft_het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="26" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="pl" root="dat" sense="dat" special="cleft_het" status="red" vwtype="pers" word="dat"/>
+              <node begin="14" end="15" frame="verb(unacc,pl,cleft)" his="normal" his_1="normal" id="27" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="cleft" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="15" end="16" frame="verb(unacc,sg_is,te_passive)" his="normal" his_1="normal" id="28" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="te_passive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="12" cat="ti" end="28" id="29" rel="vc">
+            <node begin="18" end="19" frame="complementizer(te)" his="normal" his_1="normal" id="30" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="12" cat="inf" end="28" id="31" rel="body">
+              <node begin="12" end="15" id="32" index="2" rel="obj1"/>
+              <node begin="16" cat="advp" end="18" id="33" rel="mod">
+                <node begin="16" end="17" frame="adverb" his="normal" his_1="normal" id="34" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+                <node begin="17" buiging="zonder" end="18" frame="postadv_adverb" graad="comp" his="normal" his_1="normal" id="35" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="meer"/>
+              </node>
+              <node begin="19" buiging="zonder" end="20" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="36" infl="inf" lcat="inf" lemma="achterhalen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="achterhaal" sc="transitive" sense="achterhaal" word="achterhalen" wvorm="inf"/>
+              <node begin="21" cat="cp" end="28" id="37" rel="mod">
+                <node begin="21" conjtype="onder" end="22" frame="complementizer" his="normal" his_1="normal" id="38" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+                <node begin="22" cat="ssub" end="28" id="39" rel="body">
+                  <node begin="22" cat="np" end="25" id="40" rel="su">
+                    <node begin="22" buiging="met-e" end="23" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="41" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+                    <node aform="base" begin="23" buiging="met-e" end="24" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="42" infl="e" lcat="ap" lemma="vroeg" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="vroeg" sense="vroeg" vform="adj" word="vroege"/>
+                    <node begin="24" end="25" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="43" lcat="np" lemma="boer" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="boer" sense="boer" word="boeren"/>
+                  </node>
+                  <node begin="25" cat="np" end="27" id="44" rel="obj1">
+                    <node begin="25" buiging="zonder" end="26" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="45" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+                    <node begin="26" end="27" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="46" lcat="np" lemma="schrift" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="schrift" sense="schrift" word="schrift"/>
+                  </node>
+                  <node begin="27" end="28" frame="verb(hebben,past(pl),transitive)" his="normal" his_1="normal" id="47" infl="pl" lcat="ssub" lemma="kennen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ken" sc="transitive" sense="ken" tense="past" word="kenden" wvorm="pv"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="28" end="29" frame="punct(punt)" his="normal" his_1="normal" id="48" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ze hebben zeker ook afspraken gemaakt over bezit en rechtspraak , maar welke dat zijn is niet meer te achterhalen , omdat deze vroege boeren geen schrift kenden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="23" id="0" rel="top">
+      <node begin="0" cat="conj" end="22" id="1" rel="--">
+        <node begin="0" cat="smain" end="15" id="2" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,both,de,nom,def)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="np" lemma="zij" naamval="nomin" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,vol,3p,mv)" pt="vnw" rel="su" rnum="pl" root="zij" sense="zij" status="vol" vwtype="pers" wh="nwh" word="Zij"/>
+          <node begin="1" end="2" frame="verb('hebben/zijn',past(pl),part_pc_pp(op,met))" his="normal" his_1="normal" id="4" infl="pl" lcat="smain" lemma="op_houden" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="houd_op" sc="part_pc_pp(op,met)" sense="houd_op-met" tense="past" word="hielden" wvorm="pv"/>
+          <node begin="2" cat="cp" end="7" id="5" rel="predm">
+            <node begin="2" conjtype="onder" end="3" frame="complementizer(als)" his="normal" his_1="normal" id="6" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+            <node begin="3" cat="np" end="7" id="7" rel="body">
+              <node begin="3" end="4" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="één" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="één" sense="één" word="eersten"/>
+              <node begin="4" cat="pp" end="7" id="9" rel="mod">
+                <node begin="4" end="5" frame="preposition(in,[])" his="normal" his_1="normal" id="10" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                <node begin="5" cat="np" end="7" id="11" rel="obj1">
+                  <node begin="5" buiging="met-e" end="6" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="12" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+                  <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="streek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="streek" sense="streek" word="streek"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="7" end="8" frame="particle(op)" his="normal" his_1="normal" id="14" lcat="part" lemma="op" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="op" sense="op" vztype="fin" word="op"/>
+          <node begin="8" cat="pp" end="15" id="15" rel="pc">
+            <node begin="8" end="9" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="16" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="9" cat="np" end="15" id="17" rel="obj1">
+              <node begin="9" end="10" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="18" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="10" end="11" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="bestaan" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="bestaan" sense="bestaan" word="bestaan"/>
+              <node begin="11" cat="cp" end="15" id="20" rel="mod">
+                <node begin="11" conjtype="onder" end="12" frame="complementizer(als)" his="normal" his_1="normal" id="21" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+                <node begin="12" cat="conj" end="15" id="22" rel="body">
+                  <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="23" lcat="np" lemma="jager" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="jager" sense="jager" word="jager"/>
+                  <node begin="13" conjtype="neven" end="14" frame="conj(en)" his="normal" his_1="normal" id="24" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                  <node begin="14" end="15" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="verzamelaar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="verzamelaar" sense="verzamelaar" word="verzamelaar"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="15" conjtype="neven" end="16" frame="conj(en)" his="normal" his_1="normal" id="26" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="22" id="27" rel="cnj">
+          <node begin="0" end="1" id="28" index="1" rel="su"/>
+          <node begin="16" end="17" frame="verb(zijn,past(pl),aux(inf))" his="normal" his_1="normal" id="29" infl="pl" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ga" sc="aux(inf)" sense="ga" tense="past" word="gingen" wvorm="pv"/>
+          <node begin="0" cat="inf" end="22" id="30" rel="vc">
+            <node begin="0" end="1" id="31" index="1" rel="su"/>
+            <node begin="17" buiging="zonder" end="18" frame="verb(hebben,inf,ld_pp)" his="normal" his_1="normal" id="32" infl="inf" lcat="inf" lemma="wonen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="woon" sc="ld_pp" sense="woon" word="wonen" wvorm="inf"/>
+            <node begin="18" cat="pp" end="22" id="33" rel="ld">
+              <node begin="18" end="19" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="34" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+              <node begin="19" cat="np" end="22" id="35" rel="obj1">
+                <node begin="19" end="20" frame="determiner(een)" his="normal" his_1="normal" id="36" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="base" begin="20" buiging="met-e" end="21" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="37" infl="e" lcat="ap" lemma="vast" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="vast" sense="vast" vform="adj" word="vaste"/>
+                <node begin="21" end="22" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="38" lcat="np" lemma="plek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="plek" sense="plek" word="plek"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="22" end="23" frame="punct(punt)" his="normal" his_1="normal" id="39" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zij hielden als eersten in deze streek op met het bestaan als jager en verzamelaar en gingen wonen op een vaste plek .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d6.example.alpino
+++ b/tests/d6.example.alpino
@@ -1,0 +1,201 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="35" id="0" rel="top">
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="19" end="20" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="21" end="22" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="34" id="4" rel="--">
+        <node begin="0" cat="pp" end="6" id="5" rel="mod">
+          <node begin="0" end="1" frame="preposition(bij,[vandaan])" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="Bij"/>
+          <node begin="1" cat="np" end="6" id="7" rel="obj1">
+            <node begin="1" end="2" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="opgraving" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="opgraving" sense="opgraving" word="opgravingen"/>
+            <node begin="2" cat="conj" end="6" id="9" rel="mod">
+              <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="10" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="2" cat="pp" end="6" id="11" rel="cnj">
+                <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="12" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                <node begin="5" end="6" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="13" index="1" lcat="np" lemma="hunebed" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="hunebed" sense="hunebed" word="hunebedden"/>
+              </node>
+              <node begin="4" cat="pp" end="6" id="14" rel="cnj">
+                <node begin="4" end="5" frame="preposition(rond,[heen])" his="normal" his_1="normal" id="15" lcat="pp" lemma="rond" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="rond" sense="rond" vztype="init" word="rond"/>
+                <node begin="5" end="6" id="16" index="1" rel="obj1"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="6" end="7" frame="verb(unacc,pl,copula)" his="normal" his_1="normal" id="17" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+        <node begin="7" cat="np" end="24" id="18" rel="su">
+          <node begin="7" buiging="zonder" end="8" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="19" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+          <node begin="8" end="9" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="skelet" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="skelet" sense="skelet" word="skeletten"/>
+          <node begin="10" cat="rel" end="24" id="21" rel="mod">
+            <node begin="10" case="no_obl" end="11" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="22" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+            <node begin="10" cat="ssub" end="24" id="23" rel="body">
+              <node begin="10" end="11" id="24" index="2" rel="su"/>
+              <node begin="18" end="19" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="25" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+              <node begin="10" cat="ppart" end="24" id="26" rel="vc">
+                <node begin="10" end="11" id="27" index="2" rel="su"/>
+                <node begin="11" cat="pp" end="16" id="28" rel="mod">
+                  <node begin="11" end="12" frame="preposition(na,[])" his="normal" his_1="normal" id="29" lcat="pp" lemma="na" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="na" sense="na" vztype="init" word="na"/>
+                  <node begin="12" cat="np" end="16" id="30" rel="obj1">
+                    <node begin="12" cat="detp" end="14" id="31" rel="det">
+                      <node begin="12" buiging="zonder" end="13" frame="pre_det_quant(al)" his="normal" his_1="normal" id="32" infl="al" lcat="detp" lemma="al" naamval="stan" pdtype="det" pos="det" positie="vrij" postag="VNW(onbep,det,stan,vrij,zonder)" pt="vnw" rel="mod" root="al" sense="al" special="pre_det_quant" vwtype="onbep" word="al"/>
+                      <node begin="13" buiging="zonder" end="14" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="33" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="hd" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+                    </node>
+                    <node begin="14" end="15" frame="noun(de,count,pl,measure)" gen="de" getal-n="mv-n" graad="basis" his="normal" his_1="normal" id="34" lcat="np" lemma="duizend" num="pl" numtype="hoofd" pos="noun" positie="nom" postag="TW(hoofd,nom,mv-n,basis)" pt="tw" rel="hd" rnum="pl" root="duizend" sc="measure" sense="duizend" word="duizenden"/>
+                    <node begin="15" end="16" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="35" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="mod" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+                  </node>
+                </node>
+                <node begin="16" end="17" frame="adverb" his="normal" his_1="normal" id="36" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="mod" root="helemaal" sense="helemaal" word="helemaal"/>
+                <node begin="17" buiging="zonder" end="18" frame="verb(unacc,psp,intransitive)" his="normal" his_1="normal" id="37" infl="psp" lcat="ppart" lemma="vergaan" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="verga" sc="intransitive" sense="verga" word="vergaan" wvorm="vd"/>
+                <node begin="20" cat="conj" end="24" id="38" rel="mod">
+                  <node aform="base" begin="20" buiging="zonder" end="21" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="39" infl="both" lcat="ppart" lemma="vinden" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="cnj" root="vinden" sense="vinden" vform="psp" word="gevonden" wvorm="vd"/>
+                  <node begin="22" conjtype="neven" end="23" frame="conj(maar)" his="normal" his_1="normal" id="40" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+                  <node aform="base" begin="23" end="24" frame="adjective(pred(adv))" his="normal" his_1="normal" id="41" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="cnj" root="wel" sense="wel" vform="adj" word="wel"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="24" cat="np" end="34" id="42" rel="predc">
+          <node begin="24" end="25" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="43" lcat="np" lemma="cadeau" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="cadeau" sense="cadeau" word="cadeaus"/>
+          <node begin="25" cat="pp" end="34" id="44" rel="mod">
+            <node begin="25" end="26" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="45" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+            <node begin="26" cat="np" end="34" id="46" rel="obj1">
+              <node begin="26" end="27" frame="determiner(de)" his="normal" his_1="normal" id="47" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="27" buiging="met-e" end="28" frame="noun(de,count,pl)" gen="de" getal-n="mv-n" graad="basis" his="normal" his_1="normal" id="48" lcat="np" lemma="dood" num="pl" pos="noun" positie="nom" postag="ADJ(nom,basis,met-e,mv-n)" pt="adj" rel="hd" rnum="pl" root="dode" sense="dode" word="doden"/>
+              <node begin="28" cat="pp" end="34" id="49" rel="mod">
+                <node begin="28" end="29" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="50" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+                <node begin="29" cat="np" end="34" id="51" rel="obj1">
+                  <node begin="29" end="30" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="52" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                  <node begin="30" end="31" frame="tmp_noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="53" lcat="np" lemma="leven" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="leven" sense="leven" special="tmp" word="leven"/>
+                  <node begin="31" cat="pp" end="34" id="54" rel="mod">
+                    <node begin="31" end="32" frame="preposition(na,[])" his="normal" his_1="normal" id="55" lcat="pp" lemma="na" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="na" sense="na" vztype="init" word="na"/>
+                    <node begin="32" cat="np" end="34" id="56" rel="obj1">
+                      <node begin="32" end="33" frame="determiner(de)" his="normal" his_1="normal" id="57" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                      <node begin="33" end="34" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="58" lcat="np" lemma="dood" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dood" sense="dood" word="dood"/>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="34" end="35" frame="punct(punt)" his="normal" his_1="normal" id="59" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Bij opgravingen in en rond hunebedden zijn geen skeletten , die na al die duizenden jaren helemaal vergaan zijn , gevonden , maar wel cadeaus aan de doden voor het leven na de dood .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="27" id="0" rel="top">
+      <node begin="18" end="19" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="26" id="2" rel="--">
+        <node begin="0" cat="whsub" end="18" id="3" rel="su">
+          <node begin="0" end="1" frame="wh_adjective" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="whd" root="hoe" sense="hoe" wh="ywh" word="Hoe"/>
+          <node begin="0" cat="ssub" end="18" id="5" rel="body">
+            <node begin="1" end="2" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="6" index="2" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+            <node begin="5" end="6" frame="verb(unacc,sg_is,aux_psp_zijn)" his="normal" his_1="normal" id="7" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="present" word="is" wvorm="pv"/>
+            <node begin="0" cat="ppart" end="18" id="8" rel="vc">
+              <node begin="0" end="1" id="9" index="1" rel="mod"/>
+              <node begin="1" end="2" id="10" index="2" rel="sup"/>
+              <node begin="2" cat="np" end="4" id="11" rel="obj2">
+                <node begin="2" buiging="met-e" end="3" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="12" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+                <node begin="3" end="4" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="mens" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="mens" sense="mens" word="mensen"/>
+              </node>
+              <node begin="4" buiging="zonder" end="5" frame="verb(unacc,psp,vp_subj_so_np)" his="normal" his_1="normal" id="14" infl="psp" lcat="ppart" lemma="lukken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="luk" sc="vp_subj_so_np" sense="luk" word="gelukt" wvorm="vd"/>
+              <node begin="6" cat="oti" end="18" id="15" rel="su">
+                <node begin="6" end="7" frame="complementizer(om)" his="normal" his_1="normal" id="16" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+                <node begin="7" cat="ti" end="18" id="17" rel="body">
+                  <node begin="10" end="11" frame="complementizer(te)" his="normal" his_1="normal" id="18" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                  <node begin="7" cat="inf" end="18" id="19" rel="body">
+                    <node begin="7" cat="pp" end="9" id="20" rel="mod">
+                      <node begin="7" end="8" frame="preposition(zonder,[])" his="normal" his_1="normal" id="21" lcat="pp" lemma="zonder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="zonder" sense="zonder" vztype="init" word="zonder"/>
+                      <node begin="8" end="9" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="machine" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="machine" sense="machine" word="machines"/>
+                    </node>
+                    <node begin="11" buiging="zonder" end="12" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="23" infl="inf" lcat="inf" lemma="vervoeren" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="vervoer" sc="transitive" sense="vervoer" word="vervoeren" wvorm="inf"/>
+                    <node begin="9" cat="np" end="18" id="24" rel="obj1">
+                      <node begin="9" end="10" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="steen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="steen" sense="steen" word="stenen"/>
+                      <node begin="12" cat="rel" end="18" id="26" rel="mod">
+                        <node begin="12" case="no_obl" end="13" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="27" index="3" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+                        <node begin="12" cat="ssub" end="18" id="28" rel="body">
+                          <node begin="12" end="13" id="29" index="3" rel="su"/>
+                          <node begin="13" end="14" frame="sentence_adverb" his="normal" his_1="normal" id="30" lcat="advp" lemma="soms" pos="adv" postag="BW()" pt="bw" rel="mod" root="soms" sense="soms" special="sentence" word="soms"/>
+                          <node aform="base" begin="14" end="15" frame="adjective(pred(adv))" his="normal" his_1="normal" id="31" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+                          <node begin="15" cat="np" end="17" id="32" rel="me">
+                            <node begin="15" end="16" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="33" infl="pl_num" lcat="detp" lemma="20.000" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="20.000" sense="20.000" word="20.000"/>
+                            <node begin="16" end="17" frame="meas_mod_noun(de,count,meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="34" lcat="np" lemma="kilo" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kilo" sense="kilo" special="meas_mod" word="kilo"/>
+                          </node>
+                          <node begin="17" end="18" frame="verb(hebben,pl,meas)" his="normal" his_1="normal" id="35" infl="pl" lcat="ssub" lemma="wegen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="weeg" sc="meas" sense="weeg" tense="present" word="wegen" wvorm="pv"/>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="19" end="20" frame="verb(unacc,sg_is,copula_sbar)" his="normal" his_1="normal" id="36" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula_sbar" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="20" end="21" frame="sentence_adverb" his="normal" his_1="normal" id="37" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+        <node begin="21" cat="advp" end="23" id="38" rel="mod">
+          <node begin="21" end="22" frame="modal_adverb" his="normal" his_1="normal" id="39" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sc="modal" sense="nog" word="nog"/>
+          <node begin="22" end="23" frame="adverb" his="normal" his_1="normal" id="40" lcat="advp" lemma="steeds" pos="adv" postag="BW()" pt="bw" rel="hd" root="steeds" sense="steeds" word="steeds"/>
+        </node>
+        <node begin="23" cat="ap" end="26" id="41" rel="predc">
+          <node begin="23" cat="advp" end="25" his="normal" his_1="normal" id="42" rel="mod">
+            <node begin="23" end="24" frame="adverb" id="43" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="24" end="25" frame="adverb" id="44" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="hd" root="helemaal" sense="helemaal" word="helemaal"/>
+          </node>
+          <node aform="base" begin="25" buiging="zonder" end="26" frame="adjective(no_e(adv),subject_sbar_no_het)" graad="basis" his="normal" his_1="normal" id="45" infl="no_e" lcat="ap" lemma="duidelijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="duidelijk" sc="subject_sbar_no_het" sense="duidelijk" vform="adj" word="duidelijk"/>
+        </node>
+      </node>
+      <node begin="26" end="27" frame="punct(punt)" his="normal" his_1="normal" id="46" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hoe het deze mensen gelukt is om zonder machines stenen te vervoeren die soms wel 20.000 kilo wegen , is ook nog steeds niet helemaal duidelijk .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="18" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="12" end="13" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="2" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="14" end="15" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="3" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="0" cat="smain" end="17" id="4" rel="--">
+        <node begin="0" cat="pp" end="3" id="5" rel="mod">
+          <node begin="0" end="1" frame="preposition(onder,[door,vandaan])" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="pp" lemma="onder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="onder" sense="onder" vztype="init" word="Onder"/>
+          <node begin="1" cat="np" end="3" id="7" rel="obj1">
+            <node begin="1" buiging="zonder" end="2" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="die"/>
+            <node begin="2" end="3" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="cadeau" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="cadeau" sense="cadeau" word="cadeaus"/>
+          </node>
+        </node>
+        <node begin="3" end="4" frame="verb(unacc,past(pl),intransitive)" his="normal" his_1="normal" id="10" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="past" word="waren" wvorm="pv"/>
+        <node begin="4" end="5" frame="sentence_adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+        <node begin="5" cat="np" end="17" id="12" rel="su">
+          <node aform="base" begin="5" buiging="met-e" end="6" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="13" infl="e" lcat="ap" lemma="bijzonder" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="bijzonder" sense="bijzonder" vform="adj" word="bijzondere"/>
+          <node begin="6" end="7" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="pot" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="pot" sense="pot" special="tmp" word="potten"/>
+          <node begin="8" cat="rel" end="17" id="15" rel="mod">
+            <node begin="8" case="no_obl" end="9" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="16" index="1" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+            <node begin="8" cat="ssub" end="17" id="17" rel="body">
+              <node begin="8" end="9" id="18" index="1" rel="su"/>
+              <node begin="15" end="16" frame="verb(unacc,pl,passive)" his="normal" his_1="normal" id="19" infl="pl" lcat="ssub" lemma="worden" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="word" sc="passive" sense="word" tense="present" word="worden" wvorm="pv"/>
+              <node begin="8" cat="ppart" end="17" id="20" rel="vc">
+                <node begin="8" end="9" id="21" index="1" rel="obj1"/>
+                <node begin="9" cat="pp" end="14" id="22" rel="mod">
+                  <node begin="9" end="10" frame="preposition(vanwege,[])" his="normal" his_1="normal" id="23" lcat="pp" lemma="vanwege" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="vanwege" sense="vanwege" vztype="init" word="vanwege"/>
+                  <node begin="10" cat="np" end="14" id="24" rel="obj1">
+                    <node begin="10" buiging="zonder" end="11" frame="determiner(pron)" getal="mv" his="normal" his_1="normal" id="25" infl="pron" lcat="detp" lemma="hun" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,mv,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="hun" sense="hun" status="vol" vwtype="bez" word="hun"/>
+                    <node begin="11" end="12" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="26" lcat="np" lemma="vorm" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vorm" sense="vorm" word="vorm"/>
+                    <node begin="13" end="14" frame="proper_name(both)" genus="zijd" getal="ev" graad="basis" his="quoted_name" his_1="'" his_2="'" id="27" lcat="np" lemma="trechterbekers" naamval="stan" neclass="MISC" ntype="soort" num="both" pos="name" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="trechterbekers" sense="trechterbekers" word="trechterbekers"/>
+                  </node>
+                </node>
+                <node begin="16" buiging="zonder" end="17" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="28" infl="psp" lcat="ppart" lemma="noemen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="noem" sc="transitive" sense="noem" word="genoemd" wvorm="vd"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="17" end="18" frame="punct(punt)" his="normal" his_1="normal" id="29" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Onder die cadeaus waren ook bijzondere potten , die vanwege hun vorm ' trechterbekers ' worden genoemd .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/d7.example.alpino
+++ b/tests/d7.example.alpino
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="21" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="13" end="14" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="20" id="3" rel="--">
+        <node begin="8" end="9" frame="verb(unacc,past(sg),passive)" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="word" sc="passive" sense="word" stype="declarative" tense="past" word="werd" wvorm="pv"/>
+        <node begin="9" cat="np" end="12" id="5" index="1" rel="su">
+          <node begin="9" end="10" frame="determiner(de)" his="normal" his_1="normal" id="6" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="10" end="11" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="grond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="grond" sense="grond" word="grond"/>
+          <node begin="11" end="12" frame="er_adverb(onder)" his="normal" his_1="normal" id="8" lcat="pp" lemma="eronder" pos="pp" postag="BW()" pt="bw" rel="mod" root="eronder" sense="eronder" special="er" word="eronder"/>
+        </node>
+        <node begin="0" cat="ppart" end="20" id="9" rel="vc">
+          <node begin="0" cat="cp" end="7" id="10" rel="mod">
+            <node begin="0" conjtype="onder" end="1" frame="complementizer(als)" his="normal" his_1="decap" his_1_1="normal" id="11" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="Als"/>
+            <node begin="1" cat="ssub" end="7" id="12" rel="body">
+              <node begin="1" cat="np" end="3" id="13" rel="su">
+                <node begin="1" end="2" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="2" end="3" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="steen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="steen" sense="steen" word="stenen"/>
+              </node>
+              <node begin="3" cat="pp" end="6" id="16" rel="ld">
+                <node begin="3" end="4" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="17" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                <node begin="4" cat="np" end="6" id="18" rel="obj1">
+                  <node begin="4" buiging="zonder" end="5" frame="determiner(pron)" getal="mv" his="normal" his_1="normal" id="19" infl="pron" lcat="detp" lemma="hun" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,mv,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="hun" sense="hun" status="vol" vwtype="bez" word="hun"/>
+                  <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="plek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="plek" sense="plek" word="plek"/>
+                </node>
+              </node>
+              <node begin="6" end="7" frame="verb('hebben/zijn',past(pl),ld_pp)" his="normal" his_1="normal" id="21" infl="pl" lcat="ssub" lemma="liggen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="lig" sc="ld_pp" sense="lig" tense="past" word="lagen" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="9" end="12" id="22" index="1" rel="obj1"/>
+          <node begin="12" buiging="zonder" end="13" frame="verb(hebben,psp,ninv(transitive,part_transitive(weg)))" his="normal" his_1="part-V" id="23" infl="psp" lcat="ppart" lemma="weg_halen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="haal_weg" sc="part_transitive(weg)" sense="haal_weg" word="weggehaald" wvorm="vd"/>
+          <node begin="14" cat="cp" end="20" id="24" rel="mod">
+            <node begin="14" conjtype="onder" end="15" frame="complementizer" his="normal" his_1="normal" id="25" lcat="cp" lemma="zodat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zodat" sense="zodat" word="zodat"/>
+            <node begin="15" cat="ssub" end="20" id="26" rel="body">
+              <node begin="16" cat="np" end="18" id="27" index="2" rel="su">
+                <node begin="16" end="17" frame="determiner(een)" his="normal" his_1="normal" id="28" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="17" end="18" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="29" lcat="np" lemma="graf_kamer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="graf_kamer" sense="graf_kamer" word="grafkamer"/>
+              </node>
+              <node begin="15" cat="ppart" end="19" id="30" rel="vc">
+                <node begin="15" end="16" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="31" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+                <node begin="16" end="18" id="32" index="2" rel="obj1"/>
+                <node begin="18" buiging="zonder" end="19" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="33" infl="psp" lcat="ppart" lemma="maken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="maak" sc="transitive" sense="maak" word="gemaakt" wvorm="vd"/>
+              </node>
+              <node begin="19" end="20" frame="verb(unacc,sg3,passive)" his="normal" his_1="normal" id="34" infl="sg3" lcat="ssub" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="word" sc="passive" sense="word" tense="present" word="wordt" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="20" end="21" frame="punct(punt)" his="normal" his_1="normal" id="35" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Als de stenen op hun plek lagen , werd de grond eronder weggehaald , zodat er een grafkamer gemaakt wordt .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist1.example.alpino
+++ b/tests/depdist1.example.alpino
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="smain" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(zijn,sg3,ld_pp)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="declarative" tense="present" word="gaat" wvorm="pv"/>
+        <node begin="2" cat="pp" end="4" id="4" rel="ld">
+          <node begin="2" end="3" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="5" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan gaat naar huis .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist10.example.alpino
+++ b/tests/depdist10.example.alpino
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,np_np)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="geven" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="geef" sc="np_np" sense="geef" stype="declarative" tense="present" word="geef" wvorm="pv"/>
+        <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="4" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj2" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+        <node begin="3" cat="np" end="5" id="5" rel="obj1">
+          <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="6" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik geef hem een boek .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist11.example.alpino
+++ b/tests/depdist11.example.alpino
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,np_np)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="geven" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="geef" sc="np_np" sense="geef" stype="declarative" tense="present" word="geef" wvorm="pv"/>
+        <node begin="2" cat="np" end="7" id="4" rel="obj2">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="4" cat="pp" end="7" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="5" cat="np" end="7" id="9" rel="obj1">
+              <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+            </node>
+          </node>
+        </node>
+        <node begin="7" cat="np" end="9" id="12" rel="obj1">
+          <node begin="7" end="8" frame="determiner(een)" his="normal" his_1="normal" id="13" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="8" end="9" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">ik geef de man met de pet een boek .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist11.example.ok
+++ b/tests/depdist11.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>geef</t>
-                <feat class="[geef]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>geef</t>
-                  <feat class="[geef]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/depdist12.example.alpino
+++ b/tests/depdist12.example.alpino
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,np_np)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="geven" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="geef" sc="np_np" sense="geef" stype="declarative" tense="present" word="geef" wvorm="pv"/>
+        <node begin="2" cat="conj" end="5" id="4" rel="obj2">
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+          <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        </node>
+        <node begin="5" cat="np" end="7" id="8" rel="obj1">
+          <node begin="5" end="6" frame="determiner(een)" his="normal" his_1="normal" id="9" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="6" end="7" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik geef Jan en Piet een boek .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist12.example.ok
+++ b/tests/depdist12.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>geef</t>
-                <feat class="[geef]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>geef</t>
-                  <feat class="[geef]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/depdist13.example.alpino
+++ b/tests/depdist13.example.alpino
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="conj" end="5" id="1" rel="--">
+        <node begin="2" conjtype="neven" end="3" frame="conj(en)" his="normal" his_1="normal" id="2" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="5" id="3" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="5" infl="sg1" lcat="smain" lemma="waarderen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="waardeer" sc="transitive" sense="waardeer" tense="present" word="waardeer" wvorm="pv"/>
+          <node begin="4" case="dat_acc" def="def" end="5" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="6" index="2" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+        </node>
+        <node begin="0" cat="ssub" end="5" id="7" rel="cnj">
+          <node begin="0" end="1" id="8" index="1" rel="su"/>
+          <node begin="3" end="4" frame="verb(hebben,sg1,transitive)" his="normal" his_1="normal" id="9" infl="sg1" lcat="ssub" lemma="bewonderen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="bewonder" sc="transitive" sense="bewonder" tense="present" word="bewonder" wvorm="pv"/>
+          <node begin="4" end="5" id="10" index="2" rel="obj1"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik waardeer en bewonder hem .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist13.example.ok
+++ b/tests/depdist13.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -129,35 +128,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>waardeer</t>
-                <feat class="[[waarde]noun[eer]]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="complex">
-                  <feat class="V_N*" subset="applied_rule"/>
-                  <feat class="[[waarde]noun[eer]]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                  <morpheme class="stem">
-                    <t>waarde</t>
-                    <feat class="[waarde]noun" subset="structure"/>
-                    <pos class="N" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                  </morpheme>
-                  <morpheme class="affix">
-                    <t>eer</t>
-                    <feat class="[eer]" subset="structure"/>
-                  </morpheme>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/depdist14.example.alpino
+++ b/tests/depdist14.example.alpino
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="0" cat="smain" end="12" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aci)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" cat="pp" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="5" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+          <node begin="3" cat="np" end="5" id="6" rel="obj1">
+            <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(both(nonadv))" graad="basis" his="normal" his_1="normal" id="7" infl="both" lcat="ap" lemma="eigen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="eigen" sense="eigen" vform="adj" word="eigen"/>
+            <node begin="4" end="5" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="oog" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="oog" sense="oog" word="ogen"/>
+          </node>
+        </node>
+        <node begin="5" cat="np" end="10" id="9" index="1" rel="obj1">
+          <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="6" end="7" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="7" cat="pp" end="10" id="12" rel="mod">
+            <node begin="7" end="8" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="13" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="8" cat="np" end="10" id="14" rel="obj1">
+              <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="15" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+            </node>
+          </node>
+        </node>
+        <node begin="5" cat="inf" end="12" id="17" rel="vc">
+          <node begin="5" end="10" id="18" index="1" rel="su"/>
+          <node begin="10" end="11" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="19" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="ld" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          <node begin="11" buiging="zonder" end="12" frame="verb(hebben,inf(no_e),ld_adv)" his="normal" his_1="normal" id="20" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="ld_adv" sense="sta" word="staan" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zie met eigen ogen de man met de pet daar staan .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist14.example.ok
+++ b/tests/depdist14.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zie</t>
-                <feat class="[zie]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zie</t>
-                  <feat class="[zie]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/depdist15.example.alpino
+++ b/tests/depdist15.example.alpino
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="0" cat="np" end="4" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="4" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="grote"/>
+          <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="5" infl="e" lcat="ap" lemma="boos" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="boos" sense="boos" vform="adj" word="boze"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="wolf" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wolf" sense="wolf" word="wolf"/>
+        </node>
+        <node begin="4" end="5" frame="verb(hebben,past(sg),part_intransitive(op))" his="normal" his_1="normal" id="7" infl="sg" lcat="smain" lemma="op_eten" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="eet_op" sc="part_intransitive(op)" sense="eet_op" stype="declarative" tense="past" word="at" wvorm="pv"/>
+        <node begin="5" cat="pp" end="8" id="8" rel="mod">
+          <node begin="5" end="6" frame="preposition(na,[])" his="normal" his_1="normal" id="9" lcat="pp" lemma="na" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="na" sense="na" vztype="init" word="na"/>
+          <node begin="6" cat="np" end="8" id="10" rel="obj1">
+            <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="oma" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="oma" sense="oma" word="oma"/>
+            <node begin="7" end="8" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="12" lcat="np" lemma="Roodkapje" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="Roodkapje" sense="Roodkapje" word="Roodkapje"/>
+          </node>
+        </node>
+        <node begin="8" end="9" frame="particle(op)" his="normal" his_1="normal" id="13" lcat="part" lemma="op" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="op" sense="op" vztype="fin" word="op"/>
+        <node begin="9" cat="cp" end="11" id="14" rel="mod">
+          <node begin="9" conjtype="onder" end="10" frame="complementizer(als)" his="normal" his_1="normal" id="15" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="toetje" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="body" rnum="sg" root="toetje" sense="toetje" word="toetje"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De grote boze wolf at na oma Roodkapje op als toetje .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist17.example.alpino
+++ b/tests/depdist17.example.alpino
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heeft" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="8" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="np" end="7" id="6" rel="obj1">
+            <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="3" end="4" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+            <node begin="4" cat="pp" end="7" id="9" rel="mod">
+              <node begin="4" end="5" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="10" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="5" cat="np" end="7" id="11" rel="obj1">
+                <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="12" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+              </node>
+            </node>
+          </node>
+          <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,transitive_ndev_ndev)" his="normal" his_1="normal" id="14" infl="psp" lcat="ppart" lemma="zien" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" word="gezien" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij heeft de man met de pet gezien .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist18.example.alpino
+++ b/tests/depdist18.example.alpino
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(zijn,past(sg),ld_pp)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="declarative" tense="past" word="ging" wvorm="pv"/>
+        <node begin="2" cat="pp" end="4" id="4" rel="ld">
+          <node begin="2" end="3" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="5" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+        </node>
+        <node begin="4" cat="cp" end="8" id="7" rel="mod">
+          <node begin="4" conjtype="onder" end="5" frame="complementizer" his="normal" his_1="normal" id="8" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+          <node begin="5" cat="ssub" end="8" id="9" rel="body">
+            <node begin="5" case="nom" def="def" end="6" frame="pronoun(nwh,thi,sg,de,nom,def,wkpro)" gen="de" genus="masc" getal="ev" his="normal" his_1="variant" id="10" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,red,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ie"/>
+            <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(padv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="moe" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="moe" sense="moe" vform="adj" word="moe"/>
+            <node begin="7" end="8" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="12" infl="sg" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" tense="past" word="was" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij ging naar huis omdat ie moe was .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist19.example.alpino
+++ b/tests/depdist19.example.alpino
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" cat="conj" end="7" id="2" rel="su">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+          <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="4" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="2" cat="np" end="7" id="5" rel="cnj">
+            <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="6" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="3" end="4" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+            <node begin="4" cat="pp" end="7" id="8" rel="mod">
+              <node begin="4" end="5" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="9" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="5" cat="np" end="7" id="10" rel="obj1">
+                <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="11" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="7" end="8" frame="verb('hebben/zijn',past(pl),ld_pp)" his="normal" his_1="normal" id="13" infl="pl" lcat="smain" lemma="lopen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="loop" sc="ld_pp" sense="loop" stype="declarative" tense="past" word="liepen" wvorm="pv"/>
+        <node begin="8" cat="pp" end="10" id="14" rel="ld">
+          <node begin="8" end="9" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="15" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="9" end="10" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan en de man met de pet liepen naar huis .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist2.example.alpino
+++ b/tests/depdist2.example.alpino
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" cat="np" end="5" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="2" cat="pp" end="5" id="5" rel="mod">
+            <node begin="2" end="3" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="6" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="3" cat="np" end="5" id="7" rel="obj1">
+              <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+            </node>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(zijn,sg3,ld_pp)" his="normal" his_1="normal" id="10" infl="sg3" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="declarative" tense="present" word="gaat" wvorm="pv"/>
+        <node begin="6" cat="pp" end="8" id="11" rel="ld">
+          <node begin="6" end="7" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="12" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="7" end="8" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De man met de pet gaat naar huis .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist20.example.alpino
+++ b/tests/depdist20.example.alpino
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="2" skips="1"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="5" end="6" frame="preposition(bij,[vandaan])" his="robust_skip" id="1" lcat="--" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="--" root="bij" sense="bij" vztype="init" word="bij"/>
+      <node begin="6" end="7" frame="punct(komma)" his="robust_skip" id="2" lcat="--" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="13" id="3" rel="--">
+        <node begin="0" cat="smain" end="5" id="4" rel="dp">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="1" end="2" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="maken" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="maak" sc="transitive" sense="maak" stype="declarative" tense="past" word="maakte" wvorm="pv"/>
+          <node begin="2" end="3" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="7" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="3" cat="np" end="5" id="8" rel="obj1">
+            <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="9" infl="e" lcat="ap" lemma="mooi" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="mooi" sense="mooi" vform="adj" word="mooie"/>
+            <node begin="4" end="5" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="10" lcat="np" lemma="plaat" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="plaat_DIM" sense="plaat_DIM" word="plaatjes"/>
+          </node>
+        </node>
+        <node begin="7" cat="cp" end="13" id="11" rel="dp">
+          <node begin="7" conjtype="onder" end="8" frame="complementizer" his="normal" his_1="normal" id="12" lcat="cp" lemma="zodat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zodat" sense="zodat" word="zodat"/>
+          <node begin="8" cat="ssub" end="13" id="13" rel="body">
+            <node begin="8" end="9" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="14" index="1" lcat="np" lemma="Ko" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Ko" sense="Ko" word="Ko"/>
+            <node begin="11" end="12" frame="verb('hebben/zijn',past(sg),aux(inf))" his="normal" his_1="normal" id="15" infl="sg" lcat="ssub" lemma="kunnen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="kan" sc="aux(inf)" sense="kan" tense="past" word="kon" wvorm="pv"/>
+            <node begin="8" cat="inf" end="13" id="16" rel="vc">
+              <node begin="8" end="9" id="17" index="1" rel="su"/>
+              <node begin="9" end="10" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="18" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+              <node aform="compar" begin="10" buiging="zonder" end="11" frame="adjective(er(adv))" graad="comp" his="normal" his_1="normal" id="19" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="beter"/>
+              <node begin="12" buiging="zonder" end="13" frame="verb(hebben,inf(no_e),transitive_ndev_ndev)" his="normal" his_1="normal" id="20" infl="inf(no_e)" lcat="inf" lemma="zien" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" word="zien" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="robust_skip" id="21" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij maakte er mooie plaatjes bij , zodat Ko het beter kon zien .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist21.example.alpino
+++ b/tests/depdist21.example.alpino
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" cat="np" end="6" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,sg,sbar)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="kans" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kans" sc="sbar" sense="kans" word="kans"/>
+          <node begin="2" cat="cp" end="6" id="5" rel="vc">
+            <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="6" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+            <node begin="3" cat="ssub" end="6" id="7" rel="body">
+              <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="8" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="9" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+              <node begin="5" end="6" frame="verb(hebben,sg3,transitive_ndev_ndev)" his="normal" his_1="normal" id="10" infl="sg3" lcat="ssub" lemma="zien" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" tense="present" word="ziet" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="6" end="7" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="11" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="7" cat="ap" end="9" id="12" rel="predc">
+          <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(no_e(both))" graad="basis" his="normal" his_1="normal" id="13" infl="no_e" lcat="ap" lemma="vrij" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="vrij" sense="vrij" vform="adj" word="vrij"/>
+          <node aform="base" begin="8" buiging="zonder" end="9" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="14" infl="no_e" lcat="ap" lemma="klein" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="klein" sense="klein" vform="adj" word="klein"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De kans dat hij Piet ziet is vrij klein .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist22.example.alpino
+++ b/tests/depdist22.example.alpino
@@ -1,0 +1,97 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="9" id="3" rel="--">
+        <node begin="0" cat="np" end="4" id="4" index="1" rel="su">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+          <node begin="2" cat="np" end="4" id="6" rel="app">
+            <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="7" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="zwager" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zwager" sense="zwager" word="zwager"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="9" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heeft" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="9" id="10" rel="vc">
+          <node begin="0" end="4" id="11" index="1" rel="su"/>
+          <node begin="6" cat="np" end="8" id="12" rel="obj1">
+            <node begin="6" buiging="zonder" end="7" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="13" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node begin="7" end="8" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="fiets" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="fiets" sense="fiets" word="fiets"/>
+          </node>
+          <node begin="8" buiging="zonder" end="9" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="15" infl="psp" lcat="ppart" lemma="stelen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="steel" sc="transitive" sense="steel" word="gestolen" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter , mijn zwager , heeft mijn fiets gestolen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="3" rel="--">
+        <node begin="0" cat="np" end="4" id="4" index="1" rel="su">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+          <node begin="2" cat="np" end="4" id="6" rel="app">
+            <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="7" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="zwager" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zwager" sense="zwager" word="zwager"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(unacc,sg_is,aux_psp_zijn)" his="normal" his_1="normal" id="9" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="10" id="10" rel="vc">
+          <node begin="0" end="4" id="11" index="1" rel="su"/>
+          <node begin="6" end="7" frame="adverb" his="normal" his_1="normal" id="12" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+          <node begin="7" cat="pp" end="9" id="13" rel="ld">
+            <node begin="7" end="8" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="14" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="8" end="9" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+          <node begin="9" buiging="zonder" end="10" frame="verb(zijn,psp,ld_pp)" his="normal" his_1="normal" id="16" infl="psp" lcat="ppart" lemma="gaan" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="ga" sc="ld_pp" sense="ga" word="gegaan" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter , mijn zwager , is al naar huis gegaan .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+        <node begin="1" end="2" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heeft" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="5" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="np" end="4" id="6" rel="obj1">
+            <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="7" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="fiets" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="fiets" sense="fiets" word="fiets"/>
+          </node>
+          <node begin="4" buiging="zonder" end="5" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="9" infl="psp" lcat="ppart" lemma="stelen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="steel" sc="transitive" sense="steel" word="gestolen" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter heeft mijn fiets gestolen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,aux_psp_zijn)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="6" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+          <node begin="3" cat="pp" end="5" id="7" rel="ld">
+            <node begin="3" end="4" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="8" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+          <node begin="5" buiging="zonder" end="6" frame="verb(zijn,psp,ld_pp)" his="normal" his_1="normal" id="10" infl="psp" lcat="ppart" lemma="gaan" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="ga" sc="ld_pp" sense="ga" word="gegaan" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter is al naar huis gegaan .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist3.example.alpino
+++ b/tests/depdist3.example.alpino
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" cat="conj" end="3" id="2" rel="su">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+          <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="4" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        </node>
+        <node begin="3" end="4" frame="verb(zijn,pl,ld_pp)" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="declarative" tense="present" word="gaan" wvorm="pv"/>
+        <node begin="4" cat="pp" end="6" id="7" rel="ld">
+          <node begin="4" end="5" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="8" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan en Piet gaan naar huis .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist4.example.alpino
+++ b/tests/depdist4.example.alpino
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="conj" end="9" id="1" rel="--">
+        <node begin="0" cat="smain" end="4" id="2" rel="cnj">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" index="1" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+          <node begin="1" end="2" frame="verb(zijn,sg3,ld_pp)" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" tense="present" word="gaat" wvorm="pv"/>
+          <node begin="2" cat="pp" end="4" id="5" rel="ld">
+            <node begin="2" end="3" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="6" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+        </node>
+        <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="8" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="9" id="9" rel="cnj">
+          <node begin="0" end="1" id="10" index="1" rel="su"/>
+          <node begin="5" end="6" frame="verb(hebben,sg,transitive)" his="normal" his_1="normal" id="11" infl="sg" lcat="smain" lemma="zetten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zet" sc="transitive" sense="zet" tense="present" word="zet" wvorm="pv"/>
+          <node begin="6" cat="np" end="9" id="12" rel="obj1">
+            <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="13" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="7" end="8" frame="noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="14" lcat="np" lemma="bak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="bak_DIM" sc="measure" sense="bak_DIM" word="bakje"/>
+            <node begin="8" end="9" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="koffie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="koffie" sense="koffie" word="koffie"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan gaat naar huis en zet een bakje koffie .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist4.example.ok
+++ b/tests/depdist4.example.ok
@@ -302,26 +302,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zet</t>
-                <feat class="[zet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zet</t>
-                  <feat class="[zet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.1.w.6.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zet</t>
                 <feat class="[zet]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">

--- a/tests/depdist5.example.alpino
+++ b/tests/depdist5.example.alpino
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="16" id="3" rel="--">
+        <node begin="0" cat="smain" end="11" id="4" rel="cnj">
+          <node begin="0" cat="np" end="7" id="5" index="1" rel="su">
+            <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="6" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+            <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+            <node begin="3" cat="pp" end="7" id="8" rel="mod">
+              <node begin="3" end="4" frame="preposition(met,[],absolute)" his="normal" his_1="normal" id="9" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sc="absolute" sense="met" vztype="init" word="met"/>
+              <node begin="4" cat="np" end="6" id="10" rel="obj1">
+                <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="11" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+              </node>
+              <node aform="base" begin="6" end="7" frame="adjective(pred(nonadv))" his="normal" his_1="normal" id="13" infl="pred" lcat="ap" lemma="op" pos="adj" postag="VZ(fin)" pt="vz" rel="predc" root="op" sense="op" vform="adj" vztype="fin" word="op"/>
+            </node>
+          </node>
+          <node begin="8" end="9" frame="verb(zijn,sg3,ld_pp)" his="normal" his_1="normal" id="14" infl="sg3" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" tense="present" word="gaat" wvorm="pv"/>
+          <node begin="9" cat="pp" end="11" id="15" rel="ld">
+            <node begin="9" end="10" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="16" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+        </node>
+        <node begin="11" conjtype="neven" end="12" frame="conj(en)" his="normal" his_1="normal" id="18" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="16" id="19" rel="cnj">
+          <node begin="0" end="7" id="20" index="1" rel="su"/>
+          <node begin="12" end="13" frame="verb(hebben,sg,transitive)" his="normal" his_1="normal" id="21" infl="sg" lcat="smain" lemma="zetten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zet" sc="transitive" sense="zet" tense="present" word="zet" wvorm="pv"/>
+          <node begin="13" cat="np" end="16" id="22" rel="obj1">
+            <node begin="13" end="14" frame="determiner(een)" his="normal" his_1="normal" id="23" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="14" end="15" frame="noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="24" lcat="np" lemma="bak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="bak_DIM" sc="measure" sense="bak_DIM" word="bakje"/>
+            <node begin="15" end="16" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="koffie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="koffie" sense="koffie" word="koffie"/>
+          </node>
+        </node>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="26" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De man , met de pet op , gaat naar huis en zet een bakje koffie .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist5.example.ok
+++ b/tests/depdist5.example.ok
@@ -513,26 +513,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zet</t>
-                <feat class="[zet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zet</t>
-                  <feat class="[zet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.1.w.13.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zet</t>
                 <feat class="[zet]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">

--- a/tests/depdist6.example.alpino
+++ b/tests/depdist6.example.alpino
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="conj" end="11" id="1" rel="--">
+        <node begin="0" cat="smain" end="6" id="2" rel="cnj">
+          <node begin="0" cat="conj" end="3" id="3" index="1" rel="su">
+            <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="cap" id="4" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Jan" sense="Jan" word="jan"/>
+            <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="5" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="6" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+          </node>
+          <node begin="3" end="4" frame="verb(zijn,pl,ld_pp)" his="normal" his_1="normal" id="7" infl="pl" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" tense="present" word="gaan" wvorm="pv"/>
+          <node begin="4" cat="pp" end="6" id="8" rel="ld">
+            <node begin="4" end="5" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="9" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="11" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="11" id="12" rel="cnj">
+          <node begin="0" end="3" id="13" index="1" rel="su"/>
+          <node begin="7" end="8" frame="verb(hebben,both(pl),transitive)" his="normal" his_1="normal" id="14" infl="pl" lcat="smain" lemma="zetten" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="zet" sc="transitive" sense="zet" word="zetten" wvorm="pv"/>
+          <node begin="8" cat="np" end="11" id="15" rel="obj1">
+            <node begin="8" end="9" frame="determiner(een)" his="normal" his_1="normal" id="16" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="9" end="10" frame="noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="17" lcat="np" lemma="bak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="bak_DIM" sc="measure" sense="bak_DIM" word="bakje"/>
+            <node begin="10" end="11" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="koffie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="koffie" sense="koffie" word="koffie"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">jan en Piet gaan naar huis en zetten een bakje koffie .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist7.example.alpino
+++ b/tests/depdist7.example.alpino
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aci)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="4" index="1" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+        <node begin="2" cat="inf" end="5" id="5" rel="vc">
+          <node begin="2" end="3" id="6" index="1" rel="su"/>
+          <node begin="3" end="4" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="7" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="ld" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf(no_e),ld_adv)" his="normal" his_1="normal" id="8" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="ld_adv" sense="sta" word="staan" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zie hem daar staan .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist8.example.alpino
+++ b/tests/depdist8.example.alpino
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aci)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" cat="np" end="7" id="4" index="1" rel="obj1">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="4" cat="pp" end="7" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="5" cat="np" end="7" id="9" rel="obj1">
+              <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="pet" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pet" sense="pet" word="pet"/>
+            </node>
+          </node>
+        </node>
+        <node begin="2" cat="inf" end="9" id="12" rel="vc">
+          <node begin="2" end="7" id="13" index="1" rel="su"/>
+          <node begin="7" end="8" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="14" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="ld" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf(no_e),ld_adv)" his="normal" his_1="normal" id="15" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="ld_adv" sense="sta" word="staan" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zie de man met de pet daar staan .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist8.example.ok
+++ b/tests/depdist8.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zie</t>
-                <feat class="[zie]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zie</t>
-                  <feat class="[zie]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/depdist9.example.alpino
+++ b/tests/depdist9.example.alpino
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:18" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aci)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" cat="conj" end="5" id="4" index="1" rel="obj1">
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+          <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        </node>
+        <node begin="2" cat="inf" end="7" id="8" rel="vc">
+          <node begin="2" end="5" id="9" index="1" rel="su"/>
+          <node begin="5" end="6" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="10" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="ld" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          <node begin="6" buiging="zonder" end="7" frame="verb(hebben,inf(no_e),ld_adv)" his="normal" his_1="normal" id="11" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="ld_adv" sense="sta" word="staan" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zie Jan en Piet daar staan .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/depdist9.example.ok
+++ b/tests/depdist9.example.ok
@@ -34,7 +34,6 @@
         <annotator processor="NER.1"/>
       </entity-annotation>
       <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
-      <alternative-annotation/>
       <metric-annotation annotator="tscan" set="metricset"/>
       <pos-annotation annotator="tscan" set="tscan-set"/>
     </annotations>
@@ -120,26 +119,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zie</t>
-                <feat class="[zie]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zie</t>
-                  <feat class="[zie]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/dlevel1.example.alpino
+++ b/tests/dlevel1.example.alpino
@@ -1,0 +1,122 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" cat="np" end="2" id="2" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="vergadering" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vergadering" sense="vergadering" special="tmp" word="vergadering"/>
+        </node>
+        <node begin="2" end="3" frame="verb(hebben,past(sg),aux(inf))" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="zullen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zal" sc="aux(inf)" sense="zal" stype="declarative" tense="past" word="zou" wvorm="pv"/>
+        <node begin="0" cat="inf" end="8" id="6" rel="vc">
+          <node begin="0" end="2" id="7" index="1" rel="su"/>
+          <node begin="6" buiging="zonder" end="7" frame="verb(unacc,inf,passive)" his="normal" his_1="normal" id="8" infl="inf" lcat="inf" lemma="worden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="word" sc="passive" sense="word" word="worden" wvorm="inf"/>
+          <node begin="0" cat="ppart" end="8" id="9" rel="vc">
+            <node begin="0" end="2" id="10" index="1" rel="obj1"/>
+            <node begin="3" cat="ap" end="6" id="11" rel="mod">
+              <node begin="3" cat="np" end="5" id="12" rel="me">
+                <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="13" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="4" end="5" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="week" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="week" sense="week" special="tmp" word="week"/>
+              </node>
+              <node aform="compar" begin="5" buiging="zonder" end="6" frame="adjective(er(tmpadv))" graad="comp" his="normal" his_1="normal" id="15" infl="no_e" lcat="ap" lemma="laat" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="hd" root="laat" sense="laat" vform="adj" word="later"/>
+            </node>
+            <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="16" infl="psp" lcat="ppart" lemma="houden" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="houd" sc="transitive" sense="houd" word="gehouden" wvorm="vd"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De vergadering zou een week later worden gehouden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Ella" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Ella" sense="Ella" word="Ella"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="past" word="had" wvorm="pv"/>
+        <node begin="0" cat="inf" end="10" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="np" end="5" id="6" rel="mod">
+            <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="heel" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="heel" sense="heel" vform="adj" word="hele"/>
+            <node begin="4" end="5" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="avond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="avond" sense="avond" special="tmp" word="avond"/>
+          </node>
+          <node begin="5" cat="pp" end="7" id="10" rel="mod">
+            <node begin="5" end="6" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="11" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="bij"/>
+            <node begin="6" case="dat_acc" def="def" end="7" frame="pronoun(nwh,fir,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="ons" naamval="obl" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,mv)" pt="vnw" rel="obj1" rnum="pl" root="ons" sense="ons" status="vol" vwtype="pr" wh="nwh" word="ons"/>
+          </node>
+          <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf,subj_control(wk_te))" his="normal" his_1="normal" id="13" infl="inf" lcat="inf" lemma="zitten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="zit" sc="subj_control(wk_te)" sense="zit" word="zitten" wvorm="inf"/>
+          <node begin="0" cat="inf" end="10" id="14" rel="vc">
+            <node begin="0" end="1" id="15" index="1" rel="su"/>
+            <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="16" infl="no_e" lcat="ap" lemma="gezellig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="gezellig" sense="gezellig" vform="adj" word="gezellig"/>
+            <node begin="9" buiging="zonder" end="10" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="17" infl="inf" lcat="inf" lemma="babbelen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="babbel" sc="intransitive" sense="babbel" word="babbelen" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ella had de hele avond bij ons gezellig zitten babbelen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" index="1" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,aux(te))" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="schijnen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="schijn" sc="aux(te)" sense="schijn" stype="declarative" tense="present" word="schijnt" wvorm="pv"/>
+        <node begin="0" cat="ti" end="5" id="4" rel="vc">
+          <node begin="3" end="4" frame="complementizer(te)" his="normal" his_1="normal" id="5" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="0" cat="inf" end="5" id="6" rel="body">
+            <node begin="0" end="1" id="7" index="1" rel="su"/>
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="aardig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="aardig" sense="aardig" vform="adj" word="aardig"/>
+            <node begin="4" buiging="zonder" end="5" frame="verb(unacc,inf,copula)" his="normal" his_1="normal" id="9" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="copula" sense="ben" word="zijn" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan schijnt aardig te zijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="15" id="0" rel="top">
+      <node begin="0" cat="du" end="14" id="1" rel="--">
+        <node begin="0" cat="smain" end="9" id="2" rel="dp">
+          <node begin="0" cat="np" end="2" id="3" index="1" rel="su">
+            <node begin="0" buiging="zonder" end="1" frame="determiner(pron)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="Mijn"/>
+            <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="moeder" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="moeder" sense="moeder" word="moeder"/>
+          </node>
+          <node begin="2" end="3" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="6" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heeft" wvorm="pv"/>
+          <node begin="0" cat="ppart" end="9" id="7" rel="vc">
+            <node begin="0" end="2" id="8" index="1" rel="su"/>
+            <node begin="3" end="4" frame="tmp_adverb" his="normal" his_1="normal" id="9" lcat="advp" lemma="gisteren" pos="adv" postag="BW()" pt="bw" rel="mod" root="gisteren" sense="gisteren" special="tmp" word="gisteren"/>
+            <node begin="4" cat="pp" end="7" id="10" rel="mod">
+              <node begin="4" end="5" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="11" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+              <node begin="5" cat="np" end="7" id="12" rel="obj1">
+                <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="13" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="markt" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="markt" sense="markt" word="markt"/>
+              </node>
+            </node>
+            <node begin="7" end="8" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="appel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="appel" sense="appel" word="appels"/>
+            <node begin="8" buiging="zonder" end="9" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="16" infl="psp" lcat="ppart" lemma="kopen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="koop" sc="transitive" sense="koop" word="gekocht" wvorm="vd"/>
+          </node>
+        </node>
+        <node begin="9" cat="smain" end="14" id="17" rel="dp">
+          <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="18" index="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="10" end="11" frame="verb(unacc,sg1,aux_psp_zijn)" his="normal" his_1="normal" id="19" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+          <node begin="9" cat="inf" end="14" id="20" rel="vc">
+            <node begin="9" end="10" id="21" index="2" rel="su"/>
+            <node begin="12" buiging="zonder" end="13" frame="verb(zijn,inf(no_e),aux(inf))" his="normal" his_1="normal" id="22" infl="inf(no_e)" lcat="inf" lemma="gaan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ga" sc="aux(inf)" sense="ga" word="gaan" wvorm="inf"/>
+            <node begin="9" cat="inf" end="14" id="23" rel="vc">
+              <node begin="9" end="10" id="24" index="2" rel="su"/>
+              <node begin="11" end="12" frame="adverb" his="normal" his_1="normal" id="25" lcat="advp" lemma="maar" pos="adv" postag="BW()" pt="bw" rel="mod" root="maar" sense="maar" word="maar"/>
+              <node begin="13" buiging="zonder" end="14" frame="verb('hebben/zijn',inf,intransitive)" his="normal" his_1="normal" id="26" infl="inf" lcat="inf" lemma="lopen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="loop" sc="intransitive" sense="loop" word="lopen" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="14" end="15" frame="punct(punt)" his="robust_skip" id="27" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Mijn moeder heeft gisteren op de markt appels gekocht Ik ben maar gaan lopen .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/dlevel1.example.ok
+++ b/tests/dlevel1.example.ok
@@ -2614,26 +2614,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.3.s.1.w.11.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ben</t>
-                <feat class="[zijn]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zijn</t>
-                  <feat class="[zijn]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(tijdww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.999628"/>
           <metric class="prevalenceZ" value="3.37248"/>

--- a/tests/dlevel2.example.alpino
+++ b/tests/dlevel2.example.alpino
@@ -1,0 +1,318 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="conj" end="11" id="1" rel="--">
+        <node begin="0" cat="smain" end="6" id="2" rel="cnj">
+          <node begin="0" cat="np" end="2" id="3" index="1" rel="su">
+            <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+            <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="jongen" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="jongen" sense="jongen" word="jongen"/>
+          </node>
+          <node begin="2" end="3" frame="verb(hebben,past(sg),part_transitive(op))" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="op_lopen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="loop_op" sc="part_transitive(op)" sense="loop_op" tense="past" word="liep" wvorm="pv"/>
+          <node begin="3" cat="np" end="5" id="7" rel="obj1">
+            <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="trap" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="trap" sense="trap" word="trap"/>
+          </node>
+          <node begin="5" end="6" frame="particle(op)" his="normal" his_1="normal" id="10" lcat="part" lemma="op" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="op" sense="op" vztype="fin" word="op"/>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="11" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="11" id="12" rel="cnj">
+          <node begin="0" end="2" id="13" index="1" rel="su"/>
+          <node begin="7" end="8" frame="verb(zijn,past(sg),part_ld_transitive(in))" his="normal" his_1="normal" id="14" infl="sg" lcat="smain" lemma="in_gaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ga_in" sc="part_ld_transitive(in)" sense="ga_in" tense="past" word="ging" wvorm="pv"/>
+          <node begin="8" cat="np" end="10" id="15" rel="ld">
+            <node begin="8" buiging="zonder" end="9" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="16" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="kamer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kamer" sense="kamer" word="kamer"/>
+          </node>
+          <node begin="10" end="11" frame="particle(in)" his="normal" his_1="normal" id="18" lcat="part" lemma="in" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="in" sense="in" vztype="fin" word="in"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De jongen liep de trap op en ging zijn kamer in .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="conj" end="8" id="1" rel="--">
+        <node begin="0" cat="smain" end="4" id="2" rel="cnj">
+          <node begin="0" cat="np" end="2" id="3" index="1" rel="su">
+            <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+            <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="5" lcat="np" lemma="meisje" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="meisje" sense="meisje" word="meisje"/>
+          </node>
+          <node begin="2" end="3" frame="verb(hebben,sg,copula)" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="heten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heet" sc="copula" sense="heet" tense="present" word="heet" wvorm="pv"/>
+          <node begin="3" end="4" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="w_dia" id="7" lcat="np" lemma="Aisha" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="Aisha" sense="Aisha" word="Aïsha"/>
+        </node>
+        <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="8" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="8" id="9" rel="cnj">
+          <node begin="0" end="2" id="10" index="1" rel="su"/>
+          <node begin="5" end="6" frame="verb(unacc,sg3,ld_pp)" his="normal" his_1="normal" id="11" infl="sg3" lcat="smain" lemma="komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom" sc="ld_pp" sense="kom" tense="present" word="komt" wvorm="pv"/>
+          <node begin="6" cat="pp" end="8" id="12" rel="ld">
+            <node begin="6" end="7" frame="preposition(uit,[vandaan])" his="normal" his_1="normal" id="13" lcat="pp" lemma="uit" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="uit" sense="uit" vztype="init" word="uit"/>
+            <node begin="7" end="8" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="14" lcat="np" lemma="Rotterdam" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Rotterdam" sense="Rotterdam" word="Rotterdam"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het meisje heet Aïsha en komt uit Rotterdam .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="7" id="2" rel="--">
+        <node begin="0" cat="smain" end="2" id="3" rel="dp">
+          <node begin="0" end="1" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="Het"/>
+          <node begin="1" end="2" frame="verb(hebben,sg3,het_subj)" his="normal" his_1="normal" id="5" infl="sg3" lcat="smain" lemma="regenen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="regen" sc="het_subj" sense="het-regen" stype="declarative" tense="present" word="regent" wvorm="pv"/>
+        </node>
+        <node begin="3" cat="smain" end="7" id="6" rel="dp">
+          <node begin="3" cat="np" end="5" id="7" rel="su">
+            <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="straat" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="straat" sense="straat" word="straten"/>
+          </node>
+          <node begin="5" end="6" frame="verb(unacc,pl,copula)" his="normal" his_1="normal" id="10" infl="pl" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" stype="declarative" tense="present" word="worden" wvorm="pv"/>
+          <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="nat" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="nat" sense="nat" vform="adj" word="nat"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het regent , de straten worden nat .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="18" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="17" id="2" rel="--">
+        <node begin="0" cat="smain" end="6" id="3" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,pc_pp(van))" his="normal" his_1="normal" id="5" infl="sg1" lcat="smain" lemma="houden" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="houd" sc="pc_pp(van)" sense="houd-van" stype="declarative" tense="present" word="houd" wvorm="pv"/>
+          <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+          <node begin="3" cat="pp" end="6" id="7" rel="pc">
+            <node begin="3" end="4" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="4" cat="mwu" end="6" his="normal" his_1="names_dictionary" id="9" rel="obj1">
+              <node begin="4" end="5" frame="proper_name(sg,'PER')" id="10" lcat="np" lemma="Koos" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Koos" sense="Koos" spectype="deeleigen" word="Koos"/>
+              <node begin="5" end="6" frame="proper_name(sg,'PER')" id="11" lcat="np" lemma="Alberts" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Alberts" sense="Alberts" spectype="deeleigen" word="Alberts"/>
+            </node>
+          </node>
+        </node>
+        <node begin="7" conjtype="neven" end="8" frame="conj(maar)" his="normal" his_1="normal" id="12" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+        <node begin="8" cat="smain" end="17" id="13" rel="cnj">
+          <node begin="8" case="nom" def="def" end="9" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="14" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="9" end="10" frame="verb(unacc,sg1,copula)" his="normal" his_1="normal" id="15" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+          <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="sowieso" pos="adv" postag="BW()" pt="bw" rel="mod" root="sowieso" sense="sowieso" word="sowieso"/>
+          <node begin="11" cat="np" end="17" id="17" rel="predc">
+            <node begin="11" buiging="zonder" end="12" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" his="normal" his_1="normal" id="18" infl="geen" lcat="detp" lemma="geen" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,zonder,agr)" pt="vnw" rel="det" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+            <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="liefhebber" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="liefhebber" sense="liefhebber" word="liefhebber"/>
+            <node begin="13" cat="pp" end="17" id="20" rel="mod">
+              <node begin="13" end="14" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="21" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+              <node begin="14" cat="np" end="17" id="22" rel="obj1">
+                <node begin="14" end="15" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="23" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                <node aform="base" begin="15" buiging="met-e" end="16" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="24" infl="e" lcat="ap" lemma="Nederlands" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="Nederlands" sense="Nederlands" vform="adj" word="Nederlandse"/>
+                <node begin="16" end="17" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="lied" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="lied" sense="lied" word="lied"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="17" end="18" frame="punct(punt)" his="normal" his_1="normal" id="26" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik houd niet van Koos Alberts , maar ik ben sowieso geen liefhebber van het Nederlandse lied .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="16" id="0" rel="top">
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="15" id="2" rel="--">
+        <node begin="2" end="3" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+        <node begin="4" cat="np" end="7" id="4" index="1" rel="su">
+          <node begin="4" cat="detp" end="6" id="5" rel="det">
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="ruim" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="ruim" sense="ruim" vform="adj" word="ruim"/>
+            <node begin="5" end="6" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="7" infl="pl_num" lcat="detp" lemma="vijftig" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="hd" root="vijftig" sense="vijftig" word="vijftig"/>
+          </node>
+          <node begin="6" end="7" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="hunebed" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hunebed" sense="hunebed" word="hunebedden"/>
+        </node>
+        <node begin="0" cat="ppart" end="15" id="9" rel="vc">
+          <node begin="0" cat="pp" end="2" id="10" rel="mod">
+            <node begin="0" end="1" frame="preposition(in,[])" his="normal" his_1="decap" his_1_1="normal" id="11" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="In"/>
+            <node begin="1" end="2" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="12" lcat="np" lemma="Drenthe" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Drenthe" sense="Drenthe" word="Drenthe"/>
+          </node>
+          <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+          <node begin="4" end="7" id="14" index="1" rel="su"/>
+          <node begin="8" buiging="zonder" end="9" frame="verb(unacc,psp,copula)" his="normal" his_1="normal" id="15" infl="psp" lcat="ppart" lemma="blijven" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="blijf" sc="copula" sense="blijf" word="gebleven" wvorm="vd"/>
+          <node begin="7" cat="conj" end="13" id="16" rel="predc">
+            <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(ge_no_e(adv))" his="normal" his_1="normal" id="17" infl="no_e" lcat="ppart" lemma="bewaren" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="cnj" root="bewaren" sense="bewaren" vform="psp" word="bewaard" wvorm="vd"/>
+            <node begin="10" conjtype="neven" end="11" frame="conj(en)" his="normal" his_1="normal" id="18" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="11" cat="np" end="13" id="19" rel="cnj">
+              <node begin="11" end="12" frame="adverb" his="normal" his_1="normal" id="20" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+              <node begin="12" end="13" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="21" infl="pl_num" lcat="np" lemma="twee" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="hd" root="twee" sense="twee" word="twee"/>
+            </node>
+          </node>
+          <node begin="13" cat="pp" end="15" id="22" rel="mod">
+            <node begin="13" end="14" frame="preposition(in,[])" his="normal" his_1="normal" id="23" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+            <node begin="14" end="15" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="24" lcat="np" lemma="Groningen" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Groningen" sense="Groningen" word="Groningen"/>
+          </node>
+        </node>
+      </node>
+      <node begin="15" end="16" frame="punct(punt)" his="normal" his_1="normal" id="25" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">In Drenthe zijn nog ruim vijftig hunebedden bewaard gebleven , en nog twee in Groningen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="2" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Karel" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Karel" sense="Karel" word="Karel"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),np_pc_pp(aan))" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="hechten" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="hecht" sc="np_pc_pp(aan)" sense="hecht-aan" stype="declarative" tense="past" word="hechtte" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="5" rel="obj1">
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="groot" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="groot"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="belang" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="belang" sense="belang" word="belang"/>
+        </node>
+        <node begin="4" cat="pp" end="10" id="8" rel="pc">
+          <node begin="4" end="5" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="9" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+          <node begin="5" cat="conj" end="10" id="10" rel="obj1">
+            <node begin="5" end="6" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="onderwijs" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="onderwijs" sense="onderwijs" word="onderwijs"/>
+            <node begin="7" end="8" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="cultuur" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="cultuur" sense="cultuur" word="cultuur"/>
+            <node begin="8" conjtype="neven" end="9" frame="conj(en)" his="normal" his_1="normal" id="13" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="wetenschap" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="wetenschap" sense="wetenschap" word="wetenschap"/>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Karel hechtte groot belang aan onderwijs , cultuur en wetenschap .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="15" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="14" id="2" rel="--">
+        <node begin="0" cat="smain" end="12" id="3" rel="cnj">
+          <node begin="0" cat="cp" end="7" id="4" rel="mod">
+            <node begin="0" end="1" frame="complementizer(inf)" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="cp" lemma="na" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="na" sc="inf" sense="na" vztype="init" word="Na"/>
+            <node begin="1" cat="ti" end="7" id="6" rel="body">
+              <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="7" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+              <node begin="1" cat="inf" end="7" id="8" rel="body">
+                <node begin="5" buiging="zonder" end="6" frame="verb(unacc,inf,aux_psp_zijn)" his="normal" his_1="normal" id="9" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" word="zijn" wvorm="inf"/>
+                <node begin="1" cat="ppart" end="7" id="10" rel="vc">
+                  <node begin="1" cat="pp" end="4" id="11" rel="ld">
+                    <node begin="1" end="2" frame="preposition(over,[heen])" his="normal" his_1="normal" id="12" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sense="over" vztype="init" word="over"/>
+                    <node begin="2" cat="np" end="4" id="13" rel="obj1">
+                      <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                      <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="muur" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="muur" sense="muur" word="muur"/>
+                    </node>
+                  </node>
+                  <node begin="6" buiging="zonder" end="7" frame="verb('hebben/zijn',psp,ld_pp)" his="normal" his_1="normal" id="16" infl="psp" lcat="ppart" lemma="springen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="spring" sc="ld_pp" sense="spring" word="gesprongen" wvorm="vd"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="8" end="9" frame="verb(unacc,past(sg),ld_pp)" his="normal" his_1="normal" id="17" infl="sg" lcat="smain" lemma="raken" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="raak" sc="ld_pp" sense="raak" stype="declarative" tense="past" word="raakte" wvorm="pv"/>
+          <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="18" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node begin="10" cat="pp" end="12" id="19" rel="ld">
+            <node begin="10" end="11" frame="preposition(uit,[vandaan])" his="normal" his_1="normal" id="20" lcat="pp" lemma="uit" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="uit" sense="uit" vztype="init" word="uit"/>
+            <node begin="11" end="12" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="balans" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="balans" sense="balans" word="balans"/>
+          </node>
+        </node>
+        <node begin="12" conjtype="neven" end="13" frame="conj(en)" his="normal" his_1="normal" id="22" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="9" cat="smain" end="14" id="23" rel="cnj">
+          <node begin="9" end="10" id="24" index="1" rel="su"/>
+          <node begin="13" end="14" frame="verb(unacc,past(sg),intransitive)" his="normal" his_1="normal" id="25" infl="sg" lcat="smain" lemma="vallen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="val" sc="intransitive" sense="val" tense="past" word="viel" wvorm="pv"/>
+        </node>
+      </node>
+      <node begin="14" end="15" frame="punct(punt)" his="normal" his_1="normal" id="26" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Na over de muur te zijn gesprongen , raakte hij uit balans en viel .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="16" id="2" rel="--">
+        <node begin="0" cat="pp" end="3" id="3" rel="mod">
+          <node begin="0" end="1" frame="preposition(onder,[door,vandaan])" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="pp" lemma="onder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="onder" sense="onder" vztype="init" word="Onder"/>
+          <node begin="1" cat="np" end="3" id="5" rel="obj1">
+            <node begin="1" end="2" frame="determiner(de)" his="normal" his_1="normal" id="6" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="2" end="3" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="gast" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="gast" sense="gast" word="gasten"/>
+          </node>
+        </node>
+        <node begin="3" end="4" frame="verb(hebben,past(pl),transitive_ndev_ndev)" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" stype="declarative" tense="past" word="zagen" wvorm="pv"/>
+        <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="9" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+        <node begin="5" cat="conj" end="16" id="10" rel="obj1">
+          <node begin="5" cat="np" end="7" id="11" rel="cnj">
+            <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="mevrouw" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="mevrouw" sense="mevrouw" word="mevrouw"/>
+            <node begin="6" end="7" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="13" lcat="np" lemma="Bruinsma" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="Bruinsma" sense="Bruinsma" word="Bruinsma"/>
+          </node>
+          <node begin="8" cat="np" end="13" id="14" rel="cnj">
+            <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="15" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="moeder" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="moeder" sense="moeder" word="moeder"/>
+            <node begin="10" cat="pp" end="13" id="17" rel="mod">
+              <node begin="10" end="11" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="18" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+              <node begin="11" cat="np" end="13" id="19" rel="obj1">
+                <node begin="11" end="12" frame="determiner(de)" his="normal" his_1="normal" id="20" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="12" end="13" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="21" lcat="np" lemma="jubilaris" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="jubilaris" sense="jubilaris" word="jubilaris"/>
+              </node>
+            </node>
+          </node>
+          <node begin="13" conjtype="neven" end="14" frame="conj(en)" his="normal" his_1="normal" id="22" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="14" cat="np" end="16" id="23" rel="cnj">
+            <node begin="14" end="15" frame="determiner(de)" his="normal" his_1="normal" id="24" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="15" end="16" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="burgemeester" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="burgemeester" sense="burgemeester" word="burgemeester"/>
+          </node>
+        </node>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="26" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Onder de gasten zagen we mevrouw Bruinsma , de moeder van de jubilaris en de burgemeester .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="3" skips="2"/>
+    <node begin="0" cat="top" end="21" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="15" end="16" frame="complementizer(om)" his="robust_skip" id="2" lcat="--" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="--" root="om" sc="om" sense="om" vztype="init" word="om"/>
+      <node begin="17" end="18" frame="particle(in)" his="robust_skip" id="3" lcat="--" lemma="in" pos="part" postag="VZ(init)" pt="vz" rel="--" root="in" sense="in" vztype="init" word="in"/>
+      <node begin="0" cat="du" end="20" id="4" rel="--">
+        <node begin="0" cat="conj" end="15" id="5" rel="dp">
+          <node begin="0" cat="smain" end="5" id="6" rel="cnj">
+            <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,both,de,nom,def)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="7" index="1" lcat="np" lemma="zij" naamval="nomin" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,vol,3p,mv)" pt="vnw" rel="su" rnum="pl" root="zij" sense="zij" status="vol" vwtype="pers" wh="nwh" word="Zij"/>
+            <node begin="1" end="2" frame="verb(hebben,past(pl),ld_pp)" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="wonen" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="woon" sc="ld_pp" sense="woon" tense="past" word="woonden" wvorm="pv"/>
+            <node begin="2" cat="pp" end="5" id="9" rel="ld">
+              <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="10" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="3" cat="np" end="5" id="11" rel="obj1">
+                <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(both(nonadv))" graad="basis" his="normal" his_1="normal" id="12" infl="both" lcat="ap" lemma="lemen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="lemen" sense="lemen" vform="adj" word="lemen"/>
+                <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="boerderij" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="boerderij" sense="boerderij" word="boerderijen"/>
+              </node>
+            </node>
+          </node>
+          <node begin="0" cat="smain" end="11" id="14" rel="cnj">
+            <node begin="0" end="1" id="15" index="1" rel="su"/>
+            <node begin="6" end="7" frame="verb(hebben,past(pl),transitive)" his="normal" his_1="normal" id="16" infl="pl" lcat="smain" lemma="hanteren" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="hanteer" sc="transitive" sense="hanteer" tense="past" word="hanteerden" wvorm="pv"/>
+            <node begin="7" cat="np" end="11" id="17" rel="obj1">
+              <node begin="7" cat="conj" end="10" id="18" rel="mod">
+                <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(stof)" graad="basis" his="normal" his_1="normal" id="19" infl="stof" lcat="ap" lemma="houten" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="cnj" root="houten" sense="houten" vform="adj" word="houten"/>
+                <node begin="8" conjtype="neven" end="9" frame="conj(en)" his="normal" his_1="normal" id="20" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(stof)" graad="basis" his="normal" his_1="normal" id="21" infl="stof" lcat="ap" lemma="stenen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="cnj" root="stenen" sense="stenen" vform="adj" word="stenen"/>
+              </node>
+              <node begin="10" end="11" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="werktuig" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="werktuig" sense="werktuig" word="werktuigen"/>
+            </node>
+          </node>
+          <node begin="11" conjtype="neven" end="12" frame="conj(en)" his="normal" his_1="normal" id="23" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="0" cat="smain" end="15" id="24" rel="cnj">
+            <node begin="0" end="1" id="25" index="1" rel="su"/>
+            <node begin="12" end="13" frame="verb(hebben,past(pl),transitive)" his="normal" his_1="normal" id="26" infl="pl" lcat="smain" lemma="maken" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="maak" sc="transitive" sense="maak" tense="past" word="maakten" wvorm="pv"/>
+            <node begin="13" end="14" frame="sentence_adverb" his="normal" his_1="normal" id="27" lcat="advp" lemma="dus" pos="adv" postag="BW()" pt="bw" rel="mod" root="dus" sense="dus" special="sentence" word="dus"/>
+            <node begin="14" end="15" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="pot" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="pot" sense="pot" special="tmp" word="potten"/>
+          </node>
+        </node>
+        <node begin="16" end="17" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="29" lcat="np" lemma="voorraad" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="dp" rnum="pl" root="voorraad" sense="voorraad" word="voorraden"/>
+        <node begin="18" cat="ti" end="20" id="30" rel="dp">
+          <node begin="18" end="19" frame="complementizer(te)" his="normal" his_1="normal" id="31" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="19" buiging="zonder" end="20" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="32" infl="inf" lcat="inf" lemma="bewaren" pos="verb" positie="prenom" postag="WW(inf,prenom,zonder)" pt="ww" rel="body" root="bewaar" sc="transitive" sense="bewaar" word="bewaren" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="20" end="21" frame="punct(punt)" his="robust_skip" id="33" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zij woonden in lemen boerderijen , hanteerden houten en stenen werktuigen en maakten dus potten om voorraden in te bewaren .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/dlevel2.example.ok
+++ b/tests/dlevel2.example.ok
@@ -3243,26 +3243,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.3.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>houd</t>
-                <feat class="[houd]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>houd</t>
-                  <feat class="[houd]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -3501,26 +3481,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.3.s.1.w.10.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ben</t>
-                <feat class="[zijn]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zijn</t>
-                  <feat class="[zijn]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(koppelww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.999628"/>
           <metric class="prevalenceZ" value="3.37248"/>
@@ -6191,26 +6151,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.6.s.1.w.3.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heet</t>
-                <feat class="[heet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heet</t>
-                  <feat class="[heet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.6.s.1.w.3.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>heet</t>

--- a/tests/dlevel3.example.alpino
+++ b/tests/dlevel3.example.alpino
@@ -1,0 +1,144 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="9" id="2" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Carola" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Carola" sense="Carola" word="Carola"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),tr_sbar)" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="vinden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="vind" sc="tr_sbar" sense="vind" stype="declarative" tense="past" word="vond" wvorm="pv"/>
+        <node begin="3" cat="cp" end="9" id="5" rel="vc">
+          <node begin="3" conjtype="onder" end="4" frame="complementizer(dat)" his="normal" his_1="normal" id="6" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="4" cat="ssub" end="9" id="7" rel="body">
+            <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="8" lcat="np" lemma="Artur" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Artur" sense="Artur" word="Artur"/>
+            <node aform="base" begin="5" end="6" frame="adjective(pred(adv))" his="normal" his_1="normal" id="9" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+            <node begin="6" cat="ap" end="8" id="10" rel="predc">
+              <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="erg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="erg" sense="erg" vform="adj" word="erg"/>
+              <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="12" infl="no_e" lcat="ap" lemma="raar" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="raar" sense="raar" vform="adj" word="raar"/>
+            </node>
+            <node begin="8" end="9" frame="verb(hebben,past(sg),nonp_copula)" his="normal" his_1="normal" id="13" infl="sg" lcat="ssub" lemma="doen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="doe" sc="nonp_copula" sense="doe" tense="past" word="deed" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Carola vond , dat Artur wel erg raar deed .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="0" cat="smain" end="16" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),subj_control(te_inf))" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="leren" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="leer" sc="subj_control(te_inf)" sense="leer" stype="declarative" tense="past" word="leerde" wvorm="pv"/>
+        <node begin="2" end="3" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="4" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+        <node begin="0" cat="inf" end="16" id="5" rel="vc">
+          <node begin="0" end="1" id="6" index="1" rel="su"/>
+          <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="7" infl="inf" lcat="inf" lemma="kennen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ken" sc="transitive" sense="ken" word="kennen" wvorm="inf"/>
+          <node begin="3" cat="np" end="16" id="8" rel="obj1">
+            <node begin="3" end="4" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="jongen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="jongen" sense="jongen" word="jongens"/>
+            <node begin="5" cat="rel" end="16" id="10" rel="mod">
+              <node begin="5" case="no_obl" end="6" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="11" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="5" cat="ssub" end="16" id="12" rel="body">
+                <node begin="5" end="6" id="13" index="2" rel="su"/>
+                <node begin="7" end="8" frame="verb(unacc,past(pl),copula)" his="normal" his_1="normal" id="14" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" tense="past" word="waren" wvorm="pv"/>
+                <node begin="6" cat="ap" end="16" id="15" rel="predc">
+                  <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv),pp(op))" graad="basis" his="normal" his_1="normal" id="16" infl="no_e" lcat="ap" lemma="dol" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="dol" sc="pp(op)" sense="dol-op" vform="adj" word="dol"/>
+                  <node begin="8" cat="pp" end="16" id="17" rel="pc">
+                    <node begin="8" end="9" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="18" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                    <node begin="9" cat="conj" end="16" id="19" rel="obj1">
+                      <node begin="11" conjtype="neven" end="12" frame="conj(en)" his="normal" his_1="normal" id="20" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                      <node begin="9" cat="np" end="16" id="21" rel="cnj">
+                        <node begin="9" end="10" frame="determiner(een)" his="normal" his_1="normal" id="22" index="3" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                        <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="23" lcat="np" lemma="bier" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="bier_DIM" sense="bier_DIM" word="biertje"/>
+                        <node begin="13" cat="pp" end="16" id="24" index="4" rel="mod">
+                          <node begin="13" end="14" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="25" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+                          <node begin="14" cat="np" end="16" id="26" rel="obj1">
+                            <node aform="base" begin="14" buiging="met-e" end="15" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="27" infl="e" lcat="ap" lemma="blond" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="blond" sense="blond" vform="adj" word="blonde"/>
+                            <node begin="15" end="16" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="haar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="haar" sense="haar" word="haren"/>
+                          </node>
+                        </node>
+                      </node>
+                      <node begin="9" cat="np" end="16" id="29" rel="cnj">
+                        <node begin="9" end="10" id="30" index="3" rel="det"/>
+                        <node begin="12" end="13" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="31" lcat="np" lemma="meisje" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="meisje" sense="meisje" word="meisjes"/>
+                        <node begin="13" end="16" id="32" index="4" rel="mod"/>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="33" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij leerde er jongens kennen die dol waren op een biertje en meisjes met blonde haren .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,sbar)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="geloven" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="geloof" sc="sbar" sense="geloof" stype="declarative" tense="present" word="geloof" wvorm="pv"/>
+        <node begin="2" cat="cp" end="8" id="4" rel="vc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="5" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="3" cat="ssub" end="8" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+            <node begin="4" cat="ap" end="7" id="8" rel="predc">
+              <node begin="4" cat="np" end="6" id="9" rel="obj1">
+                <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="5" end="6" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="weg" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="weg" sense="weg" special="tmp" word="weg"/>
+              </node>
+              <node begin="6" buiging="zonder" end="7" frame="np_adjective" graad="basis" his="normal" his_1="normal" id="12" lcat="ap" lemma="kwijt" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="kwijt" sense="kwijt" special="np" word="kwijt"/>
+            </node>
+            <node begin="7" end="8" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="13" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik geloof dat hij de weg kwijt is .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg,tr_sbar)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="verwachten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="verwacht" sc="tr_sbar" sense="verwacht" stype="declarative" tense="present" word="verwacht" wvorm="pv"/>
+        <node begin="2" cat="cp" end="6" id="4" rel="vc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="5" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="3" cat="ssub" end="6" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+            <node begin="4" end="5" frame="adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="5" end="6" frame="verb(unacc,sg3,intransitive)" his="normal" his_1="normal" id="9" infl="sg3" lcat="ssub" lemma="komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom" sc="intransitive" sense="kom" tense="present" word="komt" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik verwacht dat hij niet komt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),sbar)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="vertellen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="vertel" sc="sbar" sense="vertel" stype="declarative" tense="past" word="vertelde" wvorm="pv"/>
+        <node begin="2" cat="cp" end="6" id="4" rel="vc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="5" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="3" cat="ssub" end="6" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+            <node begin="3" cat="ppart" end="5" id="8" rel="vc">
+              <node begin="3" end="4" id="9" index="1" rel="obj1"/>
+              <node begin="4" buiging="zonder" end="5" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="10" infl="psp" lcat="ppart" lemma="verhinderen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="verhinder" sc="transitive" sense="verhinder" word="verhinderd" wvorm="vd"/>
+            </node>
+            <node begin="5" end="6" frame="verb(unacc,past(sg),passive)" his="normal" his_1="normal" id="11" infl="sg" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="passive" sense="ben" tense="past" word="was" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan vertelde dat hij verhinderd was .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/dlevel3.example.ok
+++ b/tests/dlevel3.example.ok
@@ -3784,26 +3784,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.3.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>geloof</t>
-                <feat class="[geloof]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>geloof</t>
-                  <feat class="[geloof]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/dlevel4.example.alpino
+++ b/tests/dlevel4.example.alpino
@@ -1,0 +1,424 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="26" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="15" end="16" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="19" end="20" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="25" id="4" rel="--">
+        <node begin="0" cat="cp" end="19" id="5" rel="su">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(dat)" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="Dat"/>
+          <node begin="1" cat="ssub" end="19" id="7" rel="body">
+            <node begin="1" cat="np" end="15" id="8" rel="su">
+              <node begin="1" end="2" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="republikein" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="republikein" sense="republikein" word="republikein"/>
+              <node begin="4" cat="rel" end="15" id="11" rel="mod">
+                <node begin="4" case="no_obl" end="5" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="12" index="1" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+                <node begin="4" cat="ssub" end="15" id="13" rel="body">
+                  <node begin="4" end="5" id="14" index="1" rel="su"/>
+                  <node begin="7" cat="np" end="10" id="15" index="2" rel="obj1">
+                    <node begin="7" end="8" frame="determiner(een)" his="normal" his_1="normal" id="16" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                    <node aform="compar" begin="8" buiging="met-e" end="9" frame="adjective(ere)" graad="basis" his="normal" his_1="normal" id="17" infl="e" lcat="ap" lemma="ander" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="ander" sense="ander" vform="adj" word="andere"/>
+                    <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="vrouw" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vrouw" sense="vrouw" word="vrouw"/>
+                  </node>
+                  <node begin="13" end="14" frame="verb(hebben,past(sg),aci_simple)" his="normal" his_1="normal" id="19" infl="sg" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="heb" sc="aci_simple" sense="heb" tense="past" word="had" wvorm="pv"/>
+                  <node begin="5" cat="inf" end="15" id="20" rel="vc">
+                    <node begin="5" cat="np" end="7" id="21" rel="mod">
+                      <node begin="5" buiging="met-e" end="6" frame="determiner(elke,nwh,mod)" his="normal" his_1="normal" id="22" infl="elke" lcat="detp" lemma="elk" naamval="stan" npagr="evz" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,met-e,evz)" pt="vnw" rel="det" root="elk" sense="elk" vwtype="onbep" wh="nwh" word="elke"/>
+                      <node begin="6" end="7" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="23" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+                    </node>
+                    <node begin="7" end="10" id="24" index="2" rel="su"/>
+                    <node begin="10" cat="pp" end="13" id="25" rel="ld">
+                      <node begin="10" end="11" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="26" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+                      <node begin="11" cat="np" end="13" id="27" rel="obj1">
+                        <node begin="11" buiging="zonder" end="12" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="28" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+                        <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="29" lcat="np" lemma="arm" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="arm" sense="arm" word="arm"/>
+                      </node>
+                    </node>
+                    <node begin="14" buiging="zonder" end="15" frame="verb(hebben,inf,ld_pp)" his="normal" his_1="normal" id="30" infl="inf" lcat="inf" lemma="hangen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="hang" sc="ld_pp" sense="hang" word="hangen" wvorm="inf"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node begin="16" cat="np" end="18" id="31" rel="obj1">
+              <node begin="16" end="17" frame="determiner(de)" his="normal" his_1="normal" id="32" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="17" end="18" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="33" lcat="np" lemma="verkiezing" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="verkiezing" sense="verkiezing" word="verkiezingen"/>
+            </node>
+            <node begin="18" end="19" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="34" infl="sg" lcat="ssub" lemma="winnen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="win" sc="transitive" sense="win" tense="past" word="won" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="20" end="21" frame="verb(unacc,past(sg),copula_sbar)" his="normal" his_1="normal" id="35" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula_sbar" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node aform="base" begin="21" end="22" frame="adjective(pred(adv))" his="normal" his_1="normal" id="36" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+        <node begin="22" cat="np" end="25" id="37" rel="predc">
+          <node begin="22" end="23" frame="determiner(een)" his="normal" his_1="normal" id="38" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="23" buiging="met-e" end="24" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="39" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="grote"/>
+          <node begin="24" end="25" frame="noun(de,count,sg,subject_sbar)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="40" lcat="np" lemma="verrassing" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verrassing" sc="subject_sbar" sense="verrassing" word="verrassing"/>
+        </node>
+      </node>
+      <node begin="25" end="26" frame="punct(punt)" his="normal" his_1="normal" id="41" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat de republikein , die elke dag een andere vrouw aan zijn arm had hangen , de verkiezingen won , was wel een grote verrassing .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="30" id="0" rel="top">
+      <node begin="8" end="9" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="20" end="21" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="29" id="3" rel="--">
+        <node begin="0" cat="smain" end="8" id="4" rel="cnj">
+          <node begin="0" end="1" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" index="1" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="pl" root="het" sense="het" special="het" status="red" vwtype="pers" word="Het"/>
+          <node begin="1" end="2" frame="verb('hebben/zijn',pl,modifier(aux(inf)))" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="moeten" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" stype="declarative" tense="present" word="moeten" wvorm="pv"/>
+          <node begin="0" cat="inf" end="8" id="7" rel="vc">
+            <node begin="0" end="1" id="8" index="1" rel="su"/>
+            <node begin="6" buiging="zonder" end="7" frame="verb(unacc,inf,aux_psp_zijn)" his="normal" his_1="normal" id="9" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" word="zijn" wvorm="inf"/>
+            <node begin="0" cat="ppart" end="8" id="10" rel="vc">
+              <node begin="0" end="1" id="11" index="1" rel="su"/>
+              <node begin="2" end="3" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="12" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+              <node begin="3" end="4" frame="sentence_adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="echter" pos="adv" postag="BW()" pt="bw" rel="mod" root="echter" sense="echter" special="sentence" word="echter"/>
+              <node begin="4" cat="np" end="6" id="14" rel="predc">
+                <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(odet_adv))" graad="basis" his="normal" his_1="normal" id="15" infl="no_e" lcat="ap" lemma="veel" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,basis)" pt="vnw" rel="mod" root="veel" sense="veel" vform="adj" vwtype="onbep" word="veel"/>
+                <node aform="compar" begin="5" buiging="zonder" end="6" frame="adjective(meer)" graad="comp" his="normal" his_1="normal" id="16" infl="meer" lcat="np" lemma="veel" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="hd" rnum="sg" root="meer" sense="meer" vform="adj" vwtype="onbep" word="meer"/>
+              </node>
+              <node begin="7" buiging="zonder" end="8" frame="verb(unacc,psp,cleft)" his="normal" his_1="normal" id="17" infl="psp" lcat="ppart" lemma="zijn" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="cleft" sense="ben" word="geweest" wvorm="vd"/>
+            </node>
+          </node>
+        </node>
+        <node begin="9" conjtype="neven" end="10" frame="conj(want)" his="normal" his_1="normal" id="18" lcat="vg" lemma="want" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="want" sense="want" word="want"/>
+        <node begin="10" cat="smain" end="29" id="19" rel="cnj">
+          <node begin="15" end="16" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="20" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="16" cat="np" end="19" id="21" index="2" rel="su">
+            <node begin="16" cat="detp" end="18" his="normal" his_1="normal" id="22" rel="det">
+              <node begin="16" buiging="zonder" end="17" frame="intensifier" graad="basis" id="23" lcat="advp" lemma="heel" pos="adv" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="heel" sense="heel" special="intensifier" word="heel"/>
+              <node begin="17" end="18" frame="determiner(wat,nwh,mod,pro,nparg,ntopicpro)" getal="ev" id="24" infl="wat" lcat="detp" lemma="wat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="hd" root="wat" sense="wat" status="vol" vwtype="onbep" wh="nwh" word="wat"/>
+            </node>
+            <node begin="18" end="19" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="hunebed" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hunebed" sense="hunebed" word="hunebedden"/>
+          </node>
+          <node begin="10" cat="ppart" end="29" id="26" rel="vc">
+            <node begin="10" cat="pp" end="15" id="27" rel="mod">
+              <node begin="10" end="11" frame="preposition(in,[])" his="normal" his_1="normal" id="28" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="11" cat="np" end="15" id="29" rel="obj1">
+                <node begin="11" end="12" frame="determiner(de)" his="normal" his_1="normal" id="30" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="31" lcat="np" lemma="loop" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="loop" sense="loop" word="loop"/>
+                <node begin="13" cat="np" end="15" id="32" rel="mod">
+                  <node begin="13" end="14" frame="determiner(der)" his="normal" his_1="normal" id="33" infl="der" lcat="detp" lemma="de" lwtype="bep" naamval="gen" npagr="rest3" pos="det" postag="LID(bep,gen,rest3)" pt="lid" rel="det" root="de" sense="de" word="der"/>
+                  <node begin="14" end="15" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="34" lcat="np" lemma="eeuw" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="eeuw" sense="eeuw" special="tmp" word="eeuwen"/>
+                </node>
+              </node>
+            </node>
+            <node begin="16" end="19" id="35" index="2" rel="su"/>
+            <node begin="19" buiging="zonder" end="20" frame="verb(unacc,psp,intransitive)" his="normal" his_1="normal" id="36" infl="psp" lcat="ppart" lemma="verdwijnen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="verdwijn" sc="intransitive" sense="verdwijn" word="verdwenen" wvorm="vd"/>
+            <node begin="21" cat="cp" end="29" id="37" rel="mod">
+              <node begin="21" end="22" frame="modal_adverb" his="normal" his_1="normal" id="38" lcat="advp" lemma="bijvoorbeeld" pos="adv" postag="BW()" pt="bw" rel="mod" root="bijvoorbeeld" sc="modal" sense="bijvoorbeeld" word="bijvoorbeeld"/>
+              <node begin="22" conjtype="onder" end="23" frame="complementizer" his="normal" his_1="normal" id="39" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+              <node begin="23" cat="ssub" end="29" id="40" rel="body">
+                <node begin="23" cat="np" end="25" id="41" index="3" rel="su">
+                  <node begin="23" end="24" frame="determiner(de)" his="normal" his_1="normal" id="42" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="24" end="25" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="43" lcat="np" lemma="steen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="steen" sense="steen" word="stenen"/>
+                </node>
+                <node begin="27" end="28" frame="verb(unacc,past(pl),passive)" his="normal" his_1="normal" id="44" infl="pl" lcat="ssub" lemma="worden" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="word" sc="passive" sense="word" tense="past" word="werden" wvorm="pv"/>
+                <node begin="23" cat="ppart" end="29" id="45" rel="vc">
+                  <node begin="23" end="25" id="46" index="3" rel="obj1"/>
+                  <node begin="25" cat="cp" end="27" id="47" rel="predc">
+                    <node begin="25" conjtype="onder" end="26" frame="complementizer(als)" his="normal" his_1="normal" id="48" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+                    <node begin="26" end="27" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="49" lcat="np" lemma="bouwmateriaal" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="body" rnum="sg" root="bouwmateriaal" sense="bouwmateriaal" word="bouwmateriaal"/>
+                  </node>
+                  <node begin="28" buiging="zonder" end="29" frame="verb(hebben,psp,als_pred_np)" his="normal" his_1="normal" id="50" infl="psp" lcat="ppart" lemma="gebruiken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="gebruik" sc="als_pred_np" sense="gebruik" word="gebruikt" wvorm="vd"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="29" end="30" frame="punct(punt)" his="normal" his_1="normal" id="51" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het moeten er echter veel meer zijn geweest , want in de loop der eeuwen zijn heel wat hunebedden verdwenen , bijvoorbeeld omdat de stenen als bouwmateriaal werden gebruikt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="20" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="12" end="13" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="19" id="3" rel="--">
+        <node begin="0" cat="np" end="16" id="4" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+          <node begin="1" end="2" frame="meas_mod_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="plaats" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="plaats" sense="plaats" special="meas_mod" word="plaats"/>
+          <node begin="2" end="3" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="delict" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="delict" sense="delict" word="delict"/>
+          <node begin="3" cat="whrel" end="16" id="8" rel="mod">
+            <node begin="3" end="4" frame="er_wh_loc_adverb" getal="getal" his="normal" his_1="normal" id="9" index="2" lcat="advp" lemma="waar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(vb,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="rhd" root="waar" sense="waar" special="er_loc" status="vol" vwtype="vb" wh="ywh" word="waar"/>
+            <node begin="3" cat="ssub" end="16" id="10" rel="body">
+              <node begin="4" cat="np" end="12" id="11" index="3" rel="su">
+                <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="12" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="jongen" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="jongen" sense="jongen" word="jongen"/>
+                <node begin="7" cat="rel" end="12" id="14" rel="mod">
+                  <node begin="7" case="no_obl" end="8" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="15" index="4" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+                  <node begin="7" cat="ssub" end="12" id="16" rel="body">
+                    <node begin="7" end="8" id="17" index="4" rel="su"/>
+                    <node begin="10" end="11" frame="verb(unacc,past(sg),aux_psp_zijn)" his="normal" his_1="normal" id="18" infl="sg" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="past" word="was" wvorm="pv"/>
+                    <node begin="7" cat="ppart" end="12" id="19" rel="vc">
+                      <node begin="7" end="8" id="20" index="4" rel="su"/>
+                      <node begin="8" end="9" frame="tmp_adverb" his="normal" his_1="normal" id="21" lcat="advp" lemma="net" pos="adv" postag="BW()" pt="bw" rel="mod" root="net" sense="net" special="tmp" word="net"/>
+                      <node begin="9" end="10" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="22" infl="pl_num" lcat="np" lemma="14" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="predc" root="14" sense="14" word="14"/>
+                      <node begin="11" buiging="zonder" end="12" frame="verb(unacc,psp,copula)" his="normal" his_1="normal" id="23" infl="psp" lcat="ppart" lemma="worden" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="word" sc="copula" sense="word" word="geworden" wvorm="vd"/>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node begin="14" end="15" frame="verb(unacc,sg_is,passive)" his="normal" his_1="normal" id="24" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" tense="present" word="is" wvorm="pv"/>
+              <node begin="3" cat="ppart" end="16" id="25" rel="vc">
+                <node begin="3" end="4" id="26" index="2" rel="mod"/>
+                <node begin="4" end="12" id="27" index="3" rel="obj1"/>
+                <node aform="base" begin="13" buiging="zonder" end="14" frame="adjective(no_e(padv))" graad="basis" his="normal" his_1="normal" id="28" infl="no_e" lcat="ap" lemma="dood" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="dood" sense="dood" vform="adj" word="dood"/>
+                <node begin="15" buiging="zonder" end="16" frame="verb(hebben,psp,ninv(ap_pred_np,part_ap_pred_np(aan)))" his="normal" his_1="part-V" id="29" infl="psp" lcat="ppart" lemma="aan_treffen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="tref_aan" sc="part_ap_pred_np(aan)" sense="tref_aan" word="aangetroffen" wvorm="vd"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="16" end="17" frame="verb(unacc,sg_is,passive)" his="normal" his_1="normal" id="30" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="19" id="31" rel="vc">
+          <node begin="0" end="16" id="32" index="1" rel="obj1"/>
+          <node begin="17" end="18" frame="adverb" his="normal" his_1="normal" id="33" lcat="advp" lemma="inmiddels" pos="adv" postag="BW()" pt="bw" rel="mod" root="inmiddels" sense="inmiddels" word="inmiddels"/>
+          <node begin="18" buiging="zonder" end="19" frame="verb(hebben,psp,ninv(transitive,part_transitive(vrij)))" his="normal" his_1="part-V" id="34" infl="psp" lcat="ppart" lemma="vrij_geven" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="geef_vrij" sc="part_transitive(vrij)" sense="geef_vrij" word="vrijgegeven" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="19" end="20" frame="punct(punt)" his="normal" his_1="normal" id="35" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het plaats delict waar de jongen , die net 14 was geworden , dood is aangetroffen is inmiddels vrijgegeven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="13" end="14" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="18" id="2" rel="--">
+        <node begin="0" end="1" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="sup" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="Het"/>
+        <node begin="1" end="2" frame="verb(unacc,past(sg),copula_sbar)" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula_sbar" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(adv),subject_sbar_no_het)" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="duidelijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="duidelijk" sc="subject_sbar_no_het" sense="duidelijk" vform="adj" word="duidelijk"/>
+        <node begin="4" cat="whsub" end="18" id="7" rel="su">
+          <node begin="4" case="both" def="indef" end="5" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="normal" id="8" index="1" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="whd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="wie"/>
+          <node begin="4" cat="ssub" end="18" id="9" rel="body">
+            <node begin="4" end="5" id="10" index="1" rel="su"/>
+            <node begin="16" end="17" frame="verb(hebben,past(sg),aux_psp_hebben)" his="normal" his_1="normal" id="11" infl="sg" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="past" word="had" wvorm="pv"/>
+            <node begin="4" cat="ppart" end="18" id="12" rel="vc">
+              <node begin="4" end="5" id="13" index="1" rel="su"/>
+              <node begin="5" cat="cp" end="13" id="14" rel="mod">
+                <node begin="5" conjtype="onder" end="6" frame="complementizer" his="normal" his_1="normal" id="15" lcat="cp" lemma="toen" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="toen" sense="toen" word="toen"/>
+                <node begin="6" cat="ssub" end="13" id="16" rel="body">
+                  <node begin="6" cat="np" end="8" id="17" index="2" rel="su">
+                    <node begin="6" end="7" frame="determiner(de)" his="normal" his_1="normal" id="18" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                    <node begin="7" end="8" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="vlam" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="vlam" sense="vlam" word="vlammen"/>
+                  </node>
+                  <node begin="11" end="12" frame="verb(unacc,past(pl),aux_psp_zijn)" his="normal" his_1="normal" id="20" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="past" word="waren" wvorm="pv"/>
+                  <node begin="6" cat="ppart" end="13" id="21" rel="vc">
+                    <node begin="6" end="8" id="22" index="2" rel="su"/>
+                    <node begin="8" cat="pp" end="11" id="23" rel="ld">
+                      <node begin="8" end="9" frame="preposition(uit,[vandaan])" his="normal" his_1="normal" id="24" lcat="pp" lemma="uit" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="uit" sense="uit" vztype="init" word="uit"/>
+                      <node begin="9" cat="np" end="11" id="25" rel="obj1">
+                        <node begin="9" end="10" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="26" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                        <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="27" lcat="np" lemma="dak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="dak" sense="dak" word="dak"/>
+                      </node>
+                    </node>
+                    <node begin="12" buiging="zonder" end="13" frame="verb(zijn,psp,ld_pp)" his="normal" his_1="normal" id="28" infl="psp" lcat="ppart" lemma="slaan" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="sla" sc="ld_pp" sense="sla" word="geslagen" wvorm="vd"/>
+                  </node>
+                </node>
+              </node>
+              <node begin="14" cat="np" end="16" id="29" rel="obj1">
+                <node begin="14" end="15" frame="determiner(de)" his="normal" his_1="normal" id="30" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="15" end="16" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="31" lcat="np" lemma="brandweer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="brandweer" sense="brandweer" word="brandweer"/>
+              </node>
+              <node begin="17" buiging="zonder" end="18" frame="verb(hebben,psp,ninv(transitive,part_transitive(op)))" his="normal" his_1="part-V" id="32" infl="psp" lcat="ppart" lemma="op_bellen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="bel_op" sc="part_transitive(op)" sense="bel_op" word="opgebeld" wvorm="vd"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(punt)" his="normal" his_1="normal" id="33" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het was niet duidelijk wie toen de vlammen uit het dak waren geslagen , de brandweer had opgebeld .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="4" skips="2"/>
+    <node begin="0" cat="top" end="27" id="0" rel="top">
+      <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="robust_skip" id="1" lcat="--" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="--" root="dat" sc="dat" sense="dat" word="dat"/>
+      <node begin="5" end="6" frame="punct(komma)" his="robust_skip" id="2" lcat="--" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="6" case="no_obl" end="7" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="robust_skip" id="3" lcat="--" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="--" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+      <node begin="13" end="14" frame="punct(komma)" his="normal" his_1="normal" id="4" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="26" id="5" rel="--">
+        <node begin="0" cat="smain" end="2" id="6" rel="dp">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="7" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,past(sg),intransitive)" his="normal" his_1="normal" id="8" infl="sg" lcat="smain" lemma="vinden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="vind" sc="intransitive" sense="vind" stype="declarative" tense="past" word="vond" wvorm="pv"/>
+        </node>
+        <node begin="3" cat="np" end="5" id="9" rel="dp">
+          <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="spreker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="spreker" sense="spreker" word="spreker"/>
+        </node>
+        <node begin="7" cat="np" end="11" id="12" rel="dp">
+          <node begin="7" buiging="zonder" end="8" frame="determiner(geen,nwh,mod,pro,yparg,nwkpro,geen)" getal-n="zonder-n" his="normal" his_1="normal" id="13" infl="geen" lcat="np" lemma="geen" naamval="stan" pdtype="det" pos="det" positie="nom" postag="VNW(onbep,det,stan,nom,zonder,zonder-n)" pt="vnw" rel="hd" rnum="sg" root="geen" sense="geen" vwtype="onbep" wh="nwh" word="geen"/>
+          <node begin="8" cat="pp" end="11" id="14" rel="mod">
+            <node begin="8" end="9" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="15" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="9" cat="np" end="11" id="16" rel="obj1">
+              <node begin="9" end="10" frame="determiner(de)" his="normal" his_1="normal" id="17" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node aform="base" begin="10" buiging="met-e" end="11" frame="nominalized_adjective" getal-n="mv-n" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="aanwezig" num="pl" personalized="true" pos="adj" positie="nom" postag="ADJ(nom,basis,met-e,mv-n)" pt="adj" rel="hd" rnum="pl" root="aanwezig" sense="aanwezig" special="a_noun" word="aanwezigen"/>
+            </node>
+          </node>
+        </node>
+        <node begin="11" cat="smain" end="26" id="19" rel="dp">
+          <node begin="11" end="12" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="tekort" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="su" rnum="sg" root="tekort" sense="tekort" word="tekort"/>
+          <node begin="12" end="13" frame="verb(hebben,past(sg),ld_pp)" his="normal" his_1="normal" id="21" infl="sg" lcat="smain" lemma="willen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="wil" sc="ld_pp" sense="wil" stype="declarative" tense="past" word="wilde" wvorm="pv"/>
+          <node begin="14" cat="np" end="17" id="22" rel="mod">
+            <node begin="14" cat="ap" end="16" id="23" rel="mod">
+              <node begin="14" end="15" frame="adverb" his="normal" his_1="normal" id="24" lcat="advp" lemma="reeds" pos="adv" postag="BW()" pt="bw" rel="mod" root="reeds" sense="reeds" word="reeds"/>
+              <node aform="base" begin="15" buiging="met-e" end="16" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="25" infl="e" lcat="ap" lemma="lang" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="hd" root="lang" sense="lang" vform="adj" word="lange"/>
+            </node>
+            <node begin="16" end="17" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="26" lcat="np" lemma="tijd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="tijd" sense="tijd" special="tmp" word="tijd"/>
+          </node>
+          <node begin="17" cat="pp" end="26" id="27" rel="ld">
+            <node begin="17" end="18" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="28" lcat="pp" lemma="bij" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="bij" sense="bij" vztype="init" word="bij"/>
+            <node begin="18" cat="np" end="26" id="29" rel="obj1">
+              <node begin="18" end="19" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="30" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node aform="base" begin="19" buiging="zonder" end="20" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="31" infl="both" lcat="ppart" lemma="bewegen" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="mod" root="bewegen" sense="bewegen" vform="psp" word="bewogen" wvorm="vd"/>
+              <node begin="20" end="21" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="32" lcat="np" lemma="verleden" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="verleden" sense="verleden" word="verleden"/>
+              <node begin="21" cat="pp" end="26" id="33" rel="mod">
+                <node begin="21" end="22" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="34" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                <node begin="22" cat="np" end="26" id="35" rel="obj1">
+                  <node begin="22" end="23" frame="determiner(de)" his="normal" his_1="normal" id="36" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="23" cat="mwu" end="26" his="name" his_1="not_begin" id="37" rel="hd">
+                    <node begin="23" end="24" frame="proper_name(both)" id="38" lcat="np" lemma="jubilaris" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="jubilaris" sense="jubilaris" spectype="deeleigen" word="jubilaris"/>
+                    <node begin="24" end="25" frame="proper_name(both)" id="39" lcat="np" lemma="had" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="had" sense="had" spectype="deeleigen" word="had"/>
+                    <node begin="25" end="26" frame="proper_name(both)" id="40" lcat="np" lemma="verwijld" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="verwijld" sense="verwijld" spectype="deeleigen" word="verwijld"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="26" end="27" frame="punct(punt)" his="robust_skip" id="41" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik vond dat de spreker , die geen van de aanwezigen tekort wilde , reeds lange tijd bij het bewogen verleden van de jubilaris had verwijld .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="4" skips="3"/>
+    <node begin="0" cat="top" end="21" id="0" rel="top">
+      <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="robust_skip" id="1" lcat="--" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="--" root="dat" sc="dat" sense="dat" word="dat"/>
+      <node begin="5" case="no_obl" end="6" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="robust_skip" id="2" lcat="--" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="--" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+      <node begin="12" end="13" frame="verb(unacc,past(sg),passive)" his="robust_skip" id="3" infl="sg" lcat="--" lemma="worden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="--" root="word" sc="passive" sense="word" tense="past" word="werd" wvorm="pv"/>
+      <node begin="0" cat="du" end="20" id="4" rel="--">
+        <node begin="0" cat="smain" end="2" id="5" rel="dp">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,past(sg),intransitive)" his="normal" his_1="normal" id="7" infl="sg" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zie" sc="intransitive" sense="zie" stype="declarative" tense="past" word="zag" wvorm="pv"/>
+        </node>
+        <node begin="3" cat="np" end="5" id="8" rel="dp">
+          <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="4" end="5" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+        </node>
+        <node begin="6" cat="smain" end="12" id="11" rel="dp">
+          <node begin="6" cat="np" end="9" id="12" index="1" rel="su">
+            <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="13" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="14" infl="both" lcat="ppart" lemma="breken" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="mod" root="breken" sense="breken" vform="psp" word="gebroken" wvorm="vd"/>
+            <node begin="8" end="9" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="been" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="been" sense="been" word="been"/>
+          </node>
+          <node begin="9" end="10" frame="verb(hebben,past(sg),aux_psp_hebben)" his="normal" his_1="normal" id="16" infl="sg" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="past" word="had" wvorm="pv"/>
+          <node begin="6" cat="ppart" end="12" id="17" rel="vc">
+            <node begin="6" end="9" id="18" index="1" rel="su"/>
+            <node aform="compar" begin="10" buiging="zonder" end="11" frame="adjective(er(adv))" graad="comp" his="normal" his_1="normal" id="19" infl="no_e" lcat="ap" lemma="eerder" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="mod" root="eerder" sense="eerder" vform="adj" word="eerder"/>
+            <node begin="11" buiging="zonder" end="12" frame="verb(hebben,psp,intransitive)" his="normal" his_1="normal" id="20" infl="psp" lcat="ppart" lemma="helpen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="help" sc="intransitive" sense="help" word="geholpen" wvorm="vd"/>
+          </node>
+        </node>
+        <node begin="13" cat="du" end="20" id="21" rel="dp">
+          <node begin="13" end="14" frame="tmp_adverb" his="normal" his_1="normal" id="22" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="dp" root="dan" sense="dan" special="tmp" word="dan"/>
+          <node begin="14" cat="np" end="20" id="23" rel="dp">
+            <node begin="14" end="15" frame="determiner(de)" his="normal" his_1="normal" id="24" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="15" end="16" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="vrouw" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vrouw" sense="vrouw" word="vrouw"/>
+            <node begin="16" cat="pp" end="20" id="26" rel="mod">
+              <node begin="16" end="17" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="27" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="17" cat="np" end="20" id="28" rel="obj1">
+                <node begin="17" end="18" frame="determiner(een)" his="normal" his_1="normal" id="29" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="base" begin="18" buiging="zonder" end="19" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="30" infl="both" lcat="ppart" lemma="breken" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="mod" root="breken" sense="breken" vform="psp" word="gebroken" wvorm="vd"/>
+                <node begin="19" end="20" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="31" lcat="np" lemma="arm" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="arm" sense="arm" word="arm"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="20" end="21" frame="punct(punt)" his="robust_skip" id="32" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zag dat de man die een gebroken been had eerder geholpen werd dan de vrouw met een gebroken arm .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="32" id="0" rel="top">
+      <node begin="12" end="13" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="26" end="27" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="31" id="3" rel="--">
+        <node begin="13" end="14" frame="verb(unacc,past(sg),passive)" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="word" sc="passive" sense="word" stype="declarative" tense="past" word="werd" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="31" id="5" rel="vc">
+          <node begin="0" cat="cp" end="12" id="6" rel="mod">
+            <node begin="0" conjtype="onder" end="1" frame="complementizer" his="normal" his_1="decap" his_1_1="normal" id="7" lcat="cp" lemma="terwijl" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="terwijl" sense="terwijl" word="Terwijl"/>
+            <node begin="1" cat="ssub" end="12" id="8" rel="body">
+              <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="9" index="1" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+              <node begin="9" end="10" frame="verb(hebben,past(pl),subj_control(wk_te))" his="normal" his_1="normal" id="10" infl="pl" lcat="ssub" lemma="zitten" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="zit" sc="subj_control(wk_te)" sense="zit" tense="past" word="zaten" wvorm="pv"/>
+              <node begin="1" cat="ti" end="12" id="11" rel="vc">
+                <node begin="10" end="11" frame="complementizer(te)" his="normal" his_1="normal" id="12" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="1" cat="inf" end="12" id="13" rel="body">
+                  <node begin="1" end="2" id="14" index="1" rel="su"/>
+                  <node begin="2" cat="pp" end="5" id="15" rel="mod">
+                    <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="16" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                    <node begin="3" cat="np" end="5" id="17" rel="obj1">
+                      <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="18" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                      <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="wacht_kamer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wacht_kamer" sense="wacht_kamer" word="wachtkamer"/>
+                    </node>
+                  </node>
+                  <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="20" infl="no_e" lcat="ap" lemma="rustig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="rustig" sense="rustig" vform="adj" word="rustig"/>
+                  <node begin="6" cat="pp" end="9" id="21" rel="pc">
+                    <node begin="6" end="7" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="22" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                    <node begin="7" cat="np" end="9" id="23" rel="obj1">
+                      <node begin="7" buiging="met-e" end="8" frame="determiner(onze)" getal="mv" his="normal" his_1="normal" id="24" infl="onze" lcat="detp" lemma="ons" naamval="stan" npagr="rest" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,mv,prenom,met-e,rest)" pt="vnw" rel="det" root="ons" sense="ons" status="vol" vwtype="bez" word="onze"/>
+                      <node begin="8" end="9" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="beurt" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="beurt" sense="beurt" word="beurt"/>
+                    </node>
+                  </node>
+                  <node begin="11" buiging="zonder" end="12" frame="verb(hebben,inf,pc_pp(op))" his="normal" his_1="normal" id="26" infl="inf" lcat="inf" lemma="wachten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="wacht" sc="pc_pp(op)" sense="wacht-op" word="wachten" wvorm="inf"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="14" end="15" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="27" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+          <node begin="25" buiging="zonder" end="26" frame="verb(hebben,psp,ninv(transitive,part_transitive(binnen)))" his="normal" his_1="part-V" id="28" infl="psp" lcat="ppart" lemma="binnen_brengen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="breng_binnen" sc="part_transitive(binnen)" sense="breng_binnen" word="binnengebracht" wvorm="vd"/>
+          <node begin="15" cat="np" end="31" id="29" index="2" rel="obj1">
+            <node begin="15" end="16" frame="determiner(een)" his="normal" his_1="normal" id="30" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="16" cat="ppart" end="24" id="31" rel="mod">
+              <node begin="16" cat="pp" end="23" id="32" rel="mod">
+                <node begin="16" end="17" frame="preposition(door,[heen])" his="normal" his_1="normal" id="33" lcat="pp" lemma="door" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="door" sense="door" vztype="init" word="door"/>
+                <node begin="17" cat="np" end="23" id="34" rel="obj1">
+                  <node begin="17" end="18" frame="determiner(een)" his="normal" his_1="normal" id="35" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                  <node aform="base" begin="18" buiging="met-e" end="19" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="36" infl="e" lcat="ap" lemma="dol" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="dol" sense="dol" vform="adj" word="dolle"/>
+                  <node begin="19" end="20" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="37" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+                  <node begin="20" cat="pp" end="23" id="38" rel="mod">
+                    <node begin="20" end="21" frame="preposition(in,[])" his="normal" his_1="normal" id="39" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                    <node begin="21" cat="np" end="23" id="40" rel="obj1">
+                      <node begin="21" buiging="zonder" end="22" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="41" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+                      <node begin="22" end="23" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="42" lcat="np" lemma="been" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="been" sense="been" word="been"/>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node aform="base" begin="23" buiging="zonder" end="24" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="43" infl="both" lcat="ppart" lemma="bijten" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="hd" root="bijten" sense="bijten" vform="psp" word="gebeten" wvorm="vd"/>
+            </node>
+            <node begin="24" end="25" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="44" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+            <node begin="27" cat="rel" end="31" id="45" rel="mod">
+              <node begin="27" case="no_obl" end="28" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="46" index="3" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="27" cat="ssub" end="31" id="47" rel="body">
+                <node begin="27" end="28" id="48" index="3" rel="su"/>
+                <node aform="base" begin="28" buiging="zonder" end="29" frame="adjective(no_e(sentadv))" graad="basis" his="normal" his_1="normal" id="49" infl="no_e" lcat="ap" lemma="natuurlijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="natuurlijk" sense="natuurlijk" vform="adj" word="natuurlijk"/>
+                <node begin="29" end="30" frame="particle(voor)" his="normal" his_1="normal" id="50" lcat="part" lemma="voor" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="voor" sense="voor" vztype="fin" word="voor"/>
+                <node begin="30" end="31" frame="verb(zijn,past(sg),part_intransitive(voor))" his="normal" his_1="normal" id="51" infl="sg" lcat="ssub" lemma="voor_gaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ga_voor" sc="part_intransitive(voor)" sense="ga_voor" tense="past" word="ging" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="15" end="31" id="52" index="2" rel="su"/>
+      </node>
+      <node begin="31" end="32" frame="punct(punt)" his="normal" his_1="normal" id="53" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Terwijl we in de wachtkamer rustig op onze beurt zaten te wachten , werd er een door een dolle hond in zijn been gebeten man binnengebracht , die natuurlijk voor ging .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/dlevel5.example.alpino
+++ b/tests/dlevel5.example.alpino
@@ -1,0 +1,202 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="2" rel="--">
+        <node begin="5" end="6" frame="verb(zijn,sg1,aux(inf))" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="aux(inf)" sense="ga" stype="declarative" tense="present" word="ga" wvorm="pv"/>
+        <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="4" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="0" cat="inf" end="10" id="5" rel="vc">
+          <node begin="0" cat="cp" end="4" id="6" rel="mod">
+            <node begin="0" conjtype="onder" end="1" frame="complementizer(als)" his="normal" his_1="decap" his_1_1="normal" id="7" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="Als"/>
+            <node begin="1" cat="ssub" end="4" id="8" rel="body">
+              <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="9" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+              <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="10" infl="no_e" lcat="ap" lemma="droog" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="droog" sense="droog" vform="adj" word="droog"/>
+              <node begin="3" end="4" frame="verb(unacc,sg3,copula)" his="normal" his_1="normal" id="11" infl="sg3" lcat="ssub" lemma="blijven" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="blijf" sc="copula" sense="blijf" tense="present" word="blijft" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="6" end="7" id="12" index="1" rel="su"/>
+          <node begin="7" cat="np" end="9" id="13" rel="obj1">
+            <node begin="7" end="8" frame="determiner(een)" his="normal" his_1="normal" id="14" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="8" end="9" frame="meas_mod_noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="stuk" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="stuk" sense="stuk" special="meas_mod" word="stuk"/>
+          </node>
+          <node begin="9" buiging="zonder" end="10" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="fietsen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="fiets" sc="transitive" sense="fiets" word="fietsen" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Als het droog blijft , ga ik een stuk fietsen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="25" id="0" rel="top">
+      <node begin="0" cat="smain" end="24" id="1" rel="--">
+        <node begin="0" cat="np" end="10" id="2" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+          <node begin="1" cat="ppart" end="9" id="4" rel="mod">
+            <node begin="1" cat="pp" end="8" id="5" rel="mod">
+              <node begin="1" end="2" frame="preposition(door,[heen])" his="normal" his_1="normal" id="6" lcat="pp" lemma="door" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="door" sense="door" vztype="init" word="door"/>
+              <node begin="2" cat="np" end="8" id="7" rel="obj1">
+                <node begin="2" end="3" frame="determiner(een)" his="normal" his_1="normal" id="8" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="9" infl="e" lcat="ap" lemma="dol" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="dol" sense="dol" vform="adj" word="dolle"/>
+                <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+                <node begin="5" cat="pp" end="8" id="11" rel="mod">
+                  <node begin="5" end="6" frame="preposition(in,[])" his="normal" his_1="normal" id="12" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                  <node begin="6" cat="np" end="8" id="13" rel="obj1">
+                    <node begin="6" buiging="zonder" end="7" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="14" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+                    <node begin="7" end="8" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="been" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="been" sense="been" word="been"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node aform="base" begin="8" buiging="zonder" end="9" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="16" infl="both" lcat="ppart" lemma="bijten" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="hd" root="bijten" sense="bijten" vform="psp" word="gebeten" wvorm="vd"/>
+          </node>
+          <node begin="9" end="10" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+        </node>
+        <node begin="10" end="11" frame="verb(unacc,past(sg),passive)" his="normal" his_1="normal" id="18" infl="sg" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="word" sc="passive" sense="word" stype="declarative" tense="past" word="werd" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="24" id="19" rel="vc">
+          <node begin="0" end="10" id="20" index="1" rel="obj1"/>
+          <node begin="11" buiging="zonder" end="12" frame="verb(hebben,psp,ninv(transitive,part_transitive(binnen)))" his="normal" his_1="part-V" id="21" infl="psp" lcat="ppart" lemma="binnen_brengen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="breng_binnen" sc="part_transitive(binnen)" sense="breng_binnen" word="binnengebracht" wvorm="vd"/>
+          <node begin="12" cat="cp" end="24" id="22" rel="mod">
+            <node begin="12" conjtype="onder" end="13" frame="complementizer" his="normal" his_1="normal" id="23" lcat="cp" lemma="terwijl" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="terwijl" sense="terwijl" word="terwijl"/>
+            <node begin="13" cat="ssub" end="24" id="24" rel="body">
+              <node begin="13" case="nom" def="def" end="14" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="25" index="2" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+              <node begin="21" end="22" frame="verb(hebben,past(pl),subj_control(wk_te))" his="normal" his_1="normal" id="26" infl="pl" lcat="ssub" lemma="zitten" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="zit" sc="subj_control(wk_te)" sense="zit" tense="past" word="zaten" wvorm="pv"/>
+              <node begin="13" cat="ti" end="24" id="27" rel="vc">
+                <node begin="22" end="23" frame="complementizer(te)" his="normal" his_1="normal" id="28" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="13" cat="inf" end="24" id="29" rel="body">
+                  <node begin="13" end="14" id="30" index="2" rel="su"/>
+                  <node begin="14" cat="pp" end="17" id="31" rel="mod">
+                    <node begin="14" end="15" frame="preposition(in,[])" his="normal" his_1="normal" id="32" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                    <node begin="15" cat="np" end="17" id="33" rel="obj1">
+                      <node begin="15" end="16" frame="determiner(de)" his="normal" his_1="normal" id="34" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                      <node begin="16" end="17" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="35" lcat="np" lemma="wacht_kamer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wacht_kamer" sense="wacht_kamer" word="wachtkamer"/>
+                    </node>
+                  </node>
+                  <node aform="base" begin="17" buiging="zonder" end="18" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="36" infl="no_e" lcat="ap" lemma="rustig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="rustig" sense="rustig" vform="adj" word="rustig"/>
+                  <node begin="18" cat="pp" end="21" id="37" rel="pc">
+                    <node begin="18" end="19" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="38" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                    <node begin="19" cat="np" end="21" id="39" rel="obj1">
+                      <node begin="19" buiging="met-e" end="20" frame="determiner(onze)" getal="mv" his="normal" his_1="normal" id="40" infl="onze" lcat="detp" lemma="ons" naamval="stan" npagr="rest" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,mv,prenom,met-e,rest)" pt="vnw" rel="det" root="ons" sense="ons" status="vol" vwtype="bez" word="onze"/>
+                      <node begin="20" end="21" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="41" lcat="np" lemma="beurt" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="beurt" sense="beurt" word="beurt"/>
+                    </node>
+                  </node>
+                  <node begin="23" buiging="zonder" end="24" frame="verb(hebben,inf,pc_pp(op))" his="normal" his_1="normal" id="42" infl="inf" lcat="inf" lemma="wachten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="wacht" sc="pc_pp(op)" sense="wacht-op" word="wachten" wvorm="inf"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="24" end="25" frame="punct(punt)" his="normal" his_1="normal" id="43" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een door een dolle hond in zijn been gebeten man werd binnengebracht terwijl we in de wachtkamer rustig op onze beurt zaten te wachten .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="25" id="0" rel="top">
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="18" end="19" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="24" id="3" rel="--">
+        <node begin="0" cat="smain" end="18" id="4" rel="cnj">
+          <node begin="0" cat="cp" end="9" id="5" index="1" rel="mod">
+            <node begin="0" conjtype="onder" end="1" frame="complementizer" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="cp" lemma="hoewel" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="hoewel" sense="hoewel" word="Hoewel"/>
+            <node begin="1" cat="ssub" end="9" id="7" rel="body">
+              <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="8" index="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node begin="2" end="3" frame="predm_adverb" his="normal" his_1="normal" id="9" lcat="advp" lemma="zelf" pos="adv" postag="BW()" pt="bw" rel="predm" root="zelf" sense="zelf" special="predm" word="zelf"/>
+              <node begin="7" end="8" frame="verb('hebben/zijn',past(sg),aux(inf))" his="normal" his_1="normal" id="10" infl="sg" lcat="ssub" lemma="kunnen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="kan" sc="aux(inf)" sense="kan" tense="past" word="kon" wvorm="pv"/>
+              <node begin="1" cat="inf" end="9" id="11" rel="vc">
+                <node begin="1" end="2" id="12" index="2" rel="su"/>
+                <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="nauwelijks" pos="adv" postag="BW()" pt="bw" rel="mod" root="nauwelijks" sense="nauwelijks" word="nauwelijks"/>
+                <node begin="4" cat="np" end="7" id="14" rel="obj1">
+                  <node begin="4" buiging="zonder" end="5" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="15" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+                  <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(both(nonadv))" graad="basis" his="normal" his_1="normal" id="16" infl="both" lcat="ap" lemma="eigen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="eigen" sense="eigen" vform="adj" word="eigen"/>
+                  <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="naam" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="naam" sense="naam" word="naam"/>
+                </node>
+                <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="18" infl="inf" lcat="inf" lemma="schrijven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="schrijf" sc="transitive" sense="schrijf" word="schrijven" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+          <node begin="10" end="11" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="19" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" tense="past" word="was" wvorm="pv"/>
+          <node begin="11" case="nom" def="def" end="12" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="20" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node aform="base" begin="12" end="13" frame="adjective(pred(adv))" his="normal" his_1="normal" id="21" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+          <node begin="13" cat="ppart" end="18" id="22" rel="predc">
+            <node aform="base" begin="13" buiging="zonder" end="14" frame="adjective(ge_both(adv),pp(in))" his="normal" his_1="normal" id="23" infl="both" lcat="ppart" lemma="bedrijven" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="bedrijven" sc="pp(in)" sense="bedrijven-in" vform="psp" word="bedreven" wvorm="vd"/>
+            <node begin="14" cat="pp" end="18" id="24" rel="pc">
+              <node begin="14" end="15" frame="preposition(in,[])" his="normal" his_1="normal" id="25" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="15" cat="conj" end="18" id="26" rel="obj1">
+                <node begin="15" buiging="zonder" end="16" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="27" lcat="np" lemma="rekenen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="cnj" rnum="sg" root="reken" sc="intransitive" sense="reken" special="v_noun" word="rekenen" wvorm="inf"/>
+                <node begin="16" conjtype="neven" end="17" frame="conj(en)" his="normal" his_1="normal" id="28" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+                <node begin="17" end="18" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="29" lcat="np" lemma="ster_kunde" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="ster_kunde" sense="ster_kunde" word="sterrenkunde"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="19" conjtype="neven" end="20" frame="conj(en)" his="normal" his_1="normal" id="30" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="24" id="31" rel="cnj">
+          <node begin="0" end="9" id="32" index="1" rel="mod"/>
+          <node begin="20" end="21" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="33" infl="sg" lcat="smain" lemma="spreken" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="spreek" sc="transitive" sense="spreek" tense="past" word="sprak" wvorm="pv"/>
+          <node begin="21" case="nom" def="def" end="22" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="34" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node begin="22" cat="np" end="24" id="35" rel="obj1">
+            <node aform="base" begin="22" buiging="met-e" end="23" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="36" infl="e" lcat="ap" lemma="verschillend" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="verschillend" sense="verschillend" vform="adj" word="verschillende"/>
+            <node begin="23" end="24" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="37" lcat="np" lemma="taal" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="taal" sense="taal" word="talen"/>
+          </node>
+        </node>
+      </node>
+      <node begin="24" end="25" frame="punct(punt)" his="normal" his_1="normal" id="38" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hoewel hij zelf nauwelijks zijn eigen naam kon schrijven , was hij wel bedreven in rekenen en sterrenkunde , en sprak hij verschillende talen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="9" id="2" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Julia" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Julia" sense="Julia" word="Julia"/>
+        <node begin="1" end="2" frame="verb(unacc,sg3,part_intransitive(thuis))" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="thuis_blijven" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="blijf_thuis" sc="part_intransitive(thuis)" sense="blijf_thuis" stype="declarative" tense="present" word="blijft" wvorm="pv"/>
+        <node begin="2" end="3" frame="particle(thuis)" his="normal" his_1="normal" id="5" lcat="part" lemma="thuis" pos="part" postag="BW()" pt="bw" rel="svp" root="thuis" sense="thuis" word="thuis"/>
+        <node begin="4" cat="cp" end="9" id="6" rel="mod">
+          <node begin="4" conjtype="onder" end="5" frame="complementizer" his="normal" his_1="normal" id="7" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+          <node begin="5" cat="ssub" end="9" id="8" rel="body">
+            <node begin="5" end="6" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+            <node begin="6" cat="ap" end="8" id="10" rel="mod">
+              <node begin="6" buiging="zonder" end="7" frame="intensifier" graad="basis" his="normal" his_1="normal" id="11" lcat="advp" lemma="heel" pos="adv" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="heel" sense="heel" special="intensifier" word="heel"/>
+              <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="12" infl="no_e" lcat="ap" lemma="hard" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="hard" sense="hard" vform="adj" word="hard"/>
+            </node>
+            <node begin="8" end="9" frame="verb(hebben,sg3,het_subj)" his="normal" his_1="normal" id="13" infl="sg3" lcat="ssub" lemma="regenen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="regen" sc="het_subj" sense="het-regen" tense="present" word="regent" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Julia blijft thuis , omdat het heel hard regent .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="12" id="2" rel="--">
+        <node begin="0" cat="cp" end="4" id="3" rel="mod">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="cp" lemma="tenzij" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="tenzij" sense="tenzij" word="Tenzij"/>
+          <node begin="1" cat="ssub" end="4" id="5" rel="body">
+            <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,je,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="jij" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,vol,2v,ev)" pt="vnw" rel="su" rnum="sg" root="jij" sense="jij" status="vol" vwtype="pers" wh="nwh" word="jij"/>
+            <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,fir,sg,de,dat_acc,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="me" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,red,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="me" sense="me" special="wkpro" status="red" vwtype="pr" wh="nwh" word="me"/>
+            <node begin="3" end="4" frame="verb(hebben,sg3,ninv(transitive,part_transitive(tegen)))" his="normal" his_1="part-V" id="8" infl="sg3" lcat="ssub" lemma="tegen_houden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="houd_tegen" sc="part_transitive(tegen)" sense="houd_tegen" tense="present" word="tegenhoudt" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(zijn,sg1,ld_pp)" his="normal" his_1="normal" id="9" infl="sg1" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="declarative" tense="present" word="ga" wvorm="pv"/>
+        <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="7" end="8" frame="tmp_adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="nu" pos="adv" postag="BW()" pt="bw" rel="mod" root="nu" sense="nu" special="tmp" word="nu"/>
+        <node begin="8" end="9" frame="adverb" his="normal" his_1="normal" id="12" lcat="advp" lemma="toch" pos="adv" postag="BW()" pt="bw" rel="mod" root="toch" sense="toch" word="toch"/>
+        <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="13" infl="no_e" lcat="ap" lemma="echt" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="echt" sense="echt" vform="adj" word="echt"/>
+        <node begin="10" cat="pp" end="12" id="14" rel="ld">
+          <node begin="10" end="11" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="15" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+          <node begin="11" end="12" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(uitroep)" his="normal" his_1="normal" id="17" lcat="punct" lemma="!" pos="punct" postag="LET()" pt="let" rel="--" root="!" sense="!" special="uitroep" word="!"/>
+    </node>
+    <sentence sentid="127.0.0.1">Tenzij jij me tegenhoudt , ga ik nu toch echt naar huis !</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/dlevel6.example.alpino
+++ b/tests/dlevel6.example.alpino
@@ -1,0 +1,389 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="13" id="2" rel="--">
+        <node begin="0" cat="np" end="6" id="3" rel="su">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+          <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="5" infl="e" lcat="np" lemma="weinig" naamval="stan" npagr="agr" pdtype="grad" pos="adj" positie="prenom" postag="VNW(onbep,grad,stan,prenom,met-e,agr,basis)" pt="vnw" rel="hd" rnum="sg" root="weinig" sense="weinig" vform="adj" vwtype="onbep" word="weinige"/>
+          <node begin="2" cat="rel" end="6" id="6" rel="mod">
+            <node begin="2" case="no_obl" end="3" frame="rel_pronoun(het,no_obl)" gen="het" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3" pos="pron" postag="VNW(betr,pron,stan,vol,3,ev)" pt="vnw" rel="rhd" rnum="sg" root="dat" sense="dat" status="vol" vwtype="betr" wh="rel" word="dat"/>
+            <node begin="2" cat="ssub" end="6" id="8" rel="body">
+              <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,both,de,nom,def)" gen="de" getal="mv" his="normal" his_1="normal" id="9" index="2" lcat="np" lemma="zij" naamval="nomin" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,nomin,vol,3p,mv)" pt="vnw" rel="su" rnum="pl" root="zij" sense="zij" status="vol" vwtype="pers" wh="nwh" word="zij"/>
+              <node begin="4" end="5" frame="verb(hebben,pl,aux_psp_hebben)" his="normal" his_1="normal" id="10" infl="pl" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="present" word="hebben" wvorm="pv"/>
+              <node begin="2" cat="ppart" end="6" id="11" rel="vc">
+                <node begin="2" end="3" id="12" index="1" rel="obj1"/>
+                <node begin="3" end="4" id="13" index="2" rel="su"/>
+                <node begin="5" buiging="zonder" end="6" frame="verb(hebben,psp,ninv(transitive,part_transitive(na)))" his="normal" his_1="part-V" id="14" infl="psp" lcat="ppart" lemma="na_laten" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="laat_na" sc="part_transitive(na)" sense="laat_na" word="nagelaten" wvorm="vd"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="7" end="8" frame="verb('hebben/zijn',sg3,ld_pp)" his="normal" his_1="normal" id="15" infl="sg3" lcat="smain" lemma="liggen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="lig" sc="ld_pp" sense="lig" stype="declarative" tense="present" word="ligt" wvorm="pv"/>
+        <node begin="8" end="9" frame="sentence_adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="meestal" pos="adv" postag="BW()" pt="bw" rel="mod" root="meestal" sense="meestal" special="sentence" word="meestal"/>
+        <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="17" infl="both" lcat="ppart" lemma="verschuilen" pos="adj" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="mod" root="verschuilen" sense="verschuilen" vform="psp" word="verscholen" wvorm="vd"/>
+        <node begin="10" cat="pp" end="13" id="18" rel="ld">
+          <node begin="10" end="11" frame="preposition(in,[])" his="normal" his_1="normal" id="19" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="11" cat="np" end="13" id="20" rel="obj1">
+            <node begin="11" end="12" frame="determiner(de)" his="normal" his_1="normal" id="21" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="12" end="13" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="grond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="grond" sense="grond" word="grond"/>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="23" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het weinige dat zij hebben nagelaten , ligt meestal verscholen in de grond .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="8" end="9" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="11" id="2" rel="--">
+        <node begin="0" cat="cp" end="8" id="3" rel="su">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(dat)" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="Dat"/>
+          <node begin="1" cat="ssub" end="8" id="5" rel="body">
+            <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="2" cat="pp" end="5" id="7" rel="mod">
+              <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="8" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="3" cat="np" end="5" id="9" rel="obj1">
+                <node begin="3" buiging="zonder" end="4" frame="determiner(zulke,nwh,nmod,pro,yparg)" his="normal" his_1="normal" id="10" infl="zulke" lcat="detp" lemma="zulk" naamval="stan" npagr="evon" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,evon)" pt="vnw" rel="det" root="zulk" sense="zulk" vwtype="aanw" wh="nwh" word="zulke"/>
+                <node begin="4" end="5" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="kleed" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="kleed" sense="kleed" word="kleren"/>
+              </node>
+            </node>
+            <node begin="5" cat="pp" end="7" id="12" rel="ld">
+              <node begin="5" end="6" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="13" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="school" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="school" sense="school" word="school"/>
+            </node>
+            <node begin="7" end="8" frame="verb(zijn,sg3,ld_pp)" his="normal" his_1="normal" id="15" infl="sg3" lcat="ssub" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" tense="present" word="gaat" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="9" end="10" frame="verb(unacc,sg_is,copula_sbar)" his="normal" his_1="normal" id="16" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula_sbar" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node aform="base" begin="10" buiging="zonder" end="11" frame="adjective(no_e(adv),subject_sbar)" graad="basis" his="normal" his_1="normal" id="17" infl="no_e" lcat="ap" lemma="raar" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="raar" sc="subject_sbar" sense="raar" vform="adj" word="raar"/>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat je in zulke kleren naar school gaat , is raar .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="13" id="2" rel="--">
+        <node begin="0" cat="np" end="7" id="3" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="eik" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="eik" sense="eik" word="eik"/>
+          <node begin="2" cat="rel" end="7" id="6" rel="mod">
+            <node begin="2" case="no_obl" end="3" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="7" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+            <node begin="2" cat="ssub" end="7" id="8" rel="body">
+              <node begin="2" end="3" id="9" index="2" rel="su"/>
+              <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+              <node begin="4" cat="ap" end="6" id="11" rel="predc">
+                <node begin="4" end="5" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="eeuw" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="me" rnum="pl" root="eeuw" sense="eeuw" special="tmp" word="eeuwen"/>
+                <node aform="base" begin="5" buiging="zonder" end="6" frame="np_me_adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="13" infl="no_e" lcat="ap" lemma="oud" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="oud" sc="np_me" sense="oud" vform="adj" word="oud"/>
+              </node>
+              <node begin="6" end="7" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="14" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="8" end="9" frame="verb(unacc,sg_is,passive)" his="normal" his_1="normal" id="15" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="13" id="16" rel="vc">
+          <node begin="0" end="7" id="17" index="1" rel="obj1"/>
+          <node begin="9" cat="pp" end="12" id="18" rel="mod">
+            <node begin="9" end="10" frame="preposition(door,[heen])" his="normal" his_1="normal" id="19" lcat="pp" lemma="door" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="door" sense="door" vztype="init" word="door"/>
+            <node begin="10" cat="np" end="12" id="20" rel="obj1">
+              <node begin="10" end="11" frame="determiner(de)" his="normal" his_1="normal" id="21" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="11" end="12" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="bliksem" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="bliksem" sense="bliksem" word="bliksem"/>
+            </node>
+          </node>
+          <node begin="12" buiging="zonder" end="13" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="23" infl="psp" lcat="ppart" lemma="vellen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="vel" sc="transitive" sense="vel" word="geveld" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="24" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De eik die al eeuwen oud is , is door de bliksem geveld .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="sup" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="Het"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula_sbar)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula_sbar" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="ap" end="4" id="4" rel="predc">
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="erg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="erg" sense="erg" vform="adj" word="erg"/>
+          <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(adv),subject_sbar)" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="aardig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="aardig" sc="subject_sbar" sense="aardig" vform="adj" word="aardig"/>
+        </node>
+        <node begin="4" cat="cp" end="9" id="7" rel="su">
+          <node begin="4" conjtype="onder" end="5" frame="complementizer(dat)" his="normal" his_1="normal" id="8" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="5" cat="ssub" end="9" id="9" rel="body">
+            <node begin="5" case="both" def="def" end="6" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="10" index="1" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="5" cat="ppart" end="8" id="11" rel="vc">
+              <node begin="5" end="6" id="12" index="1" rel="su"/>
+              <node begin="6" case="dat_acc" def="def" end="7" frame="pronoun(nwh,fir,sg,de,dat_acc,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="13" lcat="np" lemma="me" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,red,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="me" sense="me" special="wkpro" status="red" vwtype="pr" wh="nwh" word="me"/>
+              <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,transitive_ndev)" his="normal" his_1="normal" id="14" infl="psp" lcat="ppart" lemma="helpen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="help" sc="transitive_ndev" sense="help" word="geholpen" wvorm="vd"/>
+            </node>
+            <node begin="8" end="9" frame="verb(hebben,sg_hebt,aux_psp_hebben)" his="normal" his_1="normal" id="15" infl="sg_hebt" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="present" word="hebt" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het is erg aardig dat je me geholpen hebt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="sup" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="Het"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,alsof_sbar_subj)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="lijken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="lijk" sc="alsof_sbar_subj" sense="lijk" stype="declarative" tense="present" word="lijkt" wvorm="pv"/>
+        <node aform="base" begin="2" end="3" frame="adjective(pred(adv))" his="normal" his_1="normal" id="4" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+        <node begin="3" cat="cp" end="9" id="5" rel="su">
+          <node begin="3" conjtype="onder" end="4" frame="complementizer(of)" his="normal" his_1="normal" id="6" lcat="cp" lemma="of" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="of" sc="of" sense="of" word="of"/>
+          <node begin="4" cat="ssub" end="9" id="7" rel="body">
+            <node begin="4" case="both" def="def" end="5" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" genus="fem" getal="ev" his="normal" his_1="normal" id="8" index="1" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,ev,fem)" pt="vnw" rel="su" rnum="sg" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+            <node begin="6" end="7" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="9" infl="sg_heeft" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="present" word="heeft" wvorm="pv"/>
+            <node begin="4" cat="inf" end="9" id="10" rel="vc">
+              <node begin="4" end="5" id="11" index="1" rel="su"/>
+              <node begin="7" buiging="zonder" end="8" frame="verb('hebben/zijn',inf,modifier(aux(inf)))" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="moeten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" word="moeten" wvorm="inf"/>
+              <node begin="4" cat="inf" end="9" id="13" rel="vc">
+                <node begin="4" end="5" id="14" index="1" rel="su"/>
+                <node begin="5" end="6" frame="reflexive(u_thi,both)" getal="getal" his="normal" his_1="normal" id="15" lcat="np" lemma="zich" naamval="obl" num="both" pdtype="pron" per="u_thi" persoon="3" pos="pron" postag="VNW(refl,pron,obl,red,3,getal)" pt="vnw" refl="refl" rel="se" root="zich" sense="zich" status="red" vwtype="refl" word="zich"/>
+                <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf,refl)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="haasten" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="haast" sc="refl" sense="zich-haast" word="haasten" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het lijkt wel of ze zich heeft moeten haasten .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="0" cat="smain" end="16" id="1" rel="--">
+        <node begin="0" cat="np" end="11" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+          <node begin="1" buiging="zonder" end="2" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="4" lcat="np" lemma="testen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="hd" rnum="sg" root="test" sc="intransitive" sense="test" special="v_noun" word="testen" wvorm="inf"/>
+          <node begin="2" cat="pp" end="11" id="5" rel="mod">
+            <node begin="2" end="3" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="6" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="3" cat="conj" end="11" id="7" rel="obj1">
+              <node begin="3" cat="np" end="5" id="8" rel="cnj">
+                <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="9" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="4" end="5" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="game" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="game" sense="game" special="tmp" word="game"/>
+              </node>
+              <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="11" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="6" cat="np" end="11" id="12" rel="cnj">
+                <node begin="6" end="7" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="13" lcat="advp" lemma="hier" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="mod" root="hier" sense="hier" special="er_loc" status="vol" vwtype="aanw" word="hier"/>
+                <node begin="7" end="8" frame="determiner(een)" his="normal" his_1="normal" id="14" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="8" end="9" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="recensie" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="recensie" sense="recensie" word="recensie"/>
+                <node begin="9" cat="pp" end="11" id="16" rel="mod">
+                  <node begin="9" end="10" frame="preposition(over,[heen])" his="normal" his_1="normal" id="17" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sense="over" vztype="init" word="over"/>
+                  <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="schrijven" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="schrijven" sense="schrijven" word="schrijven"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="11" end="12" frame="verb(hebben,sg3,so_copula)" his="normal" his_1="normal" id="19" infl="sg3" lcat="smain" lemma="lijken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="lijk" sc="so_copula" sense="lijk" stype="declarative" tense="present" word="lijkt" wvorm="pv"/>
+        <node begin="12" case="dat_acc" def="def" end="13" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="20" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj2" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+        <node begin="13" cat="np" end="16" id="21" rel="predc">
+          <node begin="13" end="14" frame="determiner(een)" his="normal" his_1="normal" id="22" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="14" buiging="met-e" end="15" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="23" infl="e" lcat="ap" lemma="ideaal" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="ideaal" sense="ideaal" vform="adj" word="ideale"/>
+          <node begin="15" end="16" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="24" lcat="np" lemma="baan" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="baan" sense="baan" word="baan"/>
+        </node>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="25" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het testen van een game en hier een recensie over schrijven lijkt mij een ideale baan .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="3" rel="--">
+        <node begin="0" cat="np" end="7" id="4" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+          <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="voorstel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="voorstel" sense="voorstel" word="voorstel"/>
+          <node begin="3" cat="rel" end="7" id="7" rel="mod">
+            <node begin="3" end="4" frame="waar_adverb(over)" his="normal" his_1="normal" id="8" index="2" lcat="pp" lemma="waarover" pos="pp" postag="BW()" pt="bw" rel="rhd" root="waarover" sense="waarover" special="waar" word="waarover"/>
+            <node begin="3" cat="ssub" end="7" id="9" rel="body">
+              <node begin="3" end="4" id="10" index="2" rel="mod"/>
+              <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="11" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node begin="5" case="both" def="def" end="6" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="getal" his="normal" his_1="normal" id="12" lcat="np" lemma="je" naamval="obl" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pr,pron,obl,red,2v,getal)" pt="vnw" rel="obj1" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pr" wh="nwh" word="je"/>
+              <node begin="6" end="7" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="13" infl="sg" lcat="ssub" lemma="vertellen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="vertel" sc="transitive" sense="vertel" tense="past" word="vertelde" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="8" end="9" frame="verb(unacc,sg_is,passive)" his="normal" his_1="normal" id="14" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="10" id="15" rel="vc">
+          <node begin="0" end="7" id="16" index="1" rel="obj1"/>
+          <node begin="9" buiging="zonder" end="10" frame="verb(hebben,psp,ninv(transitive,part_transitive(aan)))" his="normal" his_1="part-V" id="17" infl="psp" lcat="ppart" lemma="aan_nemen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="neem_aan" sc="part_transitive(aan)" sense="neem_aan" word="aangenomen" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het voorstel , waarover ik je vertelde , is aangenomen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="31" id="0" rel="top">
+      <node begin="22" end="23" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="30" id="2" rel="--">
+        <node begin="0" cat="whsub" end="22" id="3" rel="su">
+          <node begin="0" end="1" frame="wh_adjective" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="whd" root="hoe" sense="hoe" wh="ywh" word="Hoe"/>
+          <node begin="0" cat="ssub" end="22" id="5" rel="body">
+            <node begin="1" cat="np" end="3" id="6" index="2" rel="su">
+              <node begin="1" buiging="met-e" end="2" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+              <node begin="2" end="3" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="mens" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="mens" sense="mens" word="mensen"/>
+            </node>
+            <node begin="5" end="6" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="9" infl="pl" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="present" word="zijn" wvorm="pv"/>
+            <node begin="0" cat="ppart" end="22" id="10" rel="vc">
+              <node begin="0" end="1" id="11" index="1" rel="mod"/>
+              <node begin="1" end="3" id="12" index="2" rel="su"/>
+              <node begin="6" buiging="zonder" end="7" frame="verb(unacc,psp,copula)" his="normal" his_1="normal" id="13" infl="psp" lcat="ppart" lemma="zijn" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="copula" sense="ben" word="geweest" wvorm="vd"/>
+              <node begin="3" cat="ap" end="22" id="14" rel="predc">
+                <node begin="3" cat="mwu" end="5" his="normal" his_1="normal" id="15" rel="hd">
+                  <node aform="base" begin="3" end="4" frame="adjective(pred(padv),object_vp)" id="16" infl="pred" lcat="ap" lemma="in" pos="adj" postag="VZ(init)" pt="vz" rel="mwp" root="in" sc="object_vp" sense="in" vform="adj" vztype="init" word="in"/>
+                  <node aform="base" begin="4" end="5" frame="adjective(pred(padv),object_vp)" genus="zijd" getal="ev" graad="basis" id="17" infl="pred" lcat="ap" lemma="staat" naamval="stan" ntype="soort" pos="adj" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mwp" root="staat" sc="object_vp" sense="staat" vform="adj" word="staat"/>
+                </node>
+                <node begin="7" cat="oti" end="22" id="18" rel="vc">
+                  <node begin="7" end="8" frame="complementizer(om)" his="normal" his_1="normal" id="19" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+                  <node begin="8" cat="ti" end="22" id="20" rel="body">
+                    <node begin="14" end="15" frame="complementizer(te)" his="normal" his_1="normal" id="21" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                    <node begin="8" cat="inf" end="22" id="22" rel="body">
+                      <node begin="8" cat="pp" end="10" id="23" rel="mod">
+                        <node begin="8" end="9" frame="preposition(zonder,[])" his="normal" his_1="normal" id="24" lcat="pp" lemma="zonder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="zonder" sense="zonder" vztype="init" word="zonder"/>
+                        <node begin="9" end="10" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="machine" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="machine" sense="machine" word="machines"/>
+                      </node>
+                      <node begin="15" buiging="zonder" end="16" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="26" infl="inf" lcat="inf" lemma="krijgen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="krijg" sc="transitive" sense="krijg" word="krijgen" wvorm="inf"/>
+                      <node begin="10" cat="np" end="22" id="27" rel="obj1">
+                        <node begin="10" end="11" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="steen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="steen" sense="steen" word="stenen"/>
+                        <node begin="11" cat="pp" end="14" id="29" rel="mod">
+                          <node begin="11" end="12" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="30" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                          <node begin="12" cat="np" end="14" id="31" rel="obj1">
+                            <node begin="12" end="13" frame="determiner(de)" his="normal" his_1="normal" id="32" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                            <node begin="13" end="14" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="33" lcat="np" lemma="grond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="grond" sense="grond" word="grond"/>
+                          </node>
+                        </node>
+                        <node begin="16" cat="rel" end="22" id="34" rel="mod">
+                          <node begin="16" case="no_obl" end="17" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="35" index="3" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="pl" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+                          <node begin="16" cat="ssub" end="22" id="36" rel="body">
+                            <node begin="16" end="17" id="37" index="3" rel="su"/>
+                            <node begin="17" end="18" frame="sentence_adverb" his="normal" his_1="normal" id="38" lcat="advp" lemma="soms" pos="adv" postag="BW()" pt="bw" rel="mod" root="soms" sense="soms" special="sentence" word="soms"/>
+                            <node aform="base" begin="18" end="19" frame="adjective(pred(adv))" his="normal" his_1="normal" id="39" infl="pred" lcat="ap" lemma="wel" pos="adj" postag="BW()" pt="bw" rel="mod" root="wel" sense="wel" vform="adj" word="wel"/>
+                            <node begin="19" cat="np" end="21" id="40" rel="me">
+                              <node begin="19" end="20" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="41" infl="pl_num" lcat="detp" lemma="20.000" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="20.000" sense="20.000" word="20.000"/>
+                              <node begin="20" end="21" frame="meas_mod_noun(de,count,meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="42" lcat="np" lemma="kilo" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kilo" sense="kilo" special="meas_mod" word="kilo"/>
+                            </node>
+                            <node begin="21" end="22" frame="verb(hebben,pl,meas)" his="normal" his_1="normal" id="43" infl="pl" lcat="ssub" lemma="wegen" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="weeg" sc="meas" sense="weeg" tense="present" word="wegen" wvorm="pv"/>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="23" end="24" frame="verb(unacc,sg_is,copula_sbar)" his="normal" his_1="normal" id="44" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula_sbar" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="24" end="25" frame="sentence_adverb" his="normal" his_1="normal" id="45" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+        <node begin="25" cat="advp" end="27" id="46" rel="mod">
+          <node begin="25" end="26" frame="modal_adverb" his="normal" his_1="normal" id="47" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sc="modal" sense="nog" word="nog"/>
+          <node begin="26" end="27" frame="adverb" his="normal" his_1="normal" id="48" lcat="advp" lemma="steeds" pos="adv" postag="BW()" pt="bw" rel="hd" root="steeds" sense="steeds" word="steeds"/>
+        </node>
+        <node begin="27" cat="ap" end="30" id="49" rel="predc">
+          <node begin="27" cat="advp" end="29" his="normal" his_1="normal" id="50" rel="mod">
+            <node begin="27" end="28" frame="adverb" id="51" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="28" end="29" frame="adverb" id="52" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="hd" root="helemaal" sense="helemaal" word="helemaal"/>
+          </node>
+          <node aform="base" begin="29" buiging="zonder" end="30" frame="adjective(no_e(adv),subject_sbar_no_het)" graad="basis" his="normal" his_1="normal" id="53" infl="no_e" lcat="ap" lemma="duidelijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="duidelijk" sc="subject_sbar_no_het" sense="duidelijk" vform="adj" word="duidelijk"/>
+        </node>
+      </node>
+      <node begin="30" end="31" frame="punct(punt)" his="normal" his_1="normal" id="54" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hoe deze mensen in staat zijn geweest om zonder machines stenen van de grond te krijgen die soms wel 20.000 kilo wegen , is ook nog steeds niet helemaal duidelijk .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" cat="cp" end="5" id="2" rel="su">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(of)" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="cp" lemma="of" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="of" sc="of" sense="of" word="Of"/>
+          <node begin="1" cat="ssub" end="5" id="4" rel="body">
+            <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="3" end="4" frame="verb(hebben,modal_not_u,aux(inf))" his="normal" his_1="normal" id="6" infl="modal_not_u" lcat="ssub" lemma="zullen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="present" word="zal" wvorm="pv"/>
+            <node begin="1" cat="inf" end="5" id="7" rel="vc">
+              <node begin="1" end="2" id="8" index="1" rel="su"/>
+              <node begin="2" end="3" frame="tmp_adverb" his="normal" his_1="normal" id="9" lcat="advp" lemma="morgen" pos="adv" postag="BW()" pt="bw" rel="mod" root="morgen" sense="morgen" special="tmp" word="morgen"/>
+              <node begin="4" buiging="zonder" end="5" frame="verb(unacc,inf,intransitive)" his="normal" his_1="normal" id="10" infl="inf" lcat="inf" lemma="slagen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="slaag" sc="intransitive" sense="slaag" word="slagen" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(unacc,sg_is,so_copula_sbar)" his="normal" his_1="normal" id="11" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="so_copula_sbar" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="6" case="dat_acc" def="def" end="7" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="12" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj2" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+        <node begin="7" end="8" frame="adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node aform="base" begin="8" buiging="zonder" end="9" frame="adjective(postn_no_e(adv),subject_sbar_no_het)" graad="basis" his="normal" his_1="normal" id="14" infl="no_e" lcat="ap" lemma="bekend" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="bekend" sc="subject_sbar_no_het" sense="bekend" vform="adj" word="bekend"/>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Of ik morgen zal slagen is mij niet bekend .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="8" id="2" rel="--">
+        <node begin="0" cat="whrel" end="4" id="3" index="1" rel="su">
+          <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="4" index="2" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="rhd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="Wie"/>
+          <node begin="0" cat="ssub" end="4" id="5" rel="body">
+            <node begin="0" end="1" id="6" index="2" rel="su"/>
+            <node begin="1" cat="np" end="3" id="7" rel="obj1">
+              <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="ver" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="ver" sense="ver" vform="adj" word="verre"/>
+              <node begin="2" end="3" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="reis" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="reis" sense="reis" special="tmp" word="reizen"/>
+            </node>
+            <node begin="3" end="4" frame="verb(hebben,sg3,transitive_ndev)" his="normal" his_1="normal" id="10" infl="sg3" lcat="ssub" lemma="doen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="doe" sc="transitive_ndev" sense="doe" tense="present" word="doet" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb('hebben/zijn',modal_not_u,aux(inf))" his="normal" his_1="normal" id="11" infl="modal_not_u" lcat="smain" lemma="kunnen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kan" sc="aux(inf)" sense="kan" stype="declarative" tense="present" word="kan" wvorm="pv"/>
+        <node begin="0" cat="inf" end="8" id="12" rel="vc">
+          <node begin="0" end="4" id="13" index="1" rel="su"/>
+          <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(odet_adv))" graad="basis" his="normal" his_1="normal" id="14" infl="no_e" lcat="np" lemma="veel" naamval="stan" pdtype="grad" pos="adj" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,basis)" pt="vnw" rel="obj1" rnum="sg" root="veel" sense="veel" vform="adj" vwtype="onbep" word="veel"/>
+          <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="15" infl="inf" lcat="inf" lemma="verhalen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="verhaal" sc="transitive" sense="verhaal" word="verhalen" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wie verre reizen doet , kan veel verhalen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:19" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="9" id="2" rel="--">
+        <node begin="0" cat="whrel" end="4" id="3" rel="su">
+          <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="rhd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="Wie"/>
+          <node begin="0" cat="ssub" end="4" id="5" rel="body">
+            <node begin="0" end="1" id="6" index="1" rel="su"/>
+            <node begin="1" cat="np" end="3" id="7" rel="obj1">
+              <node begin="1" end="2" frame="iets_noun" getal="ev" his="normal" his_1="normal" id="8" lcat="np" lemma="zoiets" naamval="stan" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="hd" rnum="sg" root="zoiets" sc="iets" sense="zoiets" status="vol" vwtype="onbep" word="zoiets"/>
+              <node aform="base" begin="2" buiging="met-s" end="3" frame="post_adjective(no_e)" graad="basis" his="normal" his_1="Adj-s" id="9" iets="true" infl="no_e" lcat="ap" lemma="dapper" pos="adj" positie="postnom" postag="ADJ(postnom,basis,met-s)" pt="adj" rel="mod" root="dapper" sense="dapper" special="iets" vform="adj" word="dappers"/>
+            </node>
+            <node begin="3" end="4" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="10" infl="sg3" lcat="ssub" lemma="presteren" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="presteer" sc="transitive" sense="presteer" tense="present" word="presteert" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="11" infl="sg3" lcat="smain" lemma="verdienen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="verdien" sc="transitive" sense="verdien" stype="declarative" tense="present" word="verdient" wvorm="pv"/>
+        <node begin="6" cat="np" end="9" id="12" rel="obj1">
+          <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="13" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="7" buiging="met-e" end="8" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="14" infl="e" lcat="ap" lemma="hoog" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="hoog" sense="hoog" vform="adj" word="hoge"/>
+          <node begin="8" end="9" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="beloning" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="beloning" sense="beloning" word="beloning"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wie zoiets dappers presteert , verdient een hoge beloning .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/dlevel6.example.ok
+++ b/tests/dlevel6.example.ok
@@ -1194,26 +1194,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zal</t>
-                <feat class="[zal]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zal</t>
-                  <feat class="[zal]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.2.s.1.w.4.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zal</t>
                 <feat class="[zal]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -3969,30 +3949,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.2.s.5.w.10.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>aangenomen</t>
-                <feat class="[[aan]unanalysed[ge]/participle/past-tense[neemen]verb]verb" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>aan</t>
-                  <feat class="[aan]unanalysed" subset="structure"/>
-                  <pos class="X" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>ge</t>
-                  <feat class="participle" subset="inflection"/>
-                  <feat class="past-tense" subset="inflection"/>
-                </morpheme>
-                <morpheme class="stem">
-                  <t>neemen</t>
-                  <feat class="[neemen]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -8319,26 +8275,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.3.s.1.w.6.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kan</t>
-                <feat class="[kan]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kan</t>
-                  <feat class="[kan]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.3.s.1.w.6.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>kan</t>

--- a/tests/flair1.example.alpino
+++ b/tests/flair1.example.alpino
@@ -1,0 +1,888 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="mwu" end="2" his="robust_skip" id="1" rel="--">
+        <node begin="0" end="1" frame="punct(aanhaal_both)" id="2" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+        <node begin="1" end="2" frame="punct(aanhaal_both)" id="3" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="mwp" root="'" sense="'" special="aanhaal_both" word="'"/>
+      </node>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="4" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="2" cat="smain" end="8" id="5" rel="--">
+        <node begin="5" end="6" frame="verb(zijn,pl,aux(inf))" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ga" sc="aux(inf)" sense="ga" stype="declarative" tense="present" word="gaan" wvorm="pv"/>
+        <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+        <node begin="2" cat="inf" end="8" id="8" rel="vc">
+          <node begin="2" cat="np" end="4" id="9" rel="obj1">
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="10" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="Goed"/>
+            <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zoon" sense="zoon" word="zoon"/>
+          </node>
+          <node begin="6" end="7" id="12" index="1" rel="su"/>
+          <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf(no_e),transitive_ndev)" his="normal" his_1="normal" id="13" infl="inf(no_e)" lcat="inf" lemma="doen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="doe" sc="transitive_ndev" sense="doe" word="doen" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="robust_skip" id="14" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' ' Goed zoon , gaan we doen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="12" id="2" rel="--">
+        <node begin="8" end="9" frame="verb('hebben/zijn',modal_not_u,aux(inf))" his="normal" his_1="normal" id="3" infl="modal_not_u" lcat="smain" lemma="kunnen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kan" sc="aux(inf)" sense="kan" stype="declarative" tense="present" word="kan" wvorm="pv"/>
+        <node begin="9" case="both" def="def" end="10" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="4" index="1" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+        <node begin="0" cat="inf" end="12" id="5" rel="vc">
+          <node begin="0" cat="conj" end="8" id="6" rel="obj1">
+            <node begin="0" cat="mwu" end="6" his="name" his_1="begin" id="7" rel="cnj">
+              <node begin="0" end="1" frame="proper_name(both)" id="8" lcat="np" lemma="'" neclass="MISC" num="both" pos="name" postag="LET()" pt="let" rel="mwp" rnum="sg" root="'" sense="'" word="'"/>
+              <node begin="1" end="2" frame="proper_name(both)" id="9" lcat="np" lemma="'" neclass="MISC" num="both" pos="name" postag="LET()" pt="let" rel="mwp" rnum="sg" root="'" sense="'" word="'"/>
+              <node begin="2" end="3" frame="proper_name(both)" id="10" lcat="np" lemma="Ok" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Ok" sense="Ok" spectype="deeleigen" word="Ok"/>
+              <node begin="3" end="4" frame="proper_name(both)" id="11" lcat="np" lemma="man" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="man" sense="man" spectype="deeleigen" word="man"/>
+              <node begin="4" end="5" frame="proper_name(both)" id="12" lcat="np" lemma="," neclass="MISC" num="both" pos="name" postag="LET()" pt="let" rel="mwp" rnum="sg" root="," sense="," word=","/>
+              <node begin="5" end="6" frame="proper_name(both)" id="13" lcat="np" lemma="cool" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="cool" sense="cool" spectype="deeleigen" word="cool"/>
+            </node>
+            <node begin="7" end="8" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="14" lcat="np" lemma="Ollie" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="Ollie" sense="Ollie" word="Ollie"/>
+          </node>
+          <node begin="9" end="10" id="15" index="1" rel="su"/>
+          <node aform="base" begin="10" end="11" frame="adjective(both(tmpadv))" his="normal" his_1="variant" id="16" infl="both" lcat="ap" lemma="even" pos="adj" postag="BW()" pt="bw" rel="mod" root="even" sense="even" vform="adj" word="ff"/>
+          <node begin="11" buiging="zonder" end="12" frame="verb(hebben,inf,transitive_ndev)" his="normal" his_1="normal" id="17" infl="inf" lcat="inf" lemma="helpen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="help" sc="transitive_ndev" sense="help" word="helpen" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(vraag)" his="normal" his_1="normal" id="18" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">' ' Ok man , cool , Ollie kan je ff helpen ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="0" skips="0"/>
+    <node begin="0" cat="top" end="2" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="robust_skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" end="2" frame="punct(hellip)" his="robust_skip" id="2" lcat="--" lemma="..." pos="punct" postag="LET()" pt="let" rel="--" root="..." sense="..." special="hellip" word="..."/>
+    </node>
+    <sentence sentid="127.0.0.1">' ...</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" end="2" frame="--" his="skip" id="2" lcat="--" lemma="Euh" pos="--" postag="TSW()" pt="tsw" rel="--" root="Euh" sense="Euh" word="Euh"/>
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="3" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="2" cat="du" end="10" id="4" rel="--">
+        <node begin="2" cat="du" end="4" id="5" rel="dp">
+          <node begin="2" end="3" frame="tag" his="normal" his_1="normal" id="6" lcat="advp" lemma="ja" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="ja" sense="ja" word="ja"/>
+          <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="zeker" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="nucl" root="zeker" sense="zeker" vform="adj" word="zeker"/>
+        </node>
+        <node begin="5" cat="du" end="10" id="8" rel="dp">
+          <node begin="5" end="6" frame="noun(het,mass,sg)" gen="het" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="alles" naamval="stan" num="sg" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="dp" rnum="sg" root="alles" sense="alles" status="vol" vwtype="onbep" word="alles"/>
+          <node begin="6" cat="np" end="10" id="10" rel="dp">
+            <node begin="6" end="7" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="11" lcat="np" lemma="kits" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kits" sense="kits" word="kits"/>
+            <node begin="7" cat="pp" end="10" id="12" rel="mod">
+              <node begin="7" end="8" frame="preposition(achter,[aan,door,langs,om,uit,vandaan])" his="normal" his_1="normal" id="13" lcat="pp" lemma="achter" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="achter" sense="achter" vztype="init" word="achter"/>
+              <node begin="8" cat="np" end="10" id="14" rel="obj1">
+                <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="15" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="16" lcat="np" lemma="rits" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="rits" sense="rits" word="rits"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(hellip)" his="normal" his_1="normal" id="17" lcat="punct" lemma="..." pos="punct" postag="LET()" pt="let" rel="--" root="..." sense="..." special="hellip" word="..."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Euh ja zeker , alles kits achter de rits ...</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="11" id="3" rel="--">
+        <node begin="1" end="2" frame="tag" his="normal" his_1="decap" his_1_1="variant" his_1_1_1="variant" his_1_1_1_1="goedemiddag" his_1_1_1_2="goeiemiddag" his_1_1_2="normal" id="4" lcat="advp" lemma="goedemiddag" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="goedemiddag" sense="goedemiddag" word="Goeiemiddag"/>
+        <node begin="3" cat="smain" end="11" id="5" rel="nucl">
+          <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="4" end="5" frame="verb(unacc,sg1,intransitive)" his="normal" his_1="normal" id="7" infl="sg1" lcat="smain" lemma="komen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kom" sc="intransitive" sense="kom" stype="declarative" tense="present" word="kom" wvorm="pv"/>
+          <node begin="5" cat="pp" end="11" id="8" rel="mod">
+            <node begin="5" end="6" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="9" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+            <node begin="6" cat="np" end="11" id="10" rel="obj1">
+              <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="11" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="7" end="8" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="skateboard" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="skateboard" sense="skateboard" word="skateboard"/>
+              <node begin="8" cat="pp" end="11" id="13" rel="mod">
+                <node begin="8" end="9" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="14" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+                <node begin="9" cat="np" end="11" id="15" rel="obj1">
+                  <node begin="9" buiging="zonder" end="10" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="16" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+                  <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="17" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="zoon_DIM" sense="zoon_DIM" word="zoontje"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Goeiemiddag , ik kom voor een skateboard voor mijn zoontje .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" cat="smain" end="7" id="2" rel="--">
+        <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+        <node begin="2" end="3" frame="verb(hebben,sg3,vp)" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="beloven" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="beloof" sc="vp" sense="beloof" stype="declarative" tense="present" word="belooft" wvorm="pv"/>
+        <node begin="1" cat="ti" end="7" id="5" rel="vc">
+          <node begin="5" end="6" frame="complementizer(te)" his="normal" his_1="normal" id="6" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="1" cat="inf" end="7" id="7" rel="body">
+            <node begin="1" end="2" id="8" index="1" rel="su"/>
+            <node begin="3" cat="np" end="5" id="9" rel="predc">
+              <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="10" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="4" end="5" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="11" lcat="np" lemma="man_dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man_dag" sense="man_dag" special="tmp" word="mannendag"/>
+            </node>
+            <node begin="6" buiging="zonder" end="7" frame="verb(unacc,inf,copula)" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="worden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="word" sc="copula" sense="word" word="worden" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Het belooft een mannendag te worden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="6" id="3" rel="--">
+        <node begin="1" end="2" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="advp" lemma="hey" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="hey" sense="hey" word="Hey"/>
+        <node begin="2" cat="np" end="6" id="5" rel="nucl">
+          <node begin="2" end="3" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="4" cat="mwu" end="6" his="name" his_1="not_begin" id="7" rel="app">
+            <node begin="4" end="5" frame="proper_name(both,'ORG')" id="8" lcat="np" lemma="alles" neclass="ORG" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="alles" sense="alles" spectype="deeleigen" word="alles"/>
+            <node begin="5" end="6" frame="proper_name(both,'ORG')" id="9" lcat="np" lemma="flex" neclass="ORG" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="flex" sense="flex" spectype="deeleigen" word="flex"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(vraag)" his="normal" his_1="normal" id="10" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">' Hey man , alles flex ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" cat="smain" end="8" id="2" rel="--">
+        <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="2" end="3" frame="verb(hebben,sg1,aci)" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="voelen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="voel" sc="aci" sense="voel" stype="declarative" tense="present" word="voel" wvorm="pv"/>
+        <node begin="3" cat="np" end="5" id="5" index="1" rel="obj1">
+          <node begin="3" buiging="zonder" end="4" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="6" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+          <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="7" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="zoon_DIM" sense="zoon_DIM" word="zoontje"/>
+        </node>
+        <node begin="3" cat="inf" end="8" id="8" rel="vc">
+          <node begin="3" end="5" id="9" index="1" rel="su"/>
+          <node begin="5" cat="np" end="7" id="10" rel="obj1">
+            <node begin="5" end="6" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="11" infl="pl_num" lcat="detp" lemma="duizend" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="duizend" sense="duizend" word="duizend"/>
+            <node begin="6" buiging="met-e" end="7" frame="noun(de,count,pl)" gen="de" getal-n="mv-n" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="dood" num="pl" pos="noun" positie="nom" postag="ADJ(nom,basis,met-e,mv-n)" pt="adj" rel="hd" rnum="pl" root="dode" sense="dode" word="doden"/>
+          </node>
+          <node begin="7" buiging="zonder" end="8" frame="verb(unacc,inf,transitive)" his="normal" his_1="normal" id="13" infl="inf" lcat="inf" lemma="sterven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sterf" sc="transitive" sense="sterf" word="sterven" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Ik voel mijn zoontje duizend doden sterven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="15" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="1" cat="smain" end="14" id="2" rel="--">
+        <node begin="1" end="2" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" index="1" lcat="np" lemma="Ollie" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="su" rnum="sg" root="Ollie" sense="Ollie" word="Ollie"/>
+        <node begin="2" end="3" frame="verb(unacc,sg3,aux(te))" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="blijken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="blijk" sc="aux(te)" sense="blijk" stype="declarative" tense="present" word="blijkt" wvorm="pv"/>
+        <node begin="1" cat="ti" end="14" id="5" rel="vc">
+          <node begin="12" end="13" frame="complementizer(te)" his="normal" his_1="normal" id="6" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="1" cat="inf" end="14" id="7" rel="body">
+            <node begin="1" end="2" id="8" index="1" rel="su"/>
+            <node begin="3" cat="np" end="12" id="9" rel="predc">
+              <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="10" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="11" infl="both" lcat="ppart" lemma="op_schieten" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="mod" root="op_schieten" sense="op_schieten" vform="psp" word="opgeschoten" wvorm="vd"/>
+              <node aform="base" begin="5" buiging="met-e" end="6" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="12" infl="e" lcat="ap" lemma="lang" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="lang" sense="lang" vform="adj" word="lange"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="jongen" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="jongen" sense="jongen" word="jongen"/>
+              <node begin="7" cat="pp" end="12" id="14" rel="mod">
+                <node begin="7" end="8" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="15" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                <node begin="8" cat="np" end="12" his="normal" his_1="een_N_of_NUM" id="16" rel="obj1">
+                  <node begin="9" end="10" frame="tmp_noun(het,count,bare_meas)" gen="het" genus="onz" getal="ev" graad="basis" id="17" lcat="np" lemma="jaar" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" root="jaar" sense="jaar" special="tmp" word="jaar"/>
+                  <node begin="8" cat="detp" end="12" id="18" rel="det">
+                    <node begin="8" cat="mwu" end="11" id="19" rel="mod">
+                      <node begin="8" end="9" frame="determiner(een)" id="20" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="mwp" root="een" sense="een" word="een"/>
+                      <node begin="10" conjtype="neven" end="11" frame="conj(of)" id="21" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="mwp" root="of" sense="of" word="of"/>
+                    </node>
+                    <node begin="11" end="12" frame="number(hoofd(pl_num))" id="22" infl="pl_num" lcat="detp" lemma="twintig" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="hd" root="twintig" sense="twintig" word="twintig"/>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node begin="13" buiging="zonder" end="14" frame="verb(unacc,inf,copula)" his="normal" his_1="normal" id="23" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="copula" sense="ben" word="zijn" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="14" end="15" frame="punct(punt)" his="normal" his_1="normal" id="24" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Ollie blijkt een opgeschoten lange jongen van een jaar of twintig te zijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="9" id="3" rel="--">
+        <node begin="1" end="2" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="advp" lemma="pap" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="pap" sense="pap" word="Pap"/>
+        <node begin="3" cat="smain" end="9" id="5" rel="nucl">
+          <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="4" end="5" frame="verb(hebben,sg,tr_sbar)" his="normal" his_1="normal" id="7" infl="sg" lcat="smain" lemma="weten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="weet" sc="tr_sbar" sense="weet" stype="declarative" tense="present" word="weet" wvorm="pv"/>
+          <node begin="5" cat="whsub" end="9" id="8" rel="vc">
+            <node begin="5" end="6" frame="er_wh_loc_adverb" getal="getal" his="normal" his_1="normal" id="9" index="1" lcat="advp" lemma="waar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(vb,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="whd" root="waar" sense="waar" special="er_loc" status="vol" vwtype="vb" wh="ywh" word="waar"/>
+            <node begin="5" cat="ssub" end="9" id="10" rel="body">
+              <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="11" index="2" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+              <node begin="7" end="8" frame="verb('hebben/zijn',pl,modifier(aux(inf)))" his="normal" his_1="normal" id="12" infl="pl" lcat="ssub" lemma="moeten" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" tense="present" word="moeten" wvorm="pv"/>
+              <node begin="5" cat="inf" end="9" id="13" rel="vc">
+                <node begin="5" end="6" id="14" index="1" rel="ld"/>
+                <node begin="6" end="7" id="15" index="2" rel="su"/>
+                <node begin="8" buiging="zonder" end="9" frame="verb(unacc,inf,ld_adv)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="ld_adv" sense="ben" word="zijn" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Pap , ik weet waar we moeten zijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="10" id="3" rel="--">
+        <node begin="1" end="2" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="advp" lemma="pap" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="pap" sense="pap" word="Pap"/>
+        <node begin="3" cat="smain" end="10" id="5" rel="nucl">
+          <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="4" end="5" frame="verb(hebben,modal_not_u,transitive_ndev_ndev)" his="normal" his_1="normal" id="7" infl="modal_not_u" lcat="smain" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="transitive_ndev_ndev" sense="wil" stype="declarative" tense="present" word="wil" wvorm="pv"/>
+          <node begin="5" cat="np" end="10" id="8" rel="obj1">
+            <node begin="5" end="6" frame="determiner(een)" his="normal" his_1="normal" id="9" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="6" end="7" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="skateboard" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="skateboard" sense="skateboard" word="skateboard"/>
+            <node begin="7" cat="pp" end="10" id="11" rel="mod">
+              <node begin="7" end="8" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="12" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+              <node begin="8" cat="np" end="10" id="13" rel="obj1">
+                <node begin="8" buiging="zonder" end="9" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="14" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+                <node begin="9" end="10" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="verjaar_dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verjaar_dag" sense="verjaar_dag" special="tmp" word="verjaardag"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Pap , ik wil een skateboard voor mijn verjaardag .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="25" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="smain" end="24" id="3" rel="--">
+        <node begin="1" cat="cp" end="5" id="4" rel="mod">
+          <node begin="1" conjtype="onder" end="2" frame="complementizer" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="cp" lemma="toen" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="toen" sense="toen" word="Toen"/>
+          <node begin="2" cat="ssub" end="5" id="6" rel="body">
+            <node begin="2" case="nom" def="def" end="3" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="3" end="4" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="8" infl="pl_num" lcat="np" lemma="tien" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="predc" root="tien" sense="tien" word="tien"/>
+            <node begin="4" end="5" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="9" infl="sg" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" tense="past" word="was" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="6" end="7" frame="verb(hebben,past(pl),transitive)" his="normal" his_1="normal" id="10" infl="pl" lcat="smain" lemma="maken" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="maak" sc="transitive" sense="maak" stype="declarative" tense="past" word="maakten" wvorm="pv"/>
+        <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="11" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+        <node begin="8" end="9" frame="predm_adverb" his="normal" his_1="normal" id="12" lcat="advp" lemma="zelf" pos="adv" postag="BW()" pt="bw" rel="predm" root="zelf" sense="zelf" special="predm" word="zelf"/>
+        <node begin="9" cat="np" end="24" id="13" rel="obj1">
+          <node begin="9" end="10" frame="determiner(een)" his="normal" his_1="normal" id="14" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="skateboard" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="skateboard" sense="skateboard" word="skateboard"/>
+          <node begin="11" cat="pp" end="24" id="16" rel="mod">
+            <node begin="11" end="12" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="17" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="12" cat="conj" end="24" id="18" rel="obj1">
+              <node begin="14" conjtype="neven" end="15" frame="conj(en)" his="normal" his_1="normal" id="19" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="12" cat="np" end="24" id="20" rel="cnj">
+                <node begin="12" end="13" frame="determiner(een)" his="normal" his_1="normal" id="21" index="1" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="13" end="14" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="22" lcat="np" lemma="plank" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="plank" sense="plank" word="plank"/>
+                <node begin="17" cat="pp" end="24" id="23" index="2" rel="mod">
+                  <node begin="17" end="18" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="24" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                  <node begin="18" cat="np" end="24" id="25" rel="obj1">
+                    <node begin="18" end="19" frame="determiner(een)" his="normal" his_1="normal" id="26" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                    <node aform="base" begin="19" buiging="zonder" end="20" frame="adjective(ge_both(adv))" his="normal" his_1="normal" id="27" infl="both" lcat="ppart" lemma="vinden" pos="adj" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="mod" root="vinden" sense="vinden" vform="psp" word="gevonden" wvorm="vd"/>
+                    <node begin="20" end="21" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="28" lcat="np" lemma="winkel_kar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="winkel_kar" sense="winkel_kar" word="winkelkar"/>
+                    <node begin="21" cat="pp" end="24" id="29" rel="mod">
+                      <node begin="21" end="22" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="30" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                      <node begin="22" cat="np" end="24" id="31" rel="obj1">
+                        <node begin="22" end="23" frame="determiner(de)" his="normal" his_1="normal" id="32" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                        <node begin="23" end="24" frame="proper_name(sg,'ORG')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="33" lcat="np" lemma="Aldi" naamval="stan" neclass="ORG" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Aldi" sense="Aldi" word="Aldi"/>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node begin="12" cat="np" end="24" id="34" rel="cnj">
+                <node begin="12" end="13" id="35" index="1" rel="det"/>
+                <node begin="15" end="16" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="36" infl="pl_num" lcat="detp" lemma="vier" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="vier" sense="vier" word="vier"/>
+                <node begin="16" end="17" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="37" lcat="np" lemma="wiel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="wiel_DIM" sense="wiel_DIM" word="wieltjes"/>
+                <node begin="17" end="24" id="38" index="2" rel="mod"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="24" end="25" frame="punct(punt)" his="normal" his_1="normal" id="39" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Toen ik tien was , maakten we zelf een skateboard met een plank en vier wieltjes van een gevonden winkelkar van de Aldi .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" end="1" frame="punct(aanhaal_both)" his="skip" id="1" lcat="--" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="1" cat="du" end="11" id="3" rel="--">
+        <node begin="1" end="2" frame="verb(hebben,sg3,ninv(incorporated_subj_topic(intransitive),incorporated_subj_topic(intransitive)))" his="normal" his_1="decap" his_1_1="normal" id="4" infl="sg3" lcat="smain" lemma="ziehier" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="nucl" root="ziehier" sc="incorporated_subj_topic(intransitive)" sense="ziehier" stype="declarative" tense="present" word="Ziehier" wvorm="pv"/>
+        <node begin="3" cat="np" end="11" id="5" rel="sat">
+          <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="6" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="4" buiging="met-e" end="5" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="7" infl="e" lcat="ap" lemma="summier" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="summier" sense="summier" vform="adj" word="summiere"/>
+          <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="samenvatting" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="samenvatting" sense="samenvatting" word="samenvatting"/>
+          <node begin="6" cat="pp" end="11" id="9" rel="mod">
+            <node begin="6" end="7" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="10" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="7" cat="np" end="11" id="11" rel="obj1">
+              <node begin="7" end="8" frame="determiner(een)" his="normal" his_1="normal" id="12" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node aform="base" begin="8" buiging="zonder" end="9" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="13" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="goed"/>
+              <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(prefix)" graad="basis" his="normal" his_1="normal" id="14" infl="prefix" lcat="ap" lemma="vader zoon" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="vader zoon" sense="vader zoon" vform="adj" word="vader-zoon"/>
+              <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="gesprek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="gesprek" sense="gesprek" word="gesprek"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">' Ziehier , een summiere samenvatting van een goed vader-zoon gesprek .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="3" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="11" end="12" frame="punct(komma)" his="robust_skip" id="1" lcat="--" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="18" id="2" rel="--">
+        <node begin="0" cat="smain" end="9" id="3" rel="dp">
+          <node begin="0" cat="pp" end="3" id="4" rel="mod">
+            <node begin="0" end="1" frame="preposition(achterin,[])" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="pp" lemma="achterin" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="achterin" sense="achterin" vztype="init" word="Achterin"/>
+            <node begin="1" cat="np" end="3" id="6" rel="obj1">
+              <node begin="1" end="2" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="winkel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="winkel" sense="winkel" word="winkel"/>
+            </node>
+          </node>
+          <node begin="3" end="4" frame="verb(hebben,sg3,part_ld_transitive(in))" his="normal" his_1="normal" id="9" infl="sg3" lcat="smain" lemma="in_staan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="sta_in" sc="part_ld_transitive(in)" sense="sta_in" stype="declarative" tense="present" word="staat" wvorm="pv"/>
+          <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node begin="5" end="6" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="doos" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="ld" rnum="pl" root="doos" sense="doos" word="dozen"/>
+          <node begin="6" cat="conj" end="9" id="12" rel="svp">
+            <node begin="6" end="7" frame="particle(in)" his="normal" his_1="normal" id="13" lcat="part" lemma="in" pos="part" postag="VZ(fin)" pt="vz" rel="cnj" root="in" sense="in" vztype="fin" word="in"/>
+            <node begin="7" conjtype="neven" end="8" frame="conj(of)" his="normal" his_1="normal" id="14" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+            <node begin="8" end="9" frame="particle(uit)" his="normal" his_1="normal" id="15" lcat="part" lemma="uit" pos="part" postag="VZ(fin)" pt="vz" rel="cnj" root="uit" sense="uit" vztype="fin" word="uit"/>
+          </node>
+        </node>
+        <node begin="9" cat="ti" end="11" id="16" rel="dp">
+          <node begin="9" end="10" frame="complementizer(te)" his="normal" his_1="normal" id="17" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="18" infl="inf" lcat="inf" lemma="pakken" pos="verb" positie="prenom" postag="WW(inf,prenom,zonder)" pt="ww" rel="body" root="pak" sc="transitive" sense="pak" word="pakken" wvorm="inf"/>
+        </node>
+        <node begin="12" cat="smain" end="18" id="19" rel="dp">
+          <node begin="12" end="13" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="20" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+          <node begin="13" end="14" frame="verb(unacc,sg_is,so_copula)" his="normal" his_1="normal" id="21" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="so_copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="14" case="dat_acc" def="def" end="15" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="22" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj2" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+          <node begin="15" cat="advp" end="17" his="normal" his_1="normal" id="23" rel="mod">
+            <node begin="15" end="16" frame="adverb" id="24" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="16" end="17" frame="adverb" id="25" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="hd" root="helemaal" sense="helemaal" word="helemaal"/>
+          </node>
+          <node aform="base" begin="17" buiging="zonder" end="18" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="26" infl="no_e" lcat="ap" lemma="duidelijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="duidelijk" sense="duidelijk" vform="adj" word="duidelijk"/>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(punt)" his="robust_skip" id="27" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Achterin de winkel staat hij dozen in of uit te pakken , dat is mij niet helemaal duidelijk .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="ap" end="7" id="1" rel="--">
+        <node aform="base" begin="0" buiging="zonder" end="1" frame="adjective(no_e(adv))" graad="basis" his="compound" his_1="2" id="2" infl="no_e" lcat="ap" lemma="Camel_kleurig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="Camel_kleurig" sense="Camel_kleurig" vform="adj" word="Camelkleurig"/>
+        <node begin="1" cat="pp" end="7" id="3" rel="mod">
+          <node begin="1" end="2" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="4" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="2" cat="np" end="7" id="5" rel="obj1">
+            <node begin="2" end="3" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="wol" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wol" sense="wol" word="wol"/>
+            <node begin="3" cat="pp" end="7" id="7" rel="mod">
+              <node begin="3" end="4" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="4" cat="np" end="7" id="9" rel="obj1">
+                <node begin="4" end="5" frame="determiner(een)" his="normal" his_1="normal" id="10" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="fijn" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="fijn" sense="fijn" vform="adj" word="fijn"/>
+                <node begin="6" end="7" frame="noun(both,both,both)" gen="both" genus="onz" getal="ev" graad="dim" his="noun" id="12" lcat="np" lemma="visgraatje" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="visgraatje" sense="visgraatje" word="visgraatje"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Camelkleurig van wol met een fijn visgraatje .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="20" id="0" rel="top">
+      <node begin="14" end="15" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="19" id="2" rel="--">
+        <node begin="0" cat="smain" end="14" id="3" rel="nucl">
+          <node begin="0" cat="np" end="2" id="4" rel="su">
+            <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+            <node begin="1" end="2" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="muziek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="muziek" sense="muziek" word="muziek"/>
+          </node>
+          <node begin="2" end="3" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="7" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="3" cat="conj" end="14" id="8" rel="predc">
+            <node begin="3" cat="ap" end="5" id="9" rel="cnj">
+              <node begin="3" end="4" frame="adverb" getal="ev" his="normal" his_1="normal" id="10" index="1" lcat="advp" lemma="wat" naamval="stan" pdtype="pron" persoon="3o" pos="adv" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="mod" root="wat" sense="wat" status="vol" vwtype="onbep" word="wat"/>
+              <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="heftig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="heftig" sense="heftig" vform="adj" word="heftig"/>
+            </node>
+            <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="3" cat="ap" end="14" id="13" rel="cnj">
+              <node begin="3" end="4" id="14" index="1" rel="mod"/>
+              <node aform="base" begin="6" end="7" frame="adjective(no_e(adv))" his="normal" his_1="normal" id="15" infl="no_e" lcat="ap" lemma="net" pos="adj" postag="BW()" pt="bw" rel="mod" root="net" sense="net" vform="adj" word="net"/>
+              <node begin="7" cat="ap" end="10" id="16" rel="mod">
+                <node begin="7" cat="advp" end="9" id="17" rel="mod">
+                  <node begin="7" end="8" frame="meas_mod_noun(het,mass,sg)" gen="het" getal="ev" his="normal" his_1="normal" id="18" lcat="np" lemma="iets" naamval="stan" num="sg" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="me" rnum="sg" root="iets" sense="iets" special="meas_mod" status="vol" vwtype="onbep" word="iets"/>
+                  <node begin="8" end="9" frame="me_intensifier" his="normal" his_1="normal" id="19" lcat="advp" lemma="te" pos="adv" postag="BW()" pt="bw" rel="hd" root="te" sense="te" special="me_intensifier" word="te"/>
+                </node>
+                <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="20" infl="no_e" lcat="ap" lemma="hard" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="hard" sense="hard" vform="adj" word="hard"/>
+              </node>
+              <node aform="base" begin="10" end="11" frame="adjective(pred(locadv))" his="normal" his_1="normal" id="21" infl="pred" lcat="ap" lemma="voor" pos="adj" postag="VZ(fin)" pt="vz" rel="hd" root="voor" sense="voor" vform="adj" vztype="fin" word="voor"/>
+              <node begin="11" cat="pp" end="14" id="22" rel="mod">
+                <node begin="11" end="12" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="23" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                <node begin="12" cat="np" end="14" id="24" rel="obj1">
+                  <node begin="12" end="13" frame="determiner(de)" his="normal" his_1="normal" id="25" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="13" end="14" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="26" lcat="np" lemma="achtergrond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="achtergrond" sense="achtergrond" word="achtergrond"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="15" cat="sv1" end="19" id="27" rel="tag">
+          <node begin="15" end="16" frame="verb(hebben,past(sg),aux(inf))" his="normal" his_1="normal" id="28" infl="sg" lcat="sv1" lemma="zullen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="past" word="zou" wvorm="pv"/>
+          <node begin="16" case="nom" def="def" end="17" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="29" index="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="16" cat="inf" end="19" id="30" rel="vc">
+            <node begin="16" end="17" id="31" index="2" rel="su"/>
+            <node begin="17" end="18" frame="adverb" his="normal" his_1="normal" id="32" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="mod" root="zo" sense="zo" word="zo"/>
+            <node begin="18" buiging="zonder" end="19" frame="verb(hebben,inf,tr_sbar)" his="normal" his_1="normal" id="33" infl="inf" lcat="inf" lemma="denken" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="denk" sc="tr_sbar" sense="denk" word="denken" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="19" end="20" frame="punct(punt)" his="normal" his_1="normal" id="34" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De muziek is wat heftig en net iets te hard voor op de achtergrond , zou ik zo denken .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="7" end="8" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="2" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="0" cat="du" end="10" id="3" rel="--">
+        <node begin="0" cat="smain" end="6" id="4" rel="nucl">
+          <node begin="0" cat="np" end="2" id="5" rel="su">
+            <node begin="0" buiging="zonder" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="6" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="Die"/>
+            <node begin="1" end="2" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="7" lcat="np" lemma="wiel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="wiel_DIM" sense="wiel_DIM" word="wieltjes"/>
+          </node>
+          <node begin="2" end="3" frame="verb(hebben,past(pl),part_intransitive(los))" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="los_laten" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="laat_los" sc="part_intransitive(los)" sense="laat_los" stype="declarative" tense="past" word="lieten" wvorm="pv"/>
+          <node begin="3" cat="ap" end="5" id="9" rel="mod">
+            <node begin="3" end="4" frame="intensifier" his="normal" his_1="normal" id="10" lcat="advp" lemma="te" pos="adv" postag="BW()" pt="bw" rel="mod" root="te" sense="te" special="intensifier" word="te"/>
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="snel" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="snel" sense="snel" vform="adj" word="snel"/>
+          </node>
+          <node begin="5" buiging="zonder" end="6" frame="particle(los)" graad="basis" his="normal" his_1="normal" id="12" lcat="part" lemma="los" pos="part" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="svp" root="los" sense="los" word="los"/>
+        </node>
+        <node begin="8" cat="sv1" end="10" id="13" rel="tag">
+          <node begin="8" end="9" frame="verb(hebben,past(sg),sbar)" his="normal" his_1="normal" id="14" infl="sg" lcat="sv1" lemma="vervolgen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="vervolg" sc="sbar" sense="vervolg" tense="past" word="vervolgde" wvorm="pv"/>
+          <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="15" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Die wieltjes lieten te snel los , ' vervolgde ik .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="16" id="0" rel="top">
+      <node begin="0" cat="du" end="15" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+        <node begin="1" cat="smain" end="15" id="3" rel="nucl">
+          <node begin="1" end="2" frame="sentence_adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="dus" pos="adv" postag="BW()" pt="bw" rel="mod" root="dus" sense="dus" special="sentence" word="dus"/>
+          <node begin="2" end="3" frame="verb(hebben,sg1,so_np)" his="normal" his_1="normal" id="5" infl="sg1" lcat="smain" lemma="staan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="sta" sc="so_np" sense="sta" stype="declarative" tense="present" word="sta" wvorm="pv"/>
+          <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="4" cat="pp" end="11" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="8" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+            <node begin="5" cat="np" end="11" id="9" rel="obj1">
+              <node begin="5" cat="ppart" end="10" id="10" rel="mod">
+                <node begin="5" cat="np" end="9" id="11" rel="mod">
+                  <node begin="5" end="6" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="zaterdag_ochtend" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zaterdag_ochtend" sense="zaterdag_ochtend" special="tmp" word="zaterdagochtend"/>
+                  <node begin="6" cat="pp" end="9" id="13" rel="mod">
+                    <node begin="6" end="7" frame="preposition(in,[])" his="normal" his_1="normal" id="14" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+                    <node begin="7" cat="np" end="9" id="15" rel="obj1">
+                      <node begin="7" end="8" frame="determiner(een)" his="normal" his_1="normal" id="16" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                      <node begin="8" end="9" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="skateboard" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="skateboard" sense="skateboard" word="skateboard"/>
+                    </node>
+                  </node>
+                </node>
+                <node aform="base" begin="9" buiging="met-e" end="10" frame="adjective(ge_e)" his="normal" his_1="normal" id="18" infl="e" lcat="ppart" lemma="af_zakken" pos="adj" positie="prenom" postag="WW(vd,prenom,met-e)" pt="ww" rel="hd" root="af_zakken" sense="af_zakken" vform="psp" word="afgezakte" wvorm="vd"/>
+              </node>
+              <node begin="10" end="11" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="broek" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="broek" sense="broek" word="broeken"/>
+            </node>
+          </node>
+          <node begin="11" cat="np" end="15" id="20" rel="obj2">
+            <node begin="11" end="12" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="winkel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="winkel" sense="winkel" word="winkel"/>
+            <node begin="12" cat="pp" end="15" id="22" rel="mod">
+              <node begin="12" end="13" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="23" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="13" cat="np" end="15" id="24" rel="obj1">
+                <node begin="13" buiging="zonder" end="14" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="25" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+                <node begin="14" end="15" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="26" lcat="np" lemma="man" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="man_DIM" sense="man_DIM" word="mannetje"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="15" end="16" frame="punct(punt)" his="normal" his_1="normal" id="27" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">En dus sta ik op zaterdagochtend in een skateboard afgezakte broeken winkel met mijn mannetje .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="0" cat="conj" end="18" id="1" rel="--">
+        <node begin="0" cat="np" end="3" id="2" rel="cnj">
+          <node aform="base" begin="0" buiging="met-e" end="1" frame="adjective(e)" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="3" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="Grote"/>
+          <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(ende(adv))" his="normal" his_1="normal" id="4" infl="e" lcat="ppres" lemma="zoeken" pos="adj" positie="prenom" postag="WW(od,prenom,met-e)" pt="ww" rel="mod" root="zoeken" sense="zoeken" vform="gerund" word="zoekende" wvorm="od"/>
+          <node begin="2" end="3" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="oog" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="oog" sense="oog" word="ogen"/>
+        </node>
+        <node begin="3" conjtype="neven" end="4" frame="conj(want)" his="normal" his_1="normal" id="6" lcat="vg" lemma="want" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="want" sense="want" word="want"/>
+        <node begin="4" cat="conj" end="18" id="7" rel="cnj">
+          <node begin="4" cat="smain" end="10" id="8" rel="cnj">
+            <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+            <node begin="5" end="6" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="10" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+            <node begin="6" cat="ap" end="10" id="11" rel="predc">
+              <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="12" infl="no_e" lcat="ap" lemma="best" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="best" sense="best" vform="adj" word="best"/>
+              <node begin="7" cat="mwu" end="10" his="normal" his_1="normal" id="13" rel="hd">
+                <node aform="base" begin="7" end="8" frame="adjective(pred(nonadv))" id="14" infl="pred" lcat="ap" lemma="onder" pos="adj" postag="VZ(init)" pt="vz" rel="mwp" root="onder" sense="onder" vform="adj" vztype="init" word="onder"/>
+                <node aform="base" begin="8" end="9" frame="adjective(pred(nonadv))" id="15" infl="pred" lcat="ap" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="adj" postag="LID(bep,stan,rest)" pt="lid" rel="mwp" root="de" sense="de" vform="adj" word="de"/>
+                <node aform="base" begin="9" end="10" frame="adjective(pred(nonadv))" genus="zijd" getal="ev" graad="basis" id="16" infl="pred" lcat="ap" lemma="indruk" naamval="stan" ntype="soort" pos="adj" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mwp" root="indruk" sense="indruk" vform="adj" word="indruk"/>
+              </node>
+            </node>
+          </node>
+          <node begin="10" conjtype="neven" end="11" frame="conj(maar)" his="normal" his_1="normal" id="17" lcat="vg" lemma="maar" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="maar" sense="maar" word="maar"/>
+          <node begin="11" cat="smain" end="18" id="18" rel="cnj">
+            <node begin="11" cat="np" end="15" id="19" rel="su">
+              <node begin="11" buiging="zonder" end="12" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="20" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node aform="base" begin="12" buiging="met-e" end="13" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="21" infl="e" lcat="ap" lemma="stoer" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="stoer" sense="stoer" vform="adj" word="stoere"/>
+              <node begin="13" cat="mwu" end="15" his="normal" his_1="english_compound" id="22" rel="hd">
+                <node begin="13" end="14" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" id="23" lcat="np" lemma="slenter_sleep" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="mwp" rnum="sg" root="slenter_sleep" sense="slenter_sleep" word="slenter-sleep"/>
+                <node begin="14" end="15" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" id="24" lcat="np" lemma="loopje" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="mwp" rnum="sg" root="loopje" sense="loopje" word="loopje"/>
+              </node>
+            </node>
+            <node begin="15" end="16" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="25" infl="sg3" lcat="smain" lemma="compenseren" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="compenseer" sc="transitive" sense="compenseer" stype="declarative" tense="present" word="compenseert" wvorm="pv"/>
+            <node begin="16" end="17" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="26" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="obj1" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+            <node aform="base" begin="17" buiging="zonder" end="18" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="27" infl="no_e" lcat="ap" lemma="ruimschoots" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="ruimschoots" sense="ruimschoots" vform="adj" word="ruimschoots"/>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(punt)" his="normal" his_1="normal" id="28" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Grote zoekende ogen want hij is best onder de indruk maar zijn stoere slenter-sleep loopje compenseert dat ruimschoots .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="9" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="pp" end="5" id="6" rel="mod">
+            <node begin="2" end="3" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="7" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+            <node begin="3" cat="np" end="5" id="8" rel="obj1">
+              <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="gelegenheid" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="gelegenheid" sense="gelegenheid" word="gelegenheid"/>
+            </node>
+          </node>
+          <node begin="5" cat="np" end="8" id="11" rel="obj1">
+            <node begin="5" buiging="zonder" end="6" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="12" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node aform="base" begin="6" buiging="met-e" end="7" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="13" infl="e" lcat="ap" lemma="favoriet" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="favoriet" sense="favoriet" vform="adj" word="favoriete"/>
+            <node begin="7" end="8" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="14" lcat="np" lemma="jas" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="jas_DIM" sense="jas_DIM" word="jasje"/>
+          </node>
+          <node begin="8" buiging="zonder" end="9" frame="verb(hebben,psp,ninv(transitive,part_transitive(aan)))" his="normal" his_1="part-V" id="15" infl="psp" lcat="ppart" lemma="aan_trekken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="trek_aan" sc="part_transitive(aan)" sense="trek_aan" word="aangetrokken" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb voor de gelegenheid mijn favoriete jasje aangetrokken .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="conj" end="9" id="1" rel="--">
+        <node begin="0" cat="smain" end="4" id="2" rel="cnj">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+          <node begin="1" end="2" frame="verb(hebben,sg1,ld_pp)" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="kijken" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kijk" sc="ld_pp" sense="kijk" stype="declarative" tense="present" word="kijk" wvorm="pv"/>
+          <node begin="2" cat="pp" end="4" id="5" rel="ld">
+            <node begin="2" end="3" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="6" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="3" end="4" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Ollie" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Ollie" sense="Ollie" word="Ollie"/>
+          </node>
+        </node>
+        <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="8" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="5" cat="smain" end="9" id="9" rel="cnj">
+          <node begin="5" end="6" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="10" lcat="np" lemma="Ollie" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="su" rnum="sg" root="Ollie" sense="Ollie" word="Ollie"/>
+          <node begin="6" end="7" frame="verb(hebben,sg3,ld_pp)" his="normal" his_1="normal" id="11" infl="sg3" lcat="smain" lemma="kijken" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kijk" sc="ld_pp" sense="kijk" stype="declarative" tense="present" word="kijkt" wvorm="pv"/>
+          <node begin="7" cat="pp" end="9" id="12" rel="ld">
+            <node begin="7" end="8" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="13" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="8" case="dat_acc" def="def" end="9" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="14" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik kijk naar Ollie en Ollie kijkt naar mij .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="9" id="3" rel="--">
+        <node begin="0" end="1" frame="tag" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="advp" lemma="ja" pos="tag" postag="TSW()" pt="tsw" rel="tag" root="ja" sense="ja" word="Ja"/>
+        <node begin="2" cat="du" end="9" id="5" rel="nucl">
+          <node begin="2" cat="smain" end="5" id="6" rel="nucl">
+            <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="papa" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="papa" sense="papa" word="papa"/>
+            <node begin="3" end="4" frame="verb(unacc,sg3,copula)" his="normal" his_1="normal" id="8" infl="sg3" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" stype="declarative" tense="present" word="wordt" wvorm="pv"/>
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="9" infl="no_e" lcat="ap" lemma="oud" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="oud" sense="oud" vform="adj" word="oud"/>
+          </node>
+          <node begin="6" cat="smain" end="9" his="normal" his_1="normal" id="10" rel="tag">
+            <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" id="11" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="7" end="8" frame="verb(hebben,sg1,sbar)" id="12" infl="sg1" lcat="smain" lemma="weten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="weet" sc="sbar" sense="weet" tense="present" word="weet" wvorm="pv"/>
+            <node begin="8" end="9" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" id="13" infl="het" lcat="np" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="obj1" root="het" sense="het" wh="nwh" word="het"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ja , papa wordt oud , ik weet het .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="kind" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="su" rnum="pl" root="kind" sense="kind" word="Kinderen"/>
+        <node begin="1" end="2" frame="verb(unacc,pl,copula)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" stype="declarative" tense="present" word="worden" wvorm="pv"/>
+        <node begin="2" cat="ap" end="4" id="4" rel="mod">
+          <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="mod" root="zo" sense="zo" word="zo"/>
+          <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="snel" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="snel" sense="snel" vform="adj" word="snel"/>
+        </node>
+        <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="groot" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="groot" sense="groot" vform="adj" word="groot"/>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Kinderen worden zo snel groot .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="0" cat="sv1" end="13" id="1" rel="--">
+        <node begin="0" end="1" frame="verb('hebben/zijn',modal_inv,aux(inf))" his="normal" his_1="decap" his_1_1="normal" id="2" infl="modal_inv" lcat="sv1" lemma="kunnen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kan" sc="aux(inf)" sense="kan" stype="ynquestion" tense="present" word="Kun" wvorm="pv"/>
+        <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="3" index="1" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+        <node begin="1" cat="inf" end="13" id="4" rel="vc">
+          <node begin="1" end="2" id="5" index="1" rel="su"/>
+          <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="6" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="obj1" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+          <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+          <node begin="4" cat="mwu" end="7" his="normal" his_1="normal" id="8" rel="mod">
+            <node begin="4" end="5" frame="sentence_adverb" id="9" lcat="advp" lemma="af" pos="adv" postag="VZ(fin)" pt="vz" rel="mwp" root="af" sense="af" special="sentence" vztype="fin" word="af"/>
+            <node begin="5" conjtype="neven" end="6" frame="sentence_adverb" id="10" lcat="advp" lemma="en" pos="adv" postag="VG(neven)" pt="vg" rel="mwp" root="en" sense="en" special="sentence" word="en"/>
+            <node begin="6" end="7" frame="sentence_adverb" id="11" lcat="advp" lemma="toe" pos="adv" postag="VZ(fin)" pt="vz" rel="mwp" root="toe" sense="toe" special="sentence" vztype="fin" word="toe"/>
+          </node>
+          <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="sealen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="seal" sc="transitive" sense="seal" word="sealen" wvorm="inf"/>
+          <node begin="8" cat="cp" end="13" id="13" rel="mod">
+            <node begin="8" conjtype="onder" end="9" frame="complementizer" his="normal" his_1="normal" id="14" lcat="cp" lemma="zodat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zodat" sense="zodat" word="zodat"/>
+            <node begin="9" cat="ssub" end="13" id="15" rel="body">
+              <node begin="9" case="both" def="def" end="10" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="16" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+              <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="17" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+              <node aform="compar" begin="11" buiging="zonder" end="12" frame="adjective(er(adv))" graad="comp" his="normal" his_1="normal" id="18" infl="no_e" lcat="ap" lemma="oud" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="predc" root="oud" sense="oud" vform="adj" word="ouder"/>
+              <node begin="12" end="13" frame="verb(unacc,pl,copula)" his="normal" his_1="normal" id="19" infl="pl" lcat="ssub" lemma="worden" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" tense="present" word="worden" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(vraag)" his="normal" his_1="normal" id="20" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">Kun je ze niet af en toe sealen zodat ze niet ouder worden ?</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="35" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="25" end="26" frame="punct(haak_open)" his="normal" his_1="normal" id="3" lcat="punct" lemma="(" pos="punct" postag="LET()" pt="let" rel="--" root="(" sense="(" special="haak_open" word="("/>
+      <node begin="31" end="32" frame="punct(haak_sluit)" his="normal" his_1="normal" id="4" lcat="punct" lemma=")" pos="punct" postag="LET()" pt="let" rel="--" root=")" sense=")" special="haak_sluit" word=")"/>
+      <node begin="0" cat="du" end="34" id="5" rel="--">
+        <node begin="0" cat="np" end="17" id="6" rel="dp">
+          <node aform="base" begin="0" buiging="met-e" end="1" frame="adjective(e)" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="7" infl="e" lcat="ap" lemma="laag" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="laag" sense="laag" vform="adj" word="Lage"/>
+          <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="zwart" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="zwart" sense="zwart" vform="adj" word="zwarte"/>
+          <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="broek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="broek" sense="broek" word="broek"/>
+          <node begin="4" cat="np" end="17" id="10" rel="app">
+            <node aform="base" begin="4" buiging="met-e" end="5" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="11" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="grote"/>
+            <node begin="5" end="6" frame="noun(both,count,pl)" gen="both" getal="mv" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="gympen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="gympen" sense="gympen" word="gympen"/>
+            <node begin="6" cat="pp" end="17" id="13" rel="mod">
+              <node begin="6" end="7" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="14" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+              <node begin="7" cat="np" end="17" id="15" rel="obj1">
+                <node aform="base" begin="7" buiging="met-e" end="8" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="16" infl="e" lcat="ap" lemma="los" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="los" sense="los" vform="adj" word="losse"/>
+                <node begin="8" end="9" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="veter" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="veter" sense="veter" word="veters"/>
+                <node begin="10" cat="np" end="17" id="18" rel="app">
+                  <node begin="10" end="11" frame="determiner(een)" his="normal" his_1="normal" id="19" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                  <node aform="base" begin="11" buiging="zonder" end="12" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="20" infl="no_e" lcat="ap" lemma="zwart" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="zwart" sense="zwart" vform="adj" word="zwart"/>
+                  <node begin="12" end="13" frame="noun(both,count,sg)" gen="both" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="21" lcat="np" lemma="T-shirt" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="T-shirt" sense="T-shirt" word="T-shirt"/>
+                  <node begin="13" cat="pp" end="17" id="22" rel="mod">
+                    <node begin="13" end="14" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="23" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+                    <node begin="14" cat="np" end="17" id="24" rel="obj1">
+                      <node begin="14" end="15" frame="determiner(een)" his="normal" his_1="normal" id="25" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                      <node begin="15" cat="mwu" end="17" his="normal" his_1="english_compound" id="26" rel="hd">
+                        <node begin="15" end="16" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" id="27" lcat="np" lemma="cartoon" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mwp" rnum="sg" root="cartoon" sense="cartoon" word="cartoon"/>
+                        <node begin="16" end="17" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" id="28" lcat="np" lemma="gothic" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mwp" rnum="sg" root="gothic" sense="gothic" word="gothic"/>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="17" cat="du" end="34" id="29" rel="dp">
+          <node begin="17" cat="np" end="24" id="30" rel="dp">
+            <node begin="17" end="18" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="31" lcat="np" lemma="kop" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kop" sense="kop" word="kop"/>
+            <node begin="18" cat="conj" end="24" id="32" rel="mod">
+              <node begin="18" end="19" frame="er_adverb(op)" his="normal" his_1="normal" id="33" lcat="pp" lemma="erop" pos="pp" postag="BW()" pt="bw" rel="cnj" root="erop" sense="erop" special="er" word="erop"/>
+              <node begin="19" conjtype="neven" end="20" frame="conj(en)" his="normal" his_1="normal" id="34" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="20" cat="pp" end="24" id="35" rel="cnj">
+                <node begin="20" end="21" frame="preposition(op,[af,na])" his="normal" his_1="normal" id="36" lcat="pp" lemma="op" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="op" sense="op" vztype="init" word="op"/>
+                <node begin="21" cat="np" end="24" id="37" rel="obj1">
+                  <node begin="21" buiging="zonder" end="22" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="38" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+                  <node aform="base" begin="22" buiging="zonder" end="23" frame="adjective(both(nonadv))" graad="basis" his="normal" his_1="normal" id="39" infl="both" lcat="ap" lemma="eigen" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="eigen" sense="eigen" vform="adj" word="eigen"/>
+                  <node begin="23" end="24" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="40" lcat="np" lemma="hoofd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="hoofd" sense="hoofd" word="hoofd"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="24" cat="np" end="34" id="41" rel="dp">
+            <node begin="24" end="25" frame="determiner(een)" his="normal" his_1="normal" id="42" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="26" cat="whq" end="31" id="43" rel="mod">
+              <node begin="26" end="27" frame="wh_adjective" his="normal" his_1="normal" id="44" index="1" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="whd" root="hoe" sense="hoe" wh="ywh" word="hoe"/>
+              <node begin="26" cat="sv1" end="31" id="45" rel="body">
+                <node begin="26" end="27" id="46" index="1" rel="mod"/>
+                <node begin="27" end="28" frame="verb(hebben,modal_not_u,ap_copula)" his="normal" his_1="normal" id="47" infl="modal_not_u" lcat="sv1" lemma="kunnen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kan" sc="ap_copula" sense="kan" stype="whquestion" tense="present" word="kan" wvorm="pv"/>
+                <node begin="28" end="29" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="48" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+                <node begin="29" end="30" frame="sentence_adverb" his="normal" his_1="normal" id="49" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+                <node aform="compar" begin="30" end="31" frame="adjective(anders)" his="normal" his_1="normal" id="50" infl="anders" lcat="ap" lemma="anders" pos="adj" postag="BW()" pt="bw" rel="predc" root="anders" sense="anders" vform="adj" word="anders"/>
+              </node>
+            </node>
+            <node aform="base" begin="32" buiging="zonder" end="33" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="51" infl="no_e" lcat="ap" lemma="zwart" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="zwart" sense="zwart" vform="adj" word="zwart"/>
+            <node begin="33" end="34" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="52" lcat="np" lemma="muts" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="muts_DIM" sense="muts_DIM" word="mutsje"/>
+          </node>
+        </node>
+      </node>
+      <node begin="34" end="35" frame="punct(punt)" his="robust_skip" id="53" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Lage zwarte broek , grote gympen met losse veters , een zwart T-shirt met een cartoon gothic kop erop en op zijn eigen hoofd een ( hoe kan het ook anders ) zwart mutsje .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="du" end="7" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="maar" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="maar" sc="root" sense="maar" word="Maar"/>
+        <node begin="1" cat="smain" end="7" id="3" rel="nucl">
+          <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="4" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node begin="2" end="3" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="5" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="3" cat="ap" end="7" id="6" rel="predc">
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="best" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="best" sense="best" vform="adj" word="best"/>
+            <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(adv),pp(met))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="druk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="druk" sc="pp(met)" sense="druk-met" vform="adj" word="druk"/>
+            <node begin="3" cat="pp" end="7" id="9" rel="pc">
+              <node begin="3" end="4" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="10" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="obj1" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+              <node begin="6" end="7" frame="preposition(met,[mee],extracted_np)" his="normal" his_1="normal" id="11" lcat="pp" lemma="mee" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="mee" sc="extracted_np" sense="mee" vztype="fin" word="mee"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Maar hij is er best druk mee .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="25" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="11" end="12" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="2" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="13" end="14" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="3" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="21" end="22" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="4" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="0" cat="conj" end="23" id="5" rel="--">
+        <node begin="0" cat="smain" end="5" id="6" rel="cnj">
+          <node begin="0" cat="np" end="2" id="7" rel="su">
+            <node begin="0" buiging="zonder" end="1" frame="determiner(pron)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="8" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="Mijn"/>
+            <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="9" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="zoon_DIM" sense="zoon_DIM" word="zoontje"/>
+          </node>
+          <node begin="2" end="3" frame="verb(unacc,sg3,copula)" his="normal" his_1="normal" id="10" infl="sg3" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" stype="declarative" tense="present" word="wordt" wvorm="pv"/>
+          <node begin="3" end="4" frame="sentence_adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+          <node aform="compar" begin="4" buiging="zonder" end="5" frame="adjective(er(adv))" graad="comp" his="normal" his_1="normal" id="12" infl="no_e" lcat="ap" lemma="oud" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="predc" root="oud" sense="oud" vform="adj" word="ouder"/>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(want)" his="normal" his_1="normal" id="13" lcat="vg" lemma="want" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="want" sense="want" word="want"/>
+        <node begin="7" cat="smain" end="15" id="14" rel="cnj">
+          <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="15" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node begin="8" end="9" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="16" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="9" end="10" frame="sentence_adverb" his="normal" his_1="normal" id="17" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+          <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="18" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sense="al" word="al"/>
+          <node begin="12" end="13" frame="sentence_adverb" his="normal" his_1="normal" id="19" lcat="advp" lemma="bijna" pos="adv" postag="BW()" pt="bw" rel="mod" root="bijna" sense="bijna" special="sentence" word="bijna"/>
+          <node begin="14" end="15" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="20" infl="pl_num" lcat="np" lemma="tien" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="predc" root="tien" sense="tien" word="tien"/>
+        </node>
+        <node begin="15" conjtype="neven" end="16" frame="conj(en)" his="normal" his_1="normal" id="21" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="16" cat="smain" end="23" id="22" rel="cnj">
+          <node begin="16" case="nom" def="def" end="17" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="23" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+          <node begin="17" end="18" frame="verb(hebben,sg3,pred_np)" his="normal" his_1="normal" id="24" infl="sg3" lcat="smain" lemma="vinden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="vind" sc="pred_np" sense="vind" stype="declarative" tense="present" word="vindt" wvorm="pv"/>
+          <node begin="18" end="19" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="25" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+          <node begin="19" end="20" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="26" lcat="advp" lemma="hier" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="mod" root="hier" sense="hier" special="er_loc" status="vol" vwtype="aanw" word="hier"/>
+          <node begin="20" end="21" frame="adverb" his="normal" his_1="normal" id="27" lcat="advp" lemma="helemaal" pos="adv" postag="BW()" pt="bw" rel="mod" root="helemaal" sense="helemaal" word="helemaal"/>
+          <node begin="22" end="23" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="28" lcat="np" lemma="top" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="top" sense="top" word="top"/>
+        </node>
+      </node>
+      <node begin="23" end="24" frame="punct(aanhaal_both)" his="normal" his_1="normal" id="29" lcat="punct" lemma="'" pos="punct" postag="LET()" pt="let" rel="--" root="'" sense="'" special="aanhaal_both" word="'"/>
+      <node begin="24" end="25" frame="punct(punt)" his="normal" his_1="normal" id="30" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Mijn zoontje wordt ook ouder , want hij is ook al ' bijna ' tien en hij vindt het hier helemaal ' top ' .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="np" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="iets_noun" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="niets" naamval="stan" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="hd" rnum="sg" root="niets" sc="iets" sense="niets" status="vol" vwtype="onbep" word="Niets"/>
+        <node begin="1" cat="ap" end="9" id="3" rel="mod">
+          <node aform="compar" begin="1" buiging="met-s" end="2" frame="post_adjective(er)" graad="comp" his="normal" his_1="Adj-s" id="4" iets="true" infl="no_e" lcat="ap" lemma="leuk" pos="adj" positie="postnom" postag="ADJ(postnom,comp,met-s)" pt="adj" rel="hd" root="leuk" sense="leuk" special="iets" vform="adj" word="leukers"/>
+          <node begin="2" cat="cp" end="9" id="5" rel="obcomp">
+            <node begin="2" conjtype="onder" end="3" frame="comparative(dan)" his="normal" his_1="normal" id="6" lcat="comparative" lemma="dan" pos="comparative" postag="VG(onder)" pt="vg" rel="cmp" root="dan" sense="dan" word="dan"/>
+            <node begin="3" cat="ti" end="9" id="7" rel="body">
+              <node begin="7" end="8" frame="complementizer(te)" his="normal" his_1="normal" id="8" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+              <node begin="3" cat="inf" end="9" id="9" rel="body">
+                <node begin="3" case="both" def="def" end="4" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="getal" his="normal" his_1="normal" id="10" lcat="np" lemma="je" naamval="obl" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pr,pron,obl,red,2v,getal)" pt="vnw" rel="obj1" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pr" wh="nwh" word="je"/>
+                <node begin="4" cat="cp" end="7" id="11" rel="predm">
+                  <node begin="4" conjtype="onder" end="5" frame="complementizer(als)" his="normal" his_1="normal" id="12" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+                  <node begin="5" cat="np" end="7" id="13" rel="body">
+                    <node aform="base" begin="5" buiging="met-e" end="6" frame="adjective(e)" graad="basis" his="normal" his_1="variant" his_1_1="variant" his_1_1_1="oude" his_1_1_2="ouwe" his_1_2="normal" id="14" infl="e" lcat="ap" lemma="oud" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="oud" sense="oud" vform="adj" word="ouwe"/>
+                    <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="lul" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="lul" sense="lul" word="lul"/>
+                  </node>
+                </node>
+                <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="kleden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="kleed" sc="transitive" sense="kleed" word="kleden" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Niets leukers dan je als ouwe lul te kleden .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/flair1.example.ok
+++ b/tests/flair1.example.ok
@@ -1851,26 +1851,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.3.s.1.w.5.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
                 <feat class="[wil]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -5892,7 +5872,7 @@
             <morphology>
               <morpheme class="complex">
                 <t>weet</t>
-                <feat class="[wijt]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
+                <feat class="[wijt]verb/present-tense/singular/1st-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
                   <t>wijt</t>
@@ -5902,8 +5882,7 @@
                 <morpheme class="inflection">
                   <feat class="present-tense" subset="inflection"/>
                   <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
+                  <feat class="1st-person-verb" subset="inflection"/>
                 </morpheme>
               </morpheme>
             </morphology>
@@ -9652,7 +9631,7 @@
             <morphology>
               <morpheme class="complex">
                 <t>weet</t>
-                <feat class="[wijt]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
+                <feat class="[wijt]verb/present-tense/singular/1st-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
                   <t>wijt</t>
@@ -9662,8 +9641,7 @@
                 <morpheme class="inflection">
                   <feat class="present-tense" subset="inflection"/>
                   <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
+                  <feat class="1st-person-verb" subset="inflection"/>
                 </morpheme>
               </morpheme>
             </morphology>
@@ -12219,7 +12197,7 @@
           <morphology>
             <morpheme class="complex">
               <t>ruimschoots</t>
-              <feat class="[[ruim]adjective[schoot]adjective/positive]adjective" subset="structure"/>
+              <feat class="[[ruim]adjective[schoot]adjective[s]/positive]adjective" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>ruim</t>
@@ -12232,6 +12210,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>s</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -12515,8 +12494,8 @@
         <metric class="np_modifier_count" value="3"/>
         <metric class="character_count" value="101"/>
         <metric class="character_count_min_names" value="101"/>
-        <metric class="morpheme_count" value="28"/>
-        <metric class="morpheme_count_min_names" value="28"/>
+        <metric class="morpheme_count" value="29"/>
+        <metric class="morpheme_count_min_names" value="29"/>
         <metric class="d_level" value="2"/>
         <metric class="sub_verb_dist" value="0.5"/>
         <metric class="obj_verb_dist" value="0"/>
@@ -12741,8 +12720,8 @@
       <metric class="np_modifier_count" value="3"/>
       <metric class="character_count" value="101"/>
       <metric class="character_count_min_names" value="101"/>
-      <metric class="morpheme_count" value="28"/>
-      <metric class="morpheme_count_min_names" value="28"/>
+      <metric class="morpheme_count" value="29"/>
+      <metric class="morpheme_count_min_names" value="29"/>
       <metric class="d_level" value="2"/>
       <metric class="sub_verb_dist" value="0.5"/>
       <metric class="obj_verb_dist" value="0"/>
@@ -12907,26 +12886,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.11.s.1.w.5.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kom</t>
-                <feat class="[kom]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kom</t>
-                  <feat class="[kom]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -13679,26 +13638,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.11.s.2.w.9.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kan</t>
-                <feat class="[kan]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kan</t>
-                  <feat class="[kan]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.11.s.2.w.9.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>kan</t>
@@ -17987,26 +17926,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>kan</t>
-                <feat class="[kan]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kan</t>
-                  <feat class="[kan]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.14.s.1.w.28.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kan</t>
                 <feat class="[kan]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -20615,26 +20534,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.15.s.3.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kijk</t>
-                <feat class="[kijk]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kijk</t>
-                  <feat class="[kijk]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -21463,26 +21362,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.16.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heb</t>
-                <feat class="[heb]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heb</t>
-                  <feat class="[heb]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(tijdww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.994141"/>
           <metric class="prevalenceZ" value="2.52051"/>
@@ -24020,8 +23899,8 @@
     <metric class="np_modifier_count" value="43"/>
     <metric class="character_count" value="1320"/>
     <metric class="character_count_min_names" value="1296"/>
-    <metric class="morpheme_count" value="392"/>
-    <metric class="morpheme_count_min_names" value="387"/>
+    <metric class="morpheme_count" value="393"/>
+    <metric class="morpheme_count_min_names" value="388"/>
     <metric class="d_level" value="39"/>
     <metric class="d_level_gt4" value="3"/>
     <metric class="question_count" value="3"/>

--- a/tests/gebeuren_abstr.example.alpino
+++ b/tests/gebeuren_abstr.example.alpino
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="6" end="7" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="2" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="3" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="0" cat="ppart" end="11" id="4" rel="vc">
+          <node begin="0" cat="pp" end="6" id="5" rel="mod">
+            <node begin="0" end="1" frame="preposition(na,[])" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="pp" lemma="na" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="na" sense="na" vztype="init" word="Na"/>
+            <node begin="1" cat="np" end="6" id="7" rel="obj1">
+              <node begin="1" end="2" frame="determiner(een)" his="normal" his_1="normal" id="8" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="zwerf_tocht" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zwerf_tocht" sense="zwerf_tocht" word="zwerftocht"/>
+              <node begin="3" cat="pp" end="6" id="10" rel="mod">
+                <node begin="3" end="4" frame="preposition(door,[heen])" his="normal" his_1="normal" id="11" lcat="pp" lemma="door" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="door" sense="door" vztype="init" word="door"/>
+                <node begin="4" cat="np" end="6" id="12" rel="obj1">
+                  <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="13" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="5" end="6" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="stad" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="stad" sense="stad" word="stad"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="7" end="8" id="15" index="1" rel="su"/>
+          <node begin="8" cat="np" end="10" id="16" rel="obj1">
+            <node begin="8" end="9" frame="determiner(een)" his="normal" his_1="normal" id="17" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="pan" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pan" sense="pan" word="pan"/>
+          </node>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="19" infl="psp" lcat="ppart" lemma="kopen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="koop" sc="transitive" sense="koop" word="gekocht" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Na een zwerftocht door de stad heb ik een pan gekocht .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/gebeuren_conc.example.alpino
+++ b/tests/gebeuren_conc.example.alpino
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="6" end="7" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="2" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="3" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="0" cat="ppart" end="11" id="4" rel="vc">
+          <node begin="0" cat="pp" end="6" id="5" rel="mod">
+            <node begin="0" end="1" frame="preposition(na,[])" his="normal" his_1="decap" his_1_1="normal" id="6" lcat="pp" lemma="na" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="na" sense="na" vztype="init" word="Na"/>
+            <node begin="1" cat="np" end="6" id="7" rel="obj1">
+              <node begin="1" end="2" frame="determiner(een)" his="normal" his_1="normal" id="8" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node begin="2" end="3" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="9" lcat="np" lemma="auto_rit" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="auto_rit" sense="auto_rit" special="tmp" word="autorit"/>
+              <node begin="3" cat="pp" end="6" id="10" rel="mod">
+                <node begin="3" end="4" frame="preposition(door,[heen])" his="normal" his_1="normal" id="11" lcat="pp" lemma="door" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="door" sense="door" vztype="init" word="door"/>
+                <node begin="4" cat="np" end="6" id="12" rel="obj1">
+                  <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="13" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="5" end="6" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="stad" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="stad" sense="stad" word="stad"/>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node begin="7" end="8" id="15" index="1" rel="su"/>
+          <node begin="8" cat="np" end="10" id="16" rel="obj1">
+            <node begin="8" end="9" frame="determiner(een)" his="normal" his_1="normal" id="17" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="18" lcat="np" lemma="pan" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="pan" sense="pan" word="pan"/>
+          </node>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="19" infl="psp" lcat="ppart" lemma="kopen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="koop" sc="transitive" sense="koop" word="gekocht" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Na een autorit door de stad heb ik een pan gekocht .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/lsa1.example.alpino
+++ b/tests/lsa1.example.alpino
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="smain" end="3" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="4" infl="no_e" lcat="ap" lemma="groot" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="groot" sense="groot" vform="adj" word="groot"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is groot .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(unacc,sg1,copula)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="ben" wvorm="pv"/>
+        <node begin="2" cat="ap" end="6" id="4" rel="predc">
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(padv),pp(voor))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="bang" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="bang" sc="pp(voor)" sense="bang-voor" vform="adj" word="bang"/>
+          <node begin="3" cat="pp" end="6" id="6" rel="pc">
+            <node begin="3" end="4" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="7" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+            <node begin="4" cat="np" end="6" id="8" rel="obj1">
+              <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik ben bang voor de hond .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="smain" end="4" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev_ndev)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zie de hond .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="smain" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="4" infl="no_e" lcat="ap" lemma="groot" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="groot" sense="groot" vform="adj" word="groot"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Piet is groot .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="smain" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(padv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="bang" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="bang" sense="bang" vform="adj" word="bang"/>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="6" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Piet is niet bang .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="su" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,transitive_ndev_ndev)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" stype="declarative" tense="present" word="ziet" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+        </node>
+        <node begin="4" end="5" frame="sentence_adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sense="ook" special="sentence" word="ook"/>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Piet ziet de hond ook .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/lsa1.example.ok
+++ b/tests/lsa1.example.ok
@@ -120,26 +120,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zie</t>
-                <feat class="[zie]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zie</t>
-                  <feat class="[zie]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -922,26 +902,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.3.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ben</t>
-                <feat class="[zijn]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zijn</t>
-                  <feat class="[zijn]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(koppelww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.999628"/>
           <metric class="prevalenceZ" value="3.37248"/>

--- a/tests/lsa2.example.alpino
+++ b/tests/lsa2.example.alpino
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="smain" end="3" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev_ndev)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="4" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik zie Piet .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="smain" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev_ndev)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" stype="declarative" tense="present" word="zie" wvorm="pv"/>
+        <node begin="2" case="nom" def="def" end="3" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="4" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Piet zie ik .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="sv1" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="verb(hebben,sg1,transitive_ndev_ndev)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="sg1" lcat="sv1" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" stype="ynquestion" tense="present" word="Zie" wvorm="pv"/>
+        <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="4" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+      </node>
+      <node begin="3" end="4" frame="punct(vraag)" his="normal" his_1="normal" id="5" lcat="punct" lemma="?" pos="punct" postag="LET()" pt="let" rel="--" root="?" sense="?" special="vraag" word="?"/>
+    </node>
+    <sentence sentid="127.0.0.1">Zie ik Piet ?</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/lsa2.example.ok
+++ b/tests/lsa2.example.ok
@@ -120,26 +120,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zie</t>
-                <feat class="[zie]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zie</t>
-                  <feat class="[zie]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/merge_alpino_output.py
+++ b/tests/merge_alpino_output.py
@@ -3,13 +3,15 @@ from lxml import etree
 from glob import glob
 import re
 
-# 
 
 def get_tree(filename, index):
     corpus = etree.parse(filename)
     root = corpus.getroot()
-    trees = [root] if root.tag == 'alpino_ds' else corpus.findall("alpino_ds")
-    return trees[index]
+    if root.tag == 'alpino_ds':
+        return root
+
+    trees = corpus.findall("alpino_ds")
+    return trees[index-1]
 
 
 def get_alpino_target_filename(filename):

--- a/tests/merge_alpino_output.py
+++ b/tests/merge_alpino_output.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from lxml import etree
+from glob import glob
+import re
+
+# 
+
+def get_tree(filename, index):
+    corpus = etree.parse(filename)
+    root = corpus.getroot()
+    trees = [root] if root.tag == 'alpino_ds' else corpus.findall("alpino_ds")
+    return trees[index]
+
+
+def get_alpino_target_filename(filename):
+    testname = re.sub("\.example\..*alpino\.xml", "", filename)
+    return testname + ".example.alpino"
+
+
+def get_sentences():
+    lookups = glob("out*.alpino_lookup.data")
+    for lookup in lookups:
+        with open(lookup, "r") as lookup_file:
+            lines = lookup_file.readlines()
+            for line in lines:
+                sentence, filename, index = line.split("\t")
+                yield sentence, get_tree(filename, int(index)), get_alpino_target_filename(filename)
+
+
+merged_treebanks = {}
+sentences = {}
+for sentence, tree, alpino_target_filename in get_sentences():
+    sentences[sentence] = (tree, alpino_target_filename)
+
+with open("alpino_lookup.data", "w") as target:
+    for sentence, (tree, alpino_target_filename) in sentences.items():
+        try:
+            merged_treebank = merged_treebanks[alpino_target_filename]
+        except KeyError:
+            merged_treebank = etree.Element("treebank")
+            merged_treebanks[alpino_target_filename] = merged_treebank
+        merged_treebank.append(tree)
+        # numbering of treebanks is 1 based
+        target.write(
+            f"{sentence}\t{alpino_target_filename}\t{len(merged_treebank.getchildren())}\n")
+
+for merged_filename, merged_treebank in merged_treebanks.items():
+    etree.indent(merged_treebank)
+    etree.ElementTree(merged_treebank).write(
+        merged_filename, xml_declaration=True, pretty_print=True, encoding="UTF-8")

--- a/tests/mod_adv.example.alpino
+++ b/tests/mod_adv.example.alpino
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" cat="ap" end="2" id="2" rel="mod">
+          <node aform="base" begin="0" buiging="zonder" end="1" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="3" infl="no_e" lcat="ap" lemma="erg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="erg" sense="erg" vform="adj" word="Erg"/>
+          <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="4" infl="no_e" lcat="ap" lemma="geloofwaardig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="geloofwaardig" sense="geloofwaardig" vform="adj" word="geloofwaardig"/>
+        </node>
+        <node begin="2" end="3" frame="verb(hebben,sg3,intransitive)" his="special" his_1="decap" his_1_1="normal" id="5" infl="sg3" lcat="smain" lemma="opereren" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="opereer" sc="intransitive" sense="opereer" stype="declarative" tense="present" word="OPEREERT" wvorm="pv"/>
+        <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+        <node begin="4" cat="cp" end="6" id="7" rel="predm">
+          <node begin="4" conjtype="onder" end="5" frame="complementizer(als)" his="normal" his_1="normal" id="8" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="woordvoerder" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="body" rnum="sg" root="woordvoerder" sense="woordvoerder" word="woordvoerder"/>
+        </node>
+        <node begin="6" end="7" frame="adverb" his="special" his_1="decap" his_1_1="normal" id="10" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="NIET"/>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Erg geloofwaardig OPEREERT hij als woordvoerder NIET .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,intransitive)" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg3" lcat="smain" lemma="lezen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="lees" sc="intransitive" sense="lees" stype="declarative" tense="present" word="LEEST" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="mod">
+          <node begin="2" end="3" frame="modal_adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sc="modal" sense="al" word="al"/>
+          <node begin="3" end="4" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+        </node>
+        <node begin="4" cat="advp" end="6" id="7" rel="mod">
+          <node begin="4" end="5" frame="adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+          <node begin="5" buiging="zonder" end="6" frame="postadv_adverb" graad="comp" his="special" his_1="decap" his_1_1="normal" id="9" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="MEER"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij LEEST al jaren niet MEER .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),transitive)" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg" lcat="smain" lemma="lopen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="loop" sc="transitive" sense="loop" stype="declarative" tense="past" word="LIEP" wvorm="pv"/>
+        <node begin="2" cat="np" end="9" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(een)" his="normal" his_1="normal" id="5" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="6" infl="e" lcat="ap" lemma="half" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="half" sense="half" vform="adj" word="halve"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="marathon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="marathon" sense="marathon" word="marathon"/>
+          <node begin="5" cat="pp" end="9" id="8" rel="mod">
+            <node begin="5" end="6" frame="preposition(in,[])" his="normal" his_1="normal" id="9" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+            <node begin="6" cat="np" end="9" id="10" rel="obj1">
+              <node begin="6" end="7" frame="determiner(een)" his="normal" his_1="normal" id="11" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+              <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="12" infl="no_e" lcat="ap" lemma="half" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="half" sense="half" vform="adj" word="half"/>
+              <node begin="8" end="9" frame="tmp_noun(het,count,meas)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="uur" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="uur" sense="uur" special="tmp" word="uur"/>
+            </node>
+          </node>
+        </node>
+        <node begin="9" end="10" frame="tmp_adverb" his="special" his_1="decap" his_1_1="normal" id="14" lcat="advp" lemma="gisteren" pos="adv" postag="BW()" pt="bw" rel="mod" root="gisteren" sense="gisteren" special="tmp" word="GISTEREN"/>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij LIEP een halve marathon in een half uur GISTEREN .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/mod_bw.example.alpino
+++ b/tests/mod_bw.example.alpino
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),transitive)" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg" lcat="smain" lemma="lezen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="lees" sc="transitive" sense="lees" stype="declarative" tense="past" word="LAS" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        </node>
+        <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="special" his_1="decap" his_1_1="normal" id="7" infl="no_e" lcat="ap" lemma="snel" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="snel" sense="snel" vform="adj" word="SNEL"/>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij LAS het boek SNEL .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),transitive)" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg" lcat="smain" lemma="lezen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="lees" sc="transitive" sense="lees" stype="declarative" tense="past" word="LAS" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+          <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        </node>
+        <node begin="4" cat="ap" end="6" id="7" rel="mod">
+          <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="erg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="erg" sense="erg" vform="adj" word="erg"/>
+          <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(adv))" graad="basis" his="special" his_1="decap" his_1_1="normal" id="9" infl="no_e" lcat="ap" lemma="vlug" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="vlug" sense="vlug" vform="adj" word="VLUG"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij LAS het boek erg VLUG .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/mtld.example.alpino
+++ b/tests/mtld.example.alpino
@@ -1,0 +1,100 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="du" end="7" id="1" rel="--">
+        <node begin="0" cat="mwu" end="6" his="name" his_1="begin" id="2" rel="dp">
+          <node begin="0" end="1" frame="proper_name(both)" id="3" lcat="np" lemma="Before" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Before" sense="Before" spectype="deeleigen" word="Before"/>
+          <node begin="1" end="2" frame="proper_name(both)" id="4" lcat="np" lemma="is" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="is" sense="is" spectype="deeleigen" word="is"/>
+          <node begin="2" end="3" frame="proper_name(both)" id="5" lcat="np" lemma="Taro’s" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Taro’s" sense="Taro’s" spectype="deeleigen" word="Taro’s"/>
+          <node begin="3" end="4" frame="proper_name(both)" id="6" lcat="np" lemma="name" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="name" sense="name" spectype="deeleigen" word="name"/>
+          <node begin="4" end="5" frame="proper_name(both)" id="7" lcat="np" lemma="on" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="on" sense="on" spectype="deeleigen" word="on"/>
+          <node begin="5" end="6" frame="proper_name(both)" id="8" lcat="np" lemma="textbook" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="textbook" sense="textbook" spectype="deeleigen" word="textbook"/>
+        </node>
+        <node begin="6" end="7" frame="proper_name(both)" genus="genus" getal="ev" graad="basis" his="name" his_1="not_begin" id="9" lcat="np" lemma="but" naamval="stan" neclass="MISC" ntype="eigen" num="both" pos="name" postag="N(eigen,ev,basis,genus,stan)" pt="n" rel="dp" rnum="sg" root="but" sense="but" word="but"/>
+      </node>
+    </node>
+    <sentence sentid="127.0.0.1">Before is Taro’s name on textbook but</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="19" id="0" rel="top">
+      <node begin="0" cat="du" end="18" id="1" rel="--">
+        <node begin="0" cat="smain" end="2" id="2" rel="dp">
+          <node begin="0" end="1" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Lake" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="su" rnum="sg" root="Lake" sense="Lake" word="Lake"/>
+          <node begin="1" end="2" frame="verb(unacc,sg_is,intransitive)" his="normal" his_1="normal" id="4" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        </node>
+        <node begin="2" cat="smain" end="18" id="5" rel="dp">
+          <node begin="2" cat="mwu" end="7" his="name" his_1="not_begin" id="6" rel="su">
+            <node begin="2" end="3" frame="proper_name(both)" id="7" lcat="np" lemma="very" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="very" sense="very" spectype="deeleigen" word="very"/>
+            <node begin="3" end="4" frame="proper_name(both)" id="8" lcat="np" lemma="beautiful" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="beautiful" sense="beautiful" spectype="deeleigen" word="beautiful"/>
+            <node begin="4" end="5" frame="proper_name(both)" id="9" lcat="np" lemma="and" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="and" sense="and" spectype="deeleigen" word="and"/>
+            <node begin="5" end="6" frame="proper_name(both)" id="10" lcat="np" lemma="beside" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="beside" sense="beside" spectype="deeleigen" word="beside"/>
+            <node begin="6" end="7" frame="proper_name(both)" id="11" lcat="np" lemma="there" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="there" sense="there" spectype="deeleigen" word="there"/>
+          </node>
+          <node begin="7" end="8" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="12" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="8" cat="pp" end="10" id="13" rel="mod">
+            <node begin="8" end="9" frame="preposition(à,[])" his="normal" his_1="variant" his_1_1="variant" his_1_1_1="à" his_1_1_2="a" his_1_2="normal" id="14" lcat="pp" lemma="à" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="à" sense="à" vztype="init" word="a"/>
+            <node begin="9" end="10" frame="meas_mod_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="tree" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="tree" sense="tree" special="meas_mod" word="tree"/>
+          </node>
+          <node begin="10" cat="mwu" end="18" his="name" his_1="not_begin" id="16" rel="predc">
+            <node begin="10" end="11" frame="proper_name(both)" id="17" lcat="np" lemma="and" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="and" sense="and" spectype="deeleigen" word="and"/>
+            <node begin="11" end="12" frame="proper_name(both)" id="18" lcat="np" lemma="over" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="over" sense="over" spectype="deeleigen" word="over"/>
+            <node begin="12" end="13" frame="proper_name(both)" id="19" lcat="np" lemma="there" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="there" sense="there" spectype="deeleigen" word="there"/>
+            <node begin="13" end="14" frame="proper_name(both)" id="20" lcat="np" lemma="I" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="I" sense="I" spectype="deeleigen" word="I"/>
+            <node begin="14" end="15" frame="proper_name(both)" id="21" lcat="np" lemma="see" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="see" sense="see" spectype="deeleigen" word="see"/>
+            <node begin="15" end="16" frame="proper_name(both)" id="22" lcat="np" lemma="the" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="the" sense="the" spectype="deeleigen" word="the"/>
+            <node begin="16" end="17" frame="proper_name(both)" id="23" lcat="np" lemma="big" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="big" sense="big" spectype="deeleigen" word="big"/>
+            <node begin="17" end="18" frame="proper_name(both)" id="24" lcat="np" lemma="mountain" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="mountain" sense="mountain" spectype="deeleigen" word="mountain"/>
+          </node>
+        </node>
+      </node>
+      <node begin="18" end="19" frame="punct(punt)" his="robust_skip" id="25" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Lake is very beautiful and beside there is a tree and over there I see the big mountain .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="mwu" end="9" his="name" his_1="begin" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(both)" id="2" lcat="np" lemma="There" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="There" sense="There" spectype="deeleigen" word="There"/>
+        <node begin="1" end="2" frame="proper_name(both)" id="3" lcat="np" lemma="is" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="is" sense="is" spectype="deeleigen" word="is"/>
+        <node begin="2" end="3" frame="proper_name(both)" id="4" lcat="np" lemma="a" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="a" sense="a" spectype="deeleigen" word="a"/>
+        <node begin="3" end="4" frame="proper_name(both)" id="5" lcat="np" lemma="very" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="very" sense="very" spectype="deeleigen" word="very"/>
+        <node begin="4" end="5" frame="proper_name(both)" id="6" lcat="np" lemma="beautiful" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="beautiful" sense="beautiful" spectype="deeleigen" word="beautiful"/>
+        <node begin="5" end="6" frame="proper_name(both)" id="7" lcat="np" lemma="And" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="And" sense="And" spectype="deeleigen" word="And"/>
+        <node begin="6" end="7" frame="proper_name(both)" id="8" lcat="np" lemma="this" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="this" sense="this" spectype="deeleigen" word="this"/>
+        <node begin="7" end="8" frame="proper_name(both)" id="9" lcat="np" lemma="Taro’s" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Taro’s" sense="Taro’s" spectype="deeleigen" word="Taro’s"/>
+        <node begin="8" end="9" frame="proper_name(both)" id="10" lcat="np" lemma="room" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="room" sense="room" spectype="deeleigen" word="room"/>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">There is a very beautiful And this Taro’s room .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="17" id="0" rel="top">
+      <node begin="0" cat="mwu" end="16" his="name" his_1="begin" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(both)" id="2" lcat="np" lemma="This" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="This" sense="This" spectype="deeleigen" word="This"/>
+        <node begin="1" end="2" frame="proper_name(both)" id="3" lcat="np" lemma="mountain" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="mountain" sense="mountain" spectype="deeleigen" word="mountain"/>
+        <node begin="2" end="3" frame="proper_name(both)" id="4" lcat="np" lemma="is" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="is" sense="is" spectype="deeleigen" word="is"/>
+        <node begin="3" end="4" frame="proper_name(both)" id="5" lcat="np" lemma="very" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="very" sense="very" spectype="deeleigen" word="very"/>
+        <node begin="4" end="5" frame="proper_name(both)" id="6" lcat="np" lemma="big" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="big" sense="big" spectype="deeleigen" word="big"/>
+        <node begin="5" end="6" frame="proper_name(both)" id="7" lcat="np" lemma="and" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="and" sense="and" spectype="deeleigen" word="and"/>
+        <node begin="6" end="7" frame="proper_name(both)" id="8" lcat="np" lemma="the" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="the" sense="the" spectype="deeleigen" word="the"/>
+        <node begin="7" end="8" frame="proper_name(both)" id="9" lcat="np" lemma="scene" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="scene" sense="scene" spectype="deeleigen" word="scene"/>
+        <node begin="8" end="9" frame="proper_name(both)" id="10" lcat="np" lemma="is" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="is" sense="is" spectype="deeleigen" word="is"/>
+        <node begin="9" end="10" frame="proper_name(both)" id="11" lcat="np" lemma="very" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="very" sense="very" spectype="deeleigen" word="very"/>
+        <node begin="10" end="11" frame="proper_name(both)" id="12" lcat="np" lemma="good" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="good" sense="good" spectype="deeleigen" word="good"/>
+        <node begin="11" end="12" frame="proper_name(both)" id="13" lcat="np" lemma="and" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="and" sense="and" spectype="deeleigen" word="and"/>
+        <node begin="12" end="13" frame="proper_name(both)" id="14" lcat="np" lemma="there" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="there" sense="there" spectype="deeleigen" word="there"/>
+        <node begin="13" end="14" frame="proper_name(both)" id="15" lcat="np" lemma="is" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="is" sense="is" spectype="deeleigen" word="is"/>
+        <node begin="14" end="15" frame="proper_name(both)" id="16" lcat="np" lemma="a" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="a" sense="a" spectype="deeleigen" word="a"/>
+        <node begin="15" end="16" frame="proper_name(both)" id="17" lcat="np" lemma="lake" neclass="MISC" num="both" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="lake" sense="lake" spectype="deeleigen" word="lake"/>
+      </node>
+      <node begin="16" end="17" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">This mountain is very big and the scene is very good and there is a lake .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/negative.example.alpino
+++ b/tests/negative.example.alpino
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="12" id="2" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="np" lemma="dit" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dit" sense="dit" status="vol" vwtype="aanw" wh="nwh" word="Dit"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="4" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="allesbehalve" pos="adv" postag="BW()" pt="bw" rel="mod" root="allesbehalve" sense="allesbehalve" word="allesbehalve"/>
+        <node begin="3" cat="np" end="6" id="6" rel="predc">
+          <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="7" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="onmogelijk" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="onmogelijk" sense="onmogelijk" vform="adj" word="onmogelijk"/>
+          <node begin="5" end="6" frame="noun(both,count,sg)" gen="both" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="plan" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="plan" sense="plan" word="plan"/>
+        </node>
+        <node begin="7" cat="pp" end="12" id="10" rel="mod">
+          <node begin="7" cat="mwu" end="10" his="normal" his_1="normal" id="11" rel="hd">
+            <node begin="7" end="8" frame="preposition([met,uitzondering,van],[])" id="12" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="mwp" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="8" end="9" frame="preposition([met,uitzondering,van],[])" genus="zijd" getal="ev" graad="basis" id="13" lcat="pp" lemma="uitzondering" naamval="stan" ntype="soort" pos="prep" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mwp" root="uitzondering" sense="uitzondering" word="uitzondering"/>
+            <node begin="9" end="10" frame="preposition([met,uitzondering,van],[])" id="14" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="mwp" root="van" sense="van" vztype="init" word="van"/>
+          </node>
+          <node begin="10" cat="np" end="12" id="15" rel="obj1">
+            <node begin="10" end="11" frame="determiner(de)" his="normal" his_1="normal" id="16" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="11" end="12" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" his="noun" id="17" lcat="np" lemma="decompunder" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="decompunder" sense="decompunder" word="decompunder"/>
+          </node>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dit is allesbehalve een onmogelijk plan , met uitzondering van de decompunder .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="du" end="8" id="1" rel="--">
+        <node begin="0" cat="smain" end="5" id="2" rel="dp">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+          <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="4" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="duidelijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="duidelijk" sense="duidelijk" vform="adj" word="duidelijk"/>
+          <node begin="3" end="4" frame="tmp_adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+          <node begin="4" end="5" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="compound" his_1="hyphen" id="7" lcat="np" lemma="non_issue" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="non_issue" sense="non_issue" word="non-issue"/>
+        </node>
+        <node begin="5" cat="smain" end="8" id="8" rel="dp">
+          <node begin="5" cat="np" end="7" id="9" rel="su">
+            <node begin="5" end="6" frame="determiner(een)" his="normal" his_1="normal" id="10" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node begin="6" end="7" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="compound" his_1="2" id="11" lcat="np" lemma="non_issue" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="non_issue" sense="non_issue" word="nonissue"/>
+          </node>
+          <node begin="7" end="8" frame="verb(unacc,sg_is,intransitive)" his="normal" his_1="normal" id="12" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="robust_skip" id="13" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het is duidelijk dan non-issue een nonissue is .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="We"/>
+        <node begin="1" end="2" frame="verb('hebben/zijn',pl,modifier(aux(inf)))" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="moeten" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" stype="declarative" tense="present" word="moeten" wvorm="pv"/>
+        <node begin="0" cat="inf" end="5" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="np" end="4" id="6" rel="obj1">
+            <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="3" end="4" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="software" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="software" sense="software" word="software"/>
+          </node>
+          <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,transitive)" his="wo_dia" id="9" infl="inf" lcat="inf" lemma="deïnstalleren" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="deïnstalleer" sc="transitive" sense="deïnstalleer" word="deinstalleren" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">We moeten de software deinstalleren .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/nomin.example.alpino
+++ b/tests/nomin.example.alpino
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" cat="np" end="2" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+          <node begin="1" end="2" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="moederschap" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="moederschap" sense="moederschap" word="moederschap"/>
+        </node>
+        <node begin="2" end="3" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node begin="3" cat="np" end="7" id="6" rel="predc">
+          <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="7" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="verrassing" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verrassing" sense="verrassing" word="verrassing"/>
+          <node begin="5" cat="pp" end="7" id="9" rel="mod">
+            <node begin="5" end="6" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="10" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+            <node begin="6" case="dat_acc" def="def" end="7" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="fem" getal="getal" his="normal" his_1="normal" id="11" lcat="np" lemma="haar" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,getal,fem)" pt="vnw" rel="obj1" rnum="sg" root="haar" sense="haar" status="vol" vwtype="pers" wh="nwh" word="haar"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het moederschap was een verrassing voor haar .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/noun-adv.example.alpino
+++ b/tests/noun-adv.example.alpino
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="smain" end="4" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,part_intransitive(achter))" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="achter_lopen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="loop_achter" sc="part_intransitive(achter)" sense="loop_achter" stype="declarative" tense="present" word="loopt" wvorm="pv"/>
+        <node begin="2" end="3" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="eeuw" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="mod" rnum="pl" root="eeuw" sense="eeuw" special="tmp" word="eeuwen"/>
+        <node begin="3" end="4" frame="particle(achter)" his="normal" his_1="normal" id="5" lcat="part" lemma="achter" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="achter" sense="achter" vztype="fin" word="achter"/>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="6" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij loopt eeuwen achter .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="2" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,aux_psp_zijn)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="6" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" end="3" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="mod" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+          <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+          <node begin="4" end="5" frame="loc_adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="thuis" pos="adv" postag="BW()" pt="bw" rel="ld" root="thuis" sense="thuis" special="loc" word="thuis"/>
+          <node begin="5" buiging="zonder" end="6" frame="verb(unacc,psp,ld_adv)" his="normal" his_1="normal" id="9" infl="psp" lcat="ppart" lemma="zijn" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="ld_adv" sense="ben" word="geweest" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">hij is jaren niet thuis geweest .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:20" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,intransitive)" his="normal" his_1="normal" id="3" infl="sg3" lcat="smain" lemma="tennissen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="tennis" sc="intransitive" sense="tennis" stype="declarative" tense="present" word="tennist" wvorm="pv"/>
+        <node begin="2" cat="np" end="4" id="4" rel="mod">
+          <node begin="2" end="3" frame="modal_adverb" his="normal" his_1="normal" id="5" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sc="modal" sense="al" word="al"/>
+          <node begin="3" end="4" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+        </node>
+        <node begin="4" cat="advp" end="6" id="7" rel="mod">
+          <node begin="4" end="5" frame="adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+          <node begin="5" buiging="zonder" end="6" frame="postadv_adverb" graad="comp" his="normal" his_1="normal" id="9" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="meer"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">hij tennist al jaren niet meer .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/npmod.example.alpino
+++ b/tests/npmod.example.alpino
@@ -1,0 +1,833 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="3" id="0" rel="top">
+      <node begin="0" cat="np" end="2" id="1" rel="--">
+        <node begin="0" buiging="met-e" end="1" frame="determiner(alle,nwh,mod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="alle" lcat="detp" lemma="al" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,met-e,agr)" pt="vnw" rel="det" root="al" sense="al" vwtype="onbep" wh="nwh" word="Alle"/>
+        <node begin="1" end="2" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="boek" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="boek" sense="boek" word="boeken"/>
+      </node>
+      <node begin="2" end="3" frame="punct(punt)" his="normal" his_1="normal" id="4" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Alle boeken .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="np" end="5" id="1" rel="--">
+        <node begin="0" buiging="met-e" end="1" frame="determiner(alle,nwh,mod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="alle" lcat="detp" lemma="al" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,met-e,agr)" pt="vnw" rel="det" root="al" sense="al" vwtype="onbep" wh="nwh" word="Alle"/>
+        <node begin="1" end="2" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="kind" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="kind" sense="kind" word="kinderen"/>
+        <node begin="2" cat="cp" end="5" id="4" rel="mod">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(np)" his="normal" his_1="normal" id="5" lcat="cp" lemma="behalve" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="behalve" sc="np" sense="behalve" word="behalve"/>
+          <node begin="3" cat="np" end="5" id="6" rel="body">
+            <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node aform="super" begin="4" buiging="met-e" end="5" frame="adjective(ste)" getal-n="zonder-n" graad="sup" his="normal" his_1="normal" id="8" infl="e" lcat="np" lemma="oud" naamval="stan" pos="adj" positie="nom" postag="ADJ(nom,sup,met-e,zonder-n,stan)" pt="adj" rel="hd" rnum="sg" root="oud" sense="oud" vform="adj" word="oudste"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Alle kinderen behalve de oudste .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" cat="detp" end="3" id="2" rel="det">
+          <node begin="0" cat="detp" end="2" id="3" rel="mod">
+            <node begin="0" buiging="met-e" end="1" frame="num_predm_adverb" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="np" lemma="al" naamval="stan" npagr="agr" pdtype="det" pos="det" positie="prenom" postag="VNW(onbep,det,stan,prenom,met-e,agr)" pt="vnw" rel="det" root="al" sense="al" special="num_predm" vwtype="onbep" word="Alle"/>
+            <node begin="1" end="2" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="5" infl="pl_num" lcat="detp" lemma="vijf" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="hd" root="vijf" sense="vijf" word="vijf"/>
+          </node>
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="6" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="hd" root="de" sense="de" word="de"/>
+        </node>
+        <node begin="3" end="4" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="boek" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="boek" sense="boek" word="boeken"/>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Alle vijf de boeken .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="3" id="0" rel="top">
+      <node begin="0" cat="np" end="2" id="1" rel="--">
+        <node begin="0" end="1" frame="meas_mod_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="bladzij" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="bladzij" sense="bladzij" special="meas_mod" word="Bladzij"/>
+        <node begin="1" end="2" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="3" infl="pl_num" lcat="detp" lemma="22" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="app" root="22" sense="22" word="22"/>
+      </node>
+      <node begin="2" end="3" frame="punct(punt)" his="normal" his_1="normal" id="4" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Bladzij 22 .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="3" id="0" rel="top">
+      <node begin="0" cat="np" end="2" id="1" rel="--">
+        <node aform="base" begin="0" buiging="met-e" end="1" frame="adjective(ende(padv))" his="normal" his_1="decap" his_1_1="V-de" his_1_1_1="normal" id="2" infl="e" lcat="ppres" lemma="blaffen" pos="adj" positie="prenom" postag="WW(od,prenom,met-e)" pt="ww" rel="mod" root="blaf" sense="blaf" vform="gerund" word="Blaffende" wvorm="od"/>
+        <node begin="1" end="2" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="hond" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hond" sense="hond" word="honden"/>
+      </node>
+      <node begin="2" end="3" frame="punct(punt)" his="normal" his_1="normal" id="4" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Blaffende honden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" cat="np" end="2" his="normal" his_1="decap" his_1_1="normal" id="2" rel="det">
+          <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" id="3" infl="het" lcat="detp" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="det" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="Dat"/>
+          <node begin="1" end="2" frame="noun(both,both,sg)" gen="both" genus="genus" getal="ev" graad="basis" id="4" lcat="np" lemma="soort" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,genus,stan)" pt="n" rel="hd" root="soort" sense="soort" word="soort"/>
+        </node>
+        <node begin="2" end="3" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="vraag" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="vraag" sense="vraag" word="vragen"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="6" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat soort vragen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="np" end="7" id="2" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="componist" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="componist" sense="componist" word="componist"/>
+        <node begin="2" cat="pp" end="5" id="5" rel="mod">
+          <node begin="2" end="3" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="6" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="3" cat="np" end="5" id="7" rel="obj1">
+            <node begin="3" buiging="met-e" end="4" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="8" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+            <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="sonate" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="sonate" sense="sonate" word="sonate"/>
+          </node>
+        </node>
+        <node begin="6" end="7" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="10" lcat="np" lemma="Mozart" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="Mozart" sense="Mozart" word="Mozart"/>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De componist van deze sonate , Mozart .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="number(rang)" his="normal" his_1="normal" id="3" lcat="ap" lemma="één" naamval="stan" numtype="rang" pos="num" positie="prenom" postag="TW(rang,prenom,stan)" pt="tw" rel="mod" root="één" sense="één" word="eerste"/>
+        <node begin="2" end="3" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="4" infl="pl_num" lcat="detp" lemma="drie" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="drie" sense="drie" word="drie"/>
+        <node begin="3" end="4" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="kind" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="kind" sense="kind" word="kinderen"/>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="6" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De eerste drie kinderen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" his="form_of_suffix" his_1="eerde" id="3" infl="e" lcat="ap" lemma="geasfalteerd" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="geasfalteerd" sense="geasfalteerd" vform="adj" word="geasfalteerde"/>
+        <node begin="2" end="3" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="weg" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="weg" sense="weg" special="tmp" word="wegen"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De geasfalteerde wegen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="np" end="7" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="groep" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="groep" sense="groep" word="groep"/>
+        <node begin="2" cat="rel" end="7" id="4" rel="mod">
+          <node begin="2" end="3" frame="waar_adverb(tot)" his="normal" his_1="normal" id="5" index="1" lcat="pp" lemma="waartoe" pos="pp" postag="BW()" pt="bw" rel="rhd" root="waartoe" sense="waartoe" special="waar" word="waartoe"/>
+          <node begin="2" cat="ssub" end="7" id="6" rel="body">
+            <node begin="2" end="3" id="7" index="1" rel="pc"/>
+            <node begin="3" cat="np" end="6" id="8" rel="su">
+              <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node aform="super" begin="4" buiging="met-e" end="5" frame="adjective(ste)" graad="sup" his="normal" his_1="normal" id="10" infl="e" lcat="ap" lemma="groot" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,sup,met-e,stan)" pt="adj" rel="mod" root="groot" sense="groot" vform="adj" word="grootste"/>
+              <node begin="5" end="6" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="hert" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hert" sense="hert" word="herten"/>
+            </node>
+            <node begin="6" end="7" frame="verb(hebben,pl,pc_pp(tot))" his="normal" his_1="normal" id="12" infl="pl" lcat="ssub" lemma="behoren" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="behoor" sc="pc_pp(tot)" sense="behoor-tot" tense="present" word="behoren" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De groep waartoe de grootste herten behoren .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="np" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="groep" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="groep" sense="groep" word="groep"/>
+        <node begin="2" cat="rel" end="6" id="4" rel="mod">
+          <node begin="2" end="3" frame="waar_adverb(tot)" his="normal" his_1="normal" id="5" index="1" lcat="pp" lemma="waartoe" pos="pp" postag="BW()" pt="bw" rel="rhd" root="waartoe" sense="waartoe" special="waar" word="waartoe"/>
+          <node begin="2" cat="ssub" end="6" id="6" rel="body">
+            <node begin="2" end="3" id="7" index="1" rel="pc"/>
+            <node begin="3" cat="np" end="5" id="8" rel="su">
+              <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="9" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="4" end="5" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="hert" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hert" sense="hert" word="herten"/>
+            </node>
+            <node begin="5" end="6" frame="verb(hebben,pl,pc_pp(tot))" his="normal" his_1="normal" id="11" infl="pl" lcat="ssub" lemma="behoren" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="behoor" sc="pc_pp(tot)" sense="behoor-tot" tense="present" word="behoren" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De groep waartoe de herten behoren .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="np" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="groep" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="groep" sense="groep" word="groep"/>
+        <node begin="2" cat="rel" end="8" id="4" rel="mod">
+          <node begin="2" end="3" frame="waar_adverb(tot)" his="normal" his_1="normal" id="5" index="1" lcat="pp" lemma="waartoe" pos="pp" postag="BW()" pt="bw" rel="rhd" root="waartoe" sense="waartoe" special="waar" word="waartoe"/>
+          <node begin="2" cat="ssub" end="8" id="6" rel="body">
+            <node begin="2" end="3" id="7" index="1" rel="pc"/>
+            <node begin="3" cat="conj" end="7" id="8" rel="su">
+              <node begin="3" cat="np" end="5" id="9" rel="cnj">
+                <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="10" index="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="4" end="5" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="hert" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hert" sense="hert" word="herten"/>
+              </node>
+              <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="3" cat="np" end="7" id="13" rel="cnj">
+                <node begin="3" end="4" id="14" index="2" rel="det"/>
+                <node begin="6" end="7" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="zwijn" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="zwijn" sense="zwijn" word="zwijnen"/>
+              </node>
+            </node>
+            <node begin="7" end="8" frame="verb(hebben,pl,pc_pp(tot))" his="normal" his_1="normal" id="16" infl="pl" lcat="ssub" lemma="behoren" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="behoor" sc="pc_pp(tot)" sense="behoor-tot" tense="present" word="behoren" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De groep waartoe de herten en zwijnen behoren .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="tmp_noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="jeugd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="jeugd" sense="jeugd" special="tmp" word="jeugd"/>
+        <node begin="2" cat="pp" end="4" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(van,[af],tmp_adv)" his="normal" his_1="normal" id="5" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sc="tmp_adv" sense="van" vztype="init" word="van"/>
+          <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(tmpadv))" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="tegenwoordig" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="obj1" root="tegenwoordig" sense="tegenwoordig" vform="adj" word="tegenwoordig"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De jeugd van tegenwoordig .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg,app_measure)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="leraar" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="leraar" sc="app_measure" sense="leraar" word="leraar"/>
+        <node begin="2" end="3" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="aardrijkskunde" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="aardrijkskunde" sense="aardrijkskunde" word="aardrijkskunde"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De leraar aardrijkskunde .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node aform="super" begin="1" buiging="met-e" end="2" frame="adjective(ste)" graad="sup" his="normal" his_1="normal" id="3" infl="e" lcat="ap" lemma="veel" naamval="stan" npagr="agr" pdtype="grad" pos="adj" positie="prenom" postag="VNW(onbep,grad,stan,prenom,met-e,agr,sup)" pt="vnw" rel="mod" root="veel" sense="veel" vform="adj" vwtype="onbep" word="meeste"/>
+        <node begin="2" end="3" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="boek" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="boek" sense="boek" word="boeken"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De meeste boeken .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="np" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg,vp)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="opdracht" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="opdracht" sc="vp" sense="opdracht" word="opdracht"/>
+        <node begin="2" cat="oti" end="6" id="4" rel="vc">
+          <node begin="2" end="3" frame="complementizer(om)" his="normal" his_1="normal" id="5" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+          <node begin="3" cat="ti" end="6" id="6" rel="body">
+            <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="7" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="3" cat="inf" end="6" id="8" rel="body">
+              <node begin="3" end="4" frame="particle(thuis)" his="normal" his_1="normal" id="9" lcat="part" lemma="thuis" pos="part" postag="BW()" pt="bw" rel="svp" root="thuis" sense="thuis" word="thuis"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(unacc,inf,part_intransitive(thuis))" his="normal" his_1="normal" id="10" infl="inf" lcat="inf" lemma="thuis_blijven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="blijf_thuis" sc="part_intransitive(thuis)" sense="blijf_thuis" word="blijven" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De opdracht om thuis te blijven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="plek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="plek" sense="plek" word="plek"/>
+        <node begin="2" cat="np" end="4" his="normal" his_1="normal" id="4" rel="mod">
+          <node begin="2" end="3" frame="determiner(des)" id="5" infl="des" lcat="detp" lemma="de" lwtype="bep" naamval="gen" npagr="evmo" pos="det" postag="LID(bep,gen,evmo)" pt="lid" rel="det" root="de" sense="de" word="des"/>
+          <node begin="3" end="4" frame="noun(both,both,both)" gen="both" genus="zijd" getal="ev" graad="basis" id="6" lcat="np" lemma="onheil" naamval="stan" ntype="soort" num="both" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="onheil" sense="onheil" word="onheils"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De plek des onheils .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="9" id="3" rel="--">
+        <node begin="0" cat="np" end="6" id="4" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="schipper" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="schipper" sense="schipper" word="schipper"/>
+          <node begin="3" cat="np" end="6" id="7" rel="app">
+            <node begin="3" end="4" frame="determiner(een)" his="normal" his_1="normal" id="8" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="9" infl="no_e" lcat="ap" lemma="voorzichtig" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="voorzichtig" sense="voorzichtig" vform="adj" word="voorzichtig"/>
+            <node begin="5" end="6" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          </node>
+        </node>
+        <node begin="7" end="8" frame="verb(unacc,past(sg),part_intransitive(thuis))" his="normal" his_1="normal" id="11" infl="sg" lcat="smain" lemma="thuis_blijven" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="blijf_thuis" sc="part_intransitive(thuis)" sense="blijf_thuis" stype="declarative" tense="past" word="bleef" wvorm="pv"/>
+        <node begin="8" end="9" frame="particle(thuis)" his="normal" his_1="normal" id="12" lcat="part" lemma="thuis" pos="part" postag="BW()" pt="bw" rel="svp" root="thuis" sense="thuis" word="thuis"/>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De schipper , een voorzichtig man , bleef thuis .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(both,count,sg)" gen="both" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="stad" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="stad" sense="stad" word="stad"/>
+        <node begin="2" end="3" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="4" lcat="np" lemma="Antwerpen" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="app" rnum="sg" root="Antwerpen" sense="Antwerpen" word="Antwerpen"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De stad Antwerpen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" cat="ti" end="3" id="3" rel="mod">
+          <node begin="1" end="2" frame="complementizer(te)" his="normal" his_1="normal" id="4" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+          <node begin="2" buiging="zonder" end="3" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="5" infl="inf" lcat="inf" lemma="nemen" pos="verb" positie="prenom" postag="WW(inf,prenom,zonder)" pt="ww" rel="body" root="neem" sc="transitive" sense="neem" word="nemen" wvorm="inf"/>
+        </node>
+        <node begin="3" end="4" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="maatregel" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="maatregel" sense="maatregel" word="maatregelen"/>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De te nemen maatregelen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="np" end="7" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg,sbar)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="verwachting" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verwachting" sc="sbar" sense="verwachting" word="verwachting"/>
+        <node begin="2" cat="cp" end="7" id="4" rel="vc">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="5" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+          <node begin="3" cat="ssub" end="7" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="snel" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="snel" sense="snel" vform="adj" word="snel"/>
+            <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="9" lcat="advp" lemma="weer" pos="adv" postag="BW()" pt="bw" rel="mod" root="weer" sense="weer" word="weer"/>
+            <node begin="6" end="7" frame="verb(zijn,sg3,ninv(intransitive,part_intransitive(op)))" his="normal" his_1="part-V" id="10" infl="sg3" lcat="ssub" lemma="op_knappen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="knap_op" sc="part_intransitive(op)" sense="knap_op" tense="present" word="opknapt" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De verwachting dat hij snel weer opknapt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="np" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+        <node begin="1" end="2" frame="noun(de,count,sg,sbar)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="vraag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="vraag" sc="sbar" sense="vraag" word="vraag"/>
+        <node begin="2" cat="whsub" end="6" id="4" rel="vc">
+          <node begin="2" case="both" def="indef" end="3" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="whd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="wie"/>
+          <node begin="2" cat="ssub" end="6" id="6" rel="body">
+            <node begin="2" end="3" id="7" index="1" rel="su"/>
+            <node begin="2" cat="ppart" end="5" id="8" rel="vc">
+              <node begin="2" end="3" id="9" index="1" rel="su"/>
+              <node begin="3" end="4" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="10" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="obj1" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+              <node begin="4" buiging="zonder" end="5" frame="verb(hebben,psp,transitive_ndev)" his="normal" his_1="normal" id="11" infl="psp" lcat="ppart" lemma="doen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="doe" sc="transitive_ndev" sense="doe" word="gedaan" wvorm="vd"/>
+            </node>
+            <node begin="5" end="6" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="12" infl="sg_heeft" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="present" word="heeft" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De vraag wie dat gedaan heeft .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" buiging="zonder" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="Die"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="kamer" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kamer" sense="kamer" word="kamer"/>
+        <node begin="2" end="3" frame="loc_adverb" his="normal" his_1="normal" id="4" lcat="advp" lemma="boven" pos="adv" postag="VZ(fin)" pt="vz" rel="mod" root="boven" sense="boven" special="loc" vztype="fin" word="boven"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Die kamer boven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="np" end="6" id="1" rel="--">
+        <node begin="0" buiging="zonder" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="Die"/>
+        <node begin="1" end="2" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="wedstrijd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wedstrijd" sense="wedstrijd" special="tmp" word="wedstrijd"/>
+        <node begin="2" end="3" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="prefix_name" id="4" lcat="np" lemma="Ajax_Anderlecht" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="app" rnum="sg" root="Ajax_Anderlecht" sense="Ajax_Anderlecht" word="Ajax-Anderlecht"/>
+        <node begin="3" cat="pp" end="6" id="5" rel="mod">
+          <node begin="3" end="4" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="6" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="4" cat="np" end="6" id="7" rel="obj1">
+            <node aform="base" begin="4" buiging="met-e" end="5" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="vorig" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="vorig" sense="vorig" vform="adj" word="vorige"/>
+            <node begin="5" end="6" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="week" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="week" sense="week" special="tmp" word="week"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Die wedstrijd Ajax-Anderlecht van vorige week .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="np" end="5" id="1" rel="--">
+        <node begin="0" buiging="zonder" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="de" lcat="detp" lemma="die" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,rest)" pt="vnw" rel="det" root="die" sense="die" vwtype="aanw" wh="nwh" word="Die"/>
+        <node begin="1" end="2" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="wedstrijd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wedstrijd" sense="wedstrijd" special="tmp" word="wedstrijd"/>
+        <node begin="2" end="3" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="prefix_name" id="4" lcat="np" lemma="Ajax_Anderlecht" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="app" rnum="sg" root="Ajax_Anderlecht" sense="Ajax_Anderlecht" word="Ajax-Anderlecht"/>
+        <node begin="3" cat="np" end="5" id="5" rel="mod">
+          <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="6" infl="e" lcat="ap" lemma="vorig" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="vorig" sense="vorig" vform="adj" word="vorige"/>
+          <node begin="4" end="5" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="week" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="week" sense="week" special="tmp" word="week"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Die wedstrijd Ajax-Anderlecht vorige week .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="np" end="5" id="1" rel="--">
+        <node begin="0" cat="mwu" end="4" his="normal" his_1="decap" his_1_1="eneenhalve" id="2" rel="mod">
+          <node aform="base" begin="0" buiging="met-e" end="1" frame="adjective(e)" graad="basis" id="3" infl="e" lcat="ap" lemma="drie" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mwp" root="drie" sense="drie" vform="adj" word="Drie"/>
+          <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" id="4" infl="e" lcat="ap" lemma="en" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mwp" root="en" sense="en" vform="adj" word="en"/>
+          <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" id="5" infl="e" lcat="ap" lemma="een" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mwp" root="een" sense="een" vform="adj" word="een"/>
+          <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" id="6" infl="e" lcat="ap" lemma="halve" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mwp" root="halve" sense="halve" vform="adj" word="halve"/>
+        </node>
+        <node begin="4" end="5" frame="meas_mod_noun(de,count,meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="liter" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="liter" sense="liter" special="meas_mod" word="liter"/>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Drie en een halve liter .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="number(hoofd(pl_num))" his="normal" his_1="decap" his_1_1="number_expression" id="2" infl="pl_num" lcat="detp" lemma="drie" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="drie" sense="drie" word="Drie"/>
+        <node begin="1" end="2" frame="meas_mod_noun(de,count,meas,measure)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="liter" naamval="stan" ntype="soort" num="meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="liter" sc="measure" sense="liter" special="meas_mod" word="liter"/>
+        <node begin="2" end="3" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="melk" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="melk" sense="melk" word="melk"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Drie liter melk .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="np" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="auto" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="auto" sense="auto" word="auto"/>
+        <node begin="2" cat="cp" end="6" id="4" rel="mod">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(zoals)" his="normal" his_1="normal" id="5" lcat="cp" lemma="zoals" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zoals" sc="zoals" sense="zoals" word="zoals"/>
+          <node begin="3" cat="np" end="6" id="6" rel="body">
+            <node begin="3" end="4" frame="determiner(de,nwh,nmod,pro,nparg)" getal="getal" his="normal" his_1="normal" id="7" infl="de" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(aanw,pron,stan,vol,3,getal)" pt="vnw" rel="hd" rnum="sg" root="die" sense="die" status="vol" vwtype="aanw" wh="nwh" word="die"/>
+            <node begin="4" cat="pp" end="6" id="8" rel="mod">
+              <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="9" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+              <node begin="5" end="6" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="10" lcat="np" lemma="Rinus" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="obj1" rnum="sg" root="Rinus" sense="Rinus" word="Rinus"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een auto zoals die van Rinus .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="np" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        <node begin="2" cat="rel" end="8" id="4" rel="mod">
+          <node begin="2" case="no_obl" end="3" frame="rel_pronoun(het,no_obl)" gen="het" getal="ev" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3" pos="pron" postag="VNW(betr,pron,stan,vol,3,ev)" pt="vnw" rel="rhd" rnum="sg" root="dat" sense="dat" status="vol" vwtype="betr" wh="rel" word="dat"/>
+          <node begin="2" cat="ssub" end="8" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="7" index="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="4" end="5" frame="predm_adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="zelf" pos="adv" postag="BW()" pt="bw" rel="predm" root="zelf" sense="zelf" special="predm" word="zelf"/>
+            <node begin="5" end="6" frame="verb(hebben,past(sg),aux(inf))" his="normal" his_1="normal" id="9" infl="sg" lcat="ssub" lemma="zullen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="past" word="zou" wvorm="pv"/>
+            <node begin="2" cat="inf" end="8" id="10" rel="vc">
+              <node begin="3" end="4" id="11" index="2" rel="su"/>
+              <node begin="6" buiging="zonder" end="7" frame="verb(hebben,inf,modifier(aux(inf)))" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="willen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" word="willen" wvorm="inf"/>
+              <node begin="2" cat="inf" end="8" id="13" rel="vc">
+                <node begin="2" end="3" id="14" index="1" rel="obj1"/>
+                <node begin="3" end="4" id="15" index="2" rel="su"/>
+                <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="schrijven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="schrijf" sc="transitive" sense="schrijf" word="schrijven" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een boek dat ik zelf zou willen schrijven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="np" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        <node begin="2" cat="pp" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="5" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+          <node begin="3" cat="np" end="5" id="6" rel="obj1">
+            <node begin="3" end="4" frame="noun(het,count,pl)" gen="het" getal="mv" graad="dim" his="normal" his_1="normal" id="7" lcat="np" lemma="plaat" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,dim)" pt="n" rel="hd" rnum="pl" root="plaat_DIM" sense="plaat_DIM" word="plaatjes"/>
+            <node begin="4" end="5" frame="er_adverb(in)" his="normal" his_1="normal" id="8" lcat="pp" lemma="erin" pos="pp" postag="BW()" pt="bw" rel="mod" root="erin" sense="erin" special="er" word="erin"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een boek met plaatjes erin .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="np" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="boek" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="boek" sense="boek" word="boek"/>
+        <node begin="2" cat="cp" end="8" id="4" rel="mod">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(zoals)" his="normal" his_1="normal" id="5" lcat="cp" lemma="zoals" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="zoals" sc="zoals" sense="zoals" word="zoals"/>
+          <node begin="3" cat="ssub" end="8" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="4" end="5" frame="predm_adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="zelf" pos="adv" postag="BW()" pt="bw" rel="predm" root="zelf" sense="zelf" special="predm" word="zelf"/>
+            <node begin="5" end="6" frame="verb(hebben,past(sg),aux(inf))" his="normal" his_1="normal" id="9" infl="sg" lcat="ssub" lemma="zullen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="past" word="zou" wvorm="pv"/>
+            <node begin="3" cat="inf" end="8" id="10" rel="vc">
+              <node begin="3" end="4" id="11" index="1" rel="su"/>
+              <node begin="6" buiging="zonder" end="7" frame="verb(hebben,inf,modifier(aux(inf)))" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="willen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" word="willen" wvorm="inf"/>
+              <node begin="3" cat="inf" end="8" id="13" rel="vc">
+                <node begin="3" end="4" id="14" index="1" rel="su"/>
+                <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="15" infl="inf" lcat="inf" lemma="schrijven" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="schrijf" sc="intransitive" sense="schrijf" word="schrijven" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een boek zoals ik zelf zou willen schrijven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+        <node begin="2" cat="cp" end="4" id="4" rel="mod">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer(als)" his="normal" his_1="normal" id="5" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+          <node begin="3" end="4" frame="tmp_adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="vandaag" pos="adv" postag="BW()" pt="bw" rel="body" root="vandaag" sense="vandaag" special="tmp" word="vandaag"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een dag als vandaag .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="3" infl="no_e" lcat="ap" lemma="duur" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="duur" sense="duur" vform="adj" word="duur"/>
+        <node begin="2" end="3" frame="number(rang)" his="normal" his_1="number_rang" id="4" lcat="ap" lemma="twee" naamval="stan" numtype="rang" pos="num" positie="prenom" postag="TW(rang,prenom,stan)" pt="tw" rel="mod" root="twee" sense="twee" word="tweede"/>
+        <node begin="3" end="4" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="huis" sense="huis" word="huis"/>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="6" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een duur tweede huis .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="glas" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="glas" sc="measure" sense="glas" word="glas"/>
+        <node begin="2" cat="np" end="4" id="4" rel="mod">
+          <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="5" infl="e" lcat="ap" lemma="rood" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="rood" sense="rood" vform="adj" word="rode"/>
+          <node begin="3" end="4" frame="noun(de,both,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="wijn" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="wijn" sense="wijn" word="wijn"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een glas rode wijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="3" lcat="np" lemma="kaart" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="kaart_DIM" sense="kaart_DIM" word="kaartje"/>
+        <node begin="2" cat="np" end="4" his="normal" his_1="normal" id="4" rel="mod">
+          <node begin="2" end="3" frame="number(rang)" id="5" lcat="detp" lemma="één" naamval="stan" numtype="rang" pos="num" positie="prenom" postag="TW(rang,prenom,stan)" pt="tw" rel="det" root="eerste" sense="eerste" word="eerste"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" id="6" lcat="np" lemma="klas" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" root="klas" sense="klas" word="klas"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een kaartje eerste klas .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="np" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="kind" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="kind" sense="kind" word="kind"/>
+        <node begin="2" cat="oti" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="complementizer(om)" his="normal" his_1="normal" id="5" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+          <node begin="3" cat="ti" end="5" id="6" rel="body">
+            <node begin="3" end="4" frame="complementizer(te)" his="normal" his_1="normal" id="7" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="8" infl="inf" lcat="inf" lemma="zoenen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="body" root="zoen" sc="intransitive" sense="zoen" word="zoenen" wvorm="inf"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een kind om te zoenen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="noun(het,count,sg,measure)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="3" lcat="np" lemma="plak" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="plak_DIM" sc="measure" sense="plak_DIM" word="plakje"/>
+        <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="kaas" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="mod" rnum="sg" root="kaas" sense="kaas" word="kaas"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een plakje kaas .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+        <node begin="1" end="2" frame="number(rang)" his="normal" his_1="number_rang" id="3" lcat="ap" lemma="twee" naamval="stan" numtype="rang" pos="num" positie="prenom" postag="TW(rang,prenom,stan)" pt="tw" rel="mod" root="twee" sense="twee" word="tweede"/>
+        <node begin="2" end="3" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="huis" sense="huis" word="huis"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een tweede huis .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="noun(both,count,sg)" gen="both" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="arbeid_bureau" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="arbeid_bureau" sense="arbeid_bureau" word="arbeidsbureau"/>
+        <node begin="2" cat="np" end="4" his="normal" his_1="normal" id="4" rel="mod">
+          <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" id="5" infl="e" lcat="ap" lemma="nieuw" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="nieuw" sense="nieuw" vform="adj" word="nieuwe"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" id="6" lcat="np" lemma="stijl" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" root="stijl" sense="stijl" word="stijl"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het arbeidsbureau nieuwe stijl .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="getal" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="getal" sense="getal" word="getal"/>
+        <node begin="2" end="3" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="4" infl="pl_num" lcat="detp" lemma="zeven" numtype="hoofd" pos="num" positie="vrij" postag="TW(hoofd,vrij)" pt="tw" rel="app" root="zeven" sense="zeven" word="zeven"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het getal zeven .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="noun(het,count,sg,app_measure)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="hoofd" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="hoofd" sc="app_measure" sense="hoofd" word="hoofd"/>
+        <node begin="2" cat="np" end="4" id="4" rel="app">
+          <node aform="base" begin="2" buiging="met-e" end="3" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="5" infl="e" lcat="ap" lemma="buitenlands" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="buitenlands" sense="buitenlands" vform="adj" word="buitenlandse"/>
+          <node begin="3" end="4" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="betrekking" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="betrekking" sense="betrekking" word="betrekkingen"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het hoofd buitenlandse betrekkingen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="np" end="5" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="huis" sense="huis" word="huis"/>
+        <node begin="2" cat="pp" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="5" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="3" cat="np" end="5" id="6" rel="obj1">
+            <node begin="3" buiging="zonder" end="4" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="7" infl="pron" lcat="detp" lemma="mijn" naamval="stan" npagr="agr" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="mijn" sense="mijn" status="vol" vwtype="bez" word="mijn"/>
+            <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="ouder" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="ouder" sense="ouder" word="ouders"/>
+          </node>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het huis van mijn ouders .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,transitive_ndev)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="transitive_ndev" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="2" cat="np" end="8" id="4" rel="obj1">
+          <node begin="2" end="3" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="5" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+          <node begin="3" end="4" frame="noun(het,count,sg,vp)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="gevoel" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="gevoel" sc="vp" sense="gevoel" word="gevoel"/>
+          <node begin="4" cat="ti" end="8" id="7" rel="vc">
+            <node begin="6" end="7" frame="complementizer(te)" his="normal" his_1="normal" id="8" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="4" cat="inf" end="8" id="9" rel="body">
+              <node begin="4" cat="pp" end="6" id="10" rel="ld">
+                <node begin="4" end="5" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="11" lcat="advp" lemma="nergens" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(onbep,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="obj1" root="nergens" sense="nergens" special="er_loc" status="vol" vwtype="onbep" word="nergens"/>
+                <node begin="5" end="6" frame="preposition(bij,[vandaan])" his="normal" his_1="normal" id="12" lcat="pp" lemma="bij" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="bij" sense="bij" vztype="fin" word="bij"/>
+              </node>
+              <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,ld_pp)" his="normal" his_1="normal" id="13" infl="inf" lcat="inf" lemma="horen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="hoor" sc="ld_pp" sense="hoor" word="horen" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb het gevoel nergens bij te horen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="np" end="3" id="1" rel="--">
+        <node begin="0" end="1" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="jongen" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="jongen" sense="jongen" word="Jongens"/>
+        <node begin="1" cat="pp" end="3" id="3" rel="mod">
+          <node begin="1" end="2" frame="preposition(zonder,[])" his="normal" his_1="normal" id="4" lcat="pp" lemma="zonder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="zonder" sense="zonder" vztype="init" word="zonder"/>
+          <node begin="2" end="3" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="manier" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="manier" sense="manier" word="manieren"/>
+        </node>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="6" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jongens zonder manieren .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="5" id="0" rel="top">
+      <node begin="0" cat="np" end="4" id="1" rel="--">
+        <node begin="0" end="1" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="koning" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="koning" sense="koning" word="Koning"/>
+        <node begin="1" end="2" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Boudewijn" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="Boudewijn" sense="Boudewijn" word="Boudewijn"/>
+        <node begin="2" cat="pp" end="4" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="5" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="3" end="4" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="6" lcat="np" lemma="België" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="België" sense="België" word="België"/>
+        </node>
+      </node>
+      <node begin="4" end="5" frame="punct(punt)" his="normal" his_1="normal" id="7" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Koning Boudewijn van België .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="np" end="8" id="2" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Mozart" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Mozart" sense="Mozart" word="Mozart"/>
+        <node begin="2" cat="np" end="8" id="4" rel="app">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="componist" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="componist" sense="componist" word="componist"/>
+          <node begin="4" cat="pp" end="8" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="5" cat="np" end="8" id="9" rel="obj1">
+              <node begin="5" buiging="met-e" end="6" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+              <node aform="base" begin="6" buiging="met-e" end="7" frame="adjective(ende(adv))" his="normal" his_1="normal" id="11" infl="e" lcat="ppres" lemma="schitteren" pos="adj" positie="prenom" postag="WW(od,prenom,met-e)" pt="ww" rel="mod" root="schitteren" sense="schitteren" vform="gerund" word="schitterende" wvorm="od"/>
+              <node begin="7" end="8" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="sonate" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="sonate" sense="sonate" word="sonate"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Mozart , de componist van deze schitterende sonate .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="1" end="2" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="np" end="7" id="2" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Mozart" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Mozart" sense="Mozart" word="Mozart"/>
+        <node begin="2" cat="np" end="7" id="4" rel="app">
+          <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="5" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="componist" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="componist" sense="componist" word="componist"/>
+          <node begin="4" cat="pp" end="7" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="8" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+            <node begin="5" cat="np" end="7" id="9" rel="obj1">
+              <node begin="5" buiging="met-e" end="6" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="deze"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="sonate" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="sonate" sense="sonate" word="sonate"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Mozart , de componist van deze sonate .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="3" id="0" rel="top">
+      <node begin="0" cat="np" end="2" id="1" rel="--">
+        <node begin="0" end="1" frame="name_determiner(pron,'PER')" getal="ev" graad="basis" his="normal" his_1="gen" his_1_1="names_dictionary" id="2" infl="pron" lcat="detp" lemma="Peter" naamval="gen" neclass="PER" ntype="eigen" pos="det" postag="N(eigen,ev,basis,gen)" pt="n" rel="det" root="Peter" sense="Peter" special="name" word="Peters"/>
+        <node begin="1" end="2" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="3" lcat="np" lemma="hond" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hond" sense="hond" word="honden"/>
+      </node>
+      <node begin="2" end="3" frame="punct(punt)" his="normal" his_1="normal" id="4" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peters honden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="3" id="0" rel="top">
+      <node begin="0" cat="np" end="2" id="1" rel="--">
+        <node begin="0" end="1" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="2" lcat="np" lemma="prinses" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="prinses" sense="prinses" word="Prinses"/>
+        <node begin="1" end="2" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Juliana" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="app" rnum="sg" root="Juliana" sense="Juliana" word="Juliana"/>
+      </node>
+      <node begin="2" end="3" frame="punct(punt)" his="normal" his_1="normal" id="4" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Prinses Juliana .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="4" id="0" rel="top">
+      <node begin="0" cat="mwu" end="3" his="name" his_1="begin" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" id="2" lcat="np" lemma="Willem" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Willem" sense="Willem" spectype="deeleigen" word="Willem"/>
+        <node begin="1" end="2" frame="proper_name(sg,'PER')" id="3" lcat="np" lemma="de" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="de" sense="de" spectype="deeleigen" word="de"/>
+        <node begin="2" end="3" frame="proper_name(sg,'PER')" id="4" lcat="np" lemma="Tweede" neclass="PER" num="sg" pos="name" postag="SPEC(deeleigen)" pt="spec" rel="mwp" rnum="sg" root="Tweede" sense="Tweede" spectype="deeleigen" word="Tweede"/>
+      </node>
+      <node begin="3" end="4" frame="punct(punt)" his="normal" his_1="normal" id="5" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Willem de Tweede .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/npmod.example.ok
+++ b/tests/npmod.example.ok
@@ -26582,26 +26582,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.43.s.1.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heb</t>
-                <feat class="[heb]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heb</t>
-                  <feat class="[heb]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -26814,28 +26794,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.43.s.1.w.8.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>horen</t>
-                <feat class="[[hoor]verb[en]/present-tense/plural/singular]verb" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>hoor</t>
-                  <feat class="[hoor]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>en</t>
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="plural" subset="inflection"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="singular" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -32071,28 +32029,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.50.s.1.w.5.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>grootste</t>
-                <feat class="[[groot]adjective[st]/superlative[e]/suffix-e]adjective" subset="structure"/>
-                <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>groot</t>
-                  <feat class="[groot]adjective" subset="structure"/>
-                  <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>st</t>
-                  <feat class="superlative" subset="inflection"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>e</t>
-                  <feat class="suffix-e" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
           <metric class="prevalenceP" value="0.998508"/>

--- a/tests/numstring.example.alpino
+++ b/tests/numstring.example.alpino
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="16" id="0" rel="top">
+      <node begin="0" cat="smain" end="15" id="1" rel="--">
+        <node begin="0" cat="np" end="3" id="2" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node aform="base" begin="1" buiging="met-e" end="2" frame="adjective(e)" graad="basis" his="normal" his_1="numberjarig" id="4" infl="e" lcat="ap" lemma="35_jarig" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="35_jarig" sense="35_jarig" vform="adj" word="35jarige"/>
+          <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="bestuurder" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="bestuurder" sense="bestuurder" word="bestuurder"/>
+        </node>
+        <node begin="3" end="4" frame="verb('hebben/zijn',past(sg),ld_pp)" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="rijden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="rijd" sc="ld_pp" sense="rijd" stype="declarative" tense="past" word="reed" wvorm="pv"/>
+        <node begin="4" cat="pp" end="10" id="7" rel="ld">
+          <node begin="4" end="5" frame="preposition(over,[heen])" his="normal" his_1="normal" id="8" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sense="over" vztype="init" word="over"/>
+          <node begin="5" cat="conj" end="10" id="9" rel="obj1">
+            <node begin="5" cat="np" end="7" id="10" rel="cnj">
+              <node begin="5" end="6" frame="determiner(de)" his="normal" his_1="normal" id="11" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="6" end="7" frame="proper_name(both)" genus="genus" getal="ev" graad="basis" his="name" his_1="not_begin" id="12" lcat="np" lemma="A-2" naamval="stan" neclass="MISC" ntype="eigen" num="both" pos="name" postag="N(eigen,ev,basis,genus,stan)" pt="n" rel="hd" rnum="sg" root="A-2" sense="A-2" word="A-2"/>
+            </node>
+            <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="13" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="8" cat="np" end="10" id="14" rel="cnj">
+              <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="15" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="9" end="10" frame="proper_name(sg,'LOC')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="16" lcat="np" lemma="A50" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="A50" sense="A50" word="A50"/>
+            </node>
+          </node>
+        </node>
+        <node begin="10" cat="ap" end="15" id="17" rel="predm">
+          <node aform="base" begin="10" end="11" frame="adjective(postn_pred(padv),pp(met))" his="normal" his_1="normal" id="18" infl="pred" lcat="ap" lemma="samen" pos="adj" postag="BW()" pt="bw" rel="hd" root="samen" sc="pp(met)" sense="samen-met" vform="adj" word="samen"/>
+          <node begin="11" cat="pp" end="15" id="19" rel="pc">
+            <node begin="11" end="12" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="20" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+            <node begin="12" cat="np" end="15" id="21" rel="obj1">
+              <node begin="12" end="13" frame="determiner(de)" his="normal" his_1="normal" id="22" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node aform="base" begin="13" buiging="met-e" end="14" frame="adjective(e)" graad="basis" his="normal" his_1="numberjarig" id="23" infl="e" lcat="ap" lemma="20_jarig" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="20_jarig" sense="20_jarig" vform="adj" word="20-jarige"/>
+              <node begin="14" end="15" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="verb_ster" id="24" lcat="np" lemma="liftster" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="liftster" sense="liftster" word="liftster"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="15" end="16" frame="punct(punt)" his="normal" his_1="normal" id="25" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De 35jarige bestuurder reed over de A-2 en de A50 samen met de 20-jarige liftster .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/overlap1.example.alpino
+++ b/tests/overlap1.example.alpino
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" cat="np" end="2" id="2" rel="su">
+          <node begin="0" buiging="zonder" end="1" frame="determiner(pron)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" infl="pron" lcat="detp" lemma="jou" naamval="stan" npagr="agr" pdtype="det" persoon="2v" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,2v,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="jou" sense="jou" status="vol" vwtype="bez" word="Jouw"/>
+          <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+        </node>
+        <node begin="2" end="3" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="5" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+        <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="lief" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="lief" sense="lief" vform="adj" word="lief"/>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jouw hond is niet lief .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/overlap2.example.alpino
+++ b/tests/overlap2.example.alpino
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="conj" end="6" id="1" rel="--">
+        <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="2" lcat="np" lemma="Jan" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Jan" sense="Jan" word="Jan"/>
+        <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="3" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="4" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+        <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="5" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="4" cat="np" end="6" id="6" rel="cnj">
+          <node begin="4" buiging="zonder" end="5" frame="determiner(pron)" getal="mv" his="normal" his_1="normal" id="7" infl="pron" lcat="detp" lemma="hun" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,mv,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="hun" sense="hun" status="vol" vwtype="bez" word="hun"/>
+          <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="hond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="hond" sense="hond" word="hond"/>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Jan en Piet en hun hond .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="du" end="10" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="maar" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="maar" sc="root" sense="maar" word="Maar"/>
+        <node begin="1" cat="conj" end="10" id="3" rel="nucl">
+          <node begin="1" cat="conj" end="5" id="4" rel="cnj">
+            <node begin="1" cat="np" end="3" id="5" rel="cnj">
+              <node begin="1" end="2" frame="modal_adverb" his="normal" his_1="normal" id="6" index="1" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="mod" root="ook" sc="modal" sense="ook" word="ook"/>
+              <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Kees" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Kees" sense="Kees" word="Kees"/>
+            </node>
+            <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="8" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="1" cat="np" end="5" id="9" rel="cnj">
+              <node begin="1" end="2" id="10" index="1" rel="mod"/>
+              <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="11" lcat="np" lemma="Piet" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="Piet" sense="Piet" word="Piet"/>
+            </node>
+          </node>
+          <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="6" cat="np" end="10" id="13" rel="cnj">
+            <node begin="6" end="7" frame="determiner(de)" his="normal" his_1="normal" id="14" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node begin="7" end="8" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="15" lcat="np" lemma="hond" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="hond" sense="hond" word="honden"/>
+            <node begin="8" cat="pp" end="10" id="16" rel="mod">
+              <node begin="8" end="9" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="17" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+              <node begin="9" case="dat_acc" def="def" end="10" frame="pronoun(nwh,thi,pl,de,dat_acc,def)" gen="de" getal="mv" his="normal" his_1="normal" id="18" lcat="np" lemma="hen" naamval="obl" num="pl" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(pers,pron,obl,vol,3p,mv)" pt="vnw" rel="obj1" rnum="pl" root="hen" sense="hen" status="vol" vwtype="pers" wh="nwh" word="hen"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Maar ook Kees en Piet en de honden van hen .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/overlap3.example.alpino
+++ b/tests/overlap3.example.alpino
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,pl,de,nom,def)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="wij" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,mv)" pt="vnw" rel="su" rnum="pl" root="wij" sense="wij" status="vol" vwtype="pers" wh="nwh" word="Wij"/>
+        <node begin="1" end="2" frame="verb(zijn,pl,ld_pp)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="roeien" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="roei" sc="ld_pp" sense="roei" stype="declarative" tense="present" word="roeien" wvorm="pv"/>
+        <node begin="2" cat="pp" end="6" id="4" rel="ld">
+          <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="5" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="3" cat="np" end="6" id="6" rel="obj1">
+            <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node aform="base" begin="4" buiging="met-e" end="5" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="klein" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="klein" sense="klein" vform="adj" word="kleine"/>
+            <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="boot" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="boot" sense="boot" word="boot"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wij roeien in de kleine boot .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node begin="2" cat="np" end="8" id="4" rel="predc">
+          <node begin="2" end="3" frame="determiner(een)" his="normal" his_1="normal" id="5" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+          <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="6" infl="e" lcat="ap" lemma="klein" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="klein" sense="klein" vform="adj" word="kleine"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="boot" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="boot" sense="boot" word="boot"/>
+          <node begin="5" cat="rel" end="8" id="8" rel="mod">
+            <node begin="5" end="6" frame="waar_adverb(in)" his="normal" his_1="normal" id="9" index="1" lcat="pp" lemma="waarin" pos="pp" postag="BW()" pt="bw" rel="rhd" root="waarin" sense="waarin" special="waar" word="waarin"/>
+            <node begin="5" cat="ssub" end="8" id="10" rel="body">
+              <node begin="5" end="6" id="11" index="1" rel="ld"/>
+              <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+              <node begin="7" end="8" frame="verb(zijn,past(pl),ld_pp)" his="normal" his_1="normal" id="13" infl="pl" lcat="ssub" lemma="roeien" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="roei" sc="ld_pp" sense="roei" tense="past" word="roeiden" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het was een kleine boot waarin we roeiden .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/overlap4.example.alpino
+++ b/tests/overlap4.example.alpino
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="Het"/>
+        <node begin="1" end="2" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node begin="2" cat="np" end="8" id="4" rel="predc">
+          <node begin="2" buiging="met-e" end="3" frame="determiner(onze)" getal="mv" his="normal" his_1="normal" id="5" infl="onze" lcat="detp" lemma="ons" naamval="stan" npagr="rest" pdtype="det" persoon="1" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,1,mv,prenom,met-e,rest)" pt="vnw" rel="det" root="ons" sense="ons" status="vol" vwtype="bez" word="onze"/>
+          <node aform="base" begin="3" buiging="met-e" end="4" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="6" infl="e" lcat="ap" lemma="klein" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="klein" sense="klein" vform="adj" word="kleine"/>
+          <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="boot" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="boot" sense="boot" word="boot"/>
+          <node begin="5" cat="rel" end="8" id="8" rel="mod">
+            <node begin="5" end="6" frame="waar_adverb(in)" his="normal" his_1="normal" id="9" index="1" lcat="pp" lemma="waarin" pos="pp" postag="BW()" pt="bw" rel="rhd" root="waarin" sense="waarin" special="waar" word="waarin"/>
+            <node begin="5" cat="ssub" end="8" id="10" rel="body">
+              <node begin="5" end="6" id="11" index="1" rel="ld"/>
+              <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+              <node begin="7" end="8" frame="verb(zijn,past(pl),ld_pp)" his="normal" his_1="normal" id="13" infl="pl" lcat="ssub" lemma="roeien" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="roei" sc="ld_pp" sense="roei" tense="past" word="roeiden" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="14" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Het was onze kleine boot waarin we roeiden .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/overlap5.example.alpino
+++ b/tests/overlap5.example.alpino
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" cat="np" end="5" id="2" rel="su">
+          <node begin="0" buiging="zonder" end="1" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="roeien" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="hd" rnum="sg" root="roei" sc="intransitive" sense="roei" special="v_noun" word="Roeien" wvorm="inf"/>
+          <node begin="1" cat="pp" end="5" id="4" rel="mod">
+            <node begin="1" end="2" frame="preposition(in,[])" his="normal" his_1="normal" id="5" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+            <node begin="2" cat="np" end="5" id="6" rel="obj1">
+              <node begin="2" end="3" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node aform="super" begin="3" buiging="met-e" end="4" frame="adjective(ste)" graad="sup" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="klein" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,sup,met-e,stan)" pt="adj" rel="mod" root="klein" sense="klein" vform="adj" word="kleinste"/>
+              <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="boot" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="boot" sense="boot" word="boot"/>
+            </node>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(unacc,past(sg),copula)" his="normal" his_1="normal" id="10" infl="sg" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="past" word="was" wvorm="pv"/>
+        <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="vermoeiend" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="vermoeiend" sense="vermoeiend" vform="adj" word="vermoeiend"/>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Roeien in de kleinste boot was vermoeiend .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,pl,de,nom,def)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="wij" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,mv)" pt="vnw" rel="su" rnum="pl" root="wij" sense="wij" status="vol" vwtype="pers" wh="nwh" word="Wij"/>
+        <node begin="1" end="2" frame="verb(zijn,past(pl),ld_pp)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="roeien" pos="verb" postag="WW(pv,verl,mv)" pt="ww" pvagr="mv" pvtijd="verl" rel="hd" root="roei" sc="ld_pp" sense="roei" stype="declarative" tense="past" word="roeiden" wvorm="pv"/>
+        <node begin="2" cat="pp" end="6" id="4" rel="ld">
+          <node begin="2" end="3" frame="preposition(in,[])" his="normal" his_1="normal" id="5" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+          <node begin="3" cat="np" end="6" id="6" rel="obj1">
+            <node begin="3" end="4" frame="determiner(de)" his="normal" his_1="normal" id="7" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node aform="base" begin="4" buiging="met-e" end="5" frame="adjective(e)" graad="basis" his="normal" his_1="normal" id="8" infl="e" lcat="ap" lemma="klein" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,basis,met-e,stan)" pt="adj" rel="mod" root="klein" sense="klein" vform="adj" word="kleine"/>
+            <node begin="5" end="6" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="boot" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="boot" sense="boot" word="boot"/>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wij roeiden in de kleine boot .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/predc-a.example.alpino
+++ b/tests/predc-a.example.alpino
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="2" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="du" end="11" id="1" rel="--">
+        <node begin="0" cat="smain" end="5" id="2" rel="dp">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="1" end="2" frame="verb(unacc,sg3,copula)" his="special" his_1="decap" his_1_1="normal" id="4" infl="sg3" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="word" sc="copula" sense="word" stype="declarative" tense="present" word="WORDT" wvorm="pv"/>
+          <node begin="2" cat="ap" end="5" id="5" rel="predc">
+            <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="steeds" pos="adv" postag="BW()" pt="bw" rel="mod" root="steeds" sense="steeds" word="steeds"/>
+            <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="maar" pos="adv" postag="BW()" pt="bw" rel="mod" root="maar" sense="maar" word="maar"/>
+            <node aform="compar" begin="4" buiging="zonder" end="5" frame="adjective(er(adv))" graad="comp" his="special" his_1="decap" his_1_1="normal" id="8" infl="no_e" lcat="ap" lemma="vrolijk" pos="adj" positie="vrij" postag="ADJ(vrij,comp,zonder)" pt="adj" rel="hd" root="vrolijk" sense="vrolijk" vform="adj" word="VROLIJKER"/>
+          </node>
+        </node>
+        <node begin="5" cat="smain" end="11" id="9" rel="dp">
+          <node begin="5" case="nom" def="def" end="6" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="10" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="6" end="7" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="11" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="7" cat="cp" end="9" id="12" rel="predm">
+            <node begin="7" conjtype="onder" end="8" frame="complementizer(als)" his="normal" his_1="normal" id="13" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="als"/>
+            <node begin="8" end="9" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="14" lcat="np" lemma="onderzoeker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="body" rnum="sg" root="onderzoeker" sense="onderzoeker" word="onderzoeker"/>
+          </node>
+          <node begin="9" cat="ap" end="11" id="15" rel="predc">
+            <node aform="base" begin="9" buiging="zonder" end="10" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="16" infl="no_e" lcat="ap" lemma="erg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="erg" sense="erg" vform="adj" word="erg"/>
+            <node aform="base" begin="10" buiging="zonder" end="11" frame="adjective(no_e(adv))" graad="basis" his="special" his_1="decap" his_1_1="normal" id="17" infl="no_e" lcat="ap" lemma="goed" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="goed" sense="goed" vform="adj" word="GOED"/>
+          </node>
+        </node>
+      </node>
+    </node>
+    <sentence sentid="127.0.0.1">Hij WORDT steeds maar VROLIJKER Hij is als onderzoeker erg GOED</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/predc-n.example.alpino
+++ b/tests/predc-n.example.alpino
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="3" skips="0"/>
+    <node begin="0" cat="top" end="25" id="0" rel="top">
+      <node begin="0" cat="du" end="24" id="1" rel="--">
+        <node begin="0" cat="smain" end="3" id="2" rel="dp">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="4" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="2" end="3" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="bakker" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="predc" rnum="sg" root="bakker" sense="bakker" word="bakker"/>
+        </node>
+        <node begin="3" cat="smain" end="12" id="6" rel="dp">
+          <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="7" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="4" end="5" frame="verb(unacc,sg_is,copula)" his="special" his_1="decap" his_1_1="normal" id="8" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="IS" wvorm="pv"/>
+          <node begin="5" cat="pp" end="7" id="9" rel="mod">
+            <node begin="5" end="6" frame="preposition(sinds,[])" his="normal" his_1="normal" id="10" lcat="pp" lemma="sinds" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="sinds" sense="sinds" vztype="init" word="sinds"/>
+            <node begin="6" end="7" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+          </node>
+          <node begin="7" cat="np" end="12" id="12" rel="predc">
+            <node begin="7" end="8" frame="determiner(de)" his="normal" his_1="normal" id="13" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+            <node aform="super" begin="8" buiging="met-e" end="9" frame="adjective(ste)" graad="sup" his="normal" his_1="normal" id="14" infl="e" lcat="ap" lemma="goed" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,sup,met-e,stan)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="beste"/>
+            <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="wo_dia" id="15" lcat="np" lemma="skiër" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="skiër" sense="skiër" word="SKIER"/>
+            <node begin="10" cat="pp" end="12" id="16" rel="mod">
+              <node begin="10" end="11" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="17" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+              <node begin="11" end="12" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="18" lcat="np" lemma="Nederland" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Nederland" sense="Nederland" word="Nederland"/>
+            </node>
+          </node>
+        </node>
+        <node begin="12" cat="smain" end="24" id="19" rel="dp">
+          <node begin="12" case="nom" def="def" end="13" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="20" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="13" end="14" frame="verb(hebben,sg3,subj_control(te))" his="normal" his_1="normal" id="21" infl="sg3" lcat="smain" lemma="proberen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="probeer" sc="subj_control(te)" sense="probeer" stype="declarative" tense="present" word="probeert" wvorm="pv"/>
+          <node begin="14" cat="np" end="16" id="22" rel="mod">
+            <node begin="14" end="15" frame="modal_adverb" his="normal" his_1="normal" id="23" lcat="advp" lemma="al" pos="adv" postag="BW()" pt="bw" rel="mod" root="al" sc="modal" sense="al" word="al"/>
+            <node begin="15" end="16" frame="tmp_noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="24" lcat="np" lemma="jaar" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="jaar" sense="jaar" special="tmp" word="jaren"/>
+          </node>
+          <node aform="base" begin="16" buiging="zonder" end="17" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="25" infl="no_e" lcat="ap" lemma="verwoed" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="verwoed" sense="verwoed" vform="adj" word="verwoed"/>
+          <node begin="12" cat="ti" end="24" id="26" rel="vc">
+            <node begin="22" end="23" frame="complementizer(te)" his="normal" his_1="normal" id="27" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+            <node begin="12" cat="inf" end="24" id="28" rel="body">
+              <node begin="12" end="13" id="29" index="1" rel="su"/>
+              <node begin="17" cat="np" end="22" id="30" rel="predc">
+                <node begin="17" end="18" frame="determiner(de)" his="normal" his_1="normal" id="31" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node aform="super" begin="18" buiging="met-e" end="19" frame="adjective(ste)" graad="sup" his="normal" his_1="normal" id="32" infl="e" lcat="ap" lemma="goed" naamval="stan" pos="adj" positie="prenom" postag="ADJ(prenom,sup,met-e,stan)" pt="adj" rel="mod" root="goed" sense="goed" vform="adj" word="beste"/>
+                <node begin="19" end="20" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="wo_dia" id="33" lcat="np" lemma="skiër" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="skiër" sense="skiër" word="SKIER"/>
+                <node begin="20" cat="pp" end="22" id="34" rel="mod">
+                  <node begin="20" end="21" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="35" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                  <node begin="21" end="22" frame="proper_name(sg,'LOC')" genus="onz" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="36" lcat="np" lemma="Nederland" naamval="stan" neclass="LOC" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="Nederland" sense="Nederland" word="Nederland"/>
+                </node>
+              </node>
+              <node begin="23" buiging="zonder" end="24" frame="verb(unacc,inf,copula)" his="special" his_1="decap" his_1_1="normal" id="37" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="copula" sense="ben" word="ZIJN" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="24" end="25" frame="punct(punt)" his="robust_skip" id="38" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is bakker Hij IS sinds jaren de beste SKIER van Nederland Hij probeert al jaren verwoed de beste SKIER van Nederland te ZIJN .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/predc-n.example.ok
+++ b/tests/predc-n.example.ok
@@ -423,7 +423,7 @@
           <morphology>
             <morpheme class="complex">
               <t>skier</t>
-              <feat class="[skiee]noun/singular" subset="structure"/>
+              <feat class="[skiee]noun[r]/singular" subset="structure"/>
               <pos class="N" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>skiee</t>
@@ -431,6 +431,7 @@
                 <pos class="N" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>r</t>
                 <feat class="singular" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -800,7 +801,7 @@
           <morphology>
             <morpheme class="complex">
               <t>skier</t>
-              <feat class="[skiee]noun/singular" subset="structure"/>
+              <feat class="[skiee]noun[r]/singular" subset="structure"/>
               <pos class="N" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>skiee</t>
@@ -808,6 +809,7 @@
                 <pos class="N" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>r</t>
                 <feat class="singular" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -1241,8 +1243,8 @@
         <metric class="np_modifier_count" value="5"/>
         <metric class="character_count" value="105"/>
         <metric class="character_count_min_names" value="87"/>
-        <metric class="morpheme_count" value="32"/>
-        <metric class="morpheme_count_min_names" value="30"/>
+        <metric class="morpheme_count" value="34"/>
+        <metric class="morpheme_count_min_names" value="32"/>
         <metric class="d_level" value="7"/>
         <metric class="d_level_gt4" value="1"/>
         <metric class="sub_verb_dist" value="2.5"/>
@@ -1468,8 +1470,8 @@
       <metric class="np_modifier_count" value="5"/>
       <metric class="character_count" value="105"/>
       <metric class="character_count_min_names" value="87"/>
-      <metric class="morpheme_count" value="32"/>
-      <metric class="morpheme_count_min_names" value="30"/>
+      <metric class="morpheme_count" value="34"/>
+      <metric class="morpheme_count_min_names" value="32"/>
       <metric class="d_level" value="7"/>
       <metric class="d_level_gt4" value="1"/>
       <metric class="sub_verb_dist" value="2.5"/>
@@ -1696,8 +1698,8 @@
     <metric class="np_modifier_count" value="5"/>
     <metric class="character_count" value="105"/>
     <metric class="character_count_min_names" value="87"/>
-    <metric class="morpheme_count" value="32"/>
-    <metric class="morpheme_count_min_names" value="30"/>
+    <metric class="morpheme_count" value="34"/>
+    <metric class="morpheme_count_min_names" value="32"/>
     <metric class="d_level" value="7"/>
     <metric class="d_level_gt4" value="1"/>
     <metric class="sub_verb_dist" value="2.5"/>

--- a/tests/relativeclauses.example.alpino
+++ b/tests/relativeclauses.example.alpino
@@ -1,0 +1,495 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="13" id="2" rel="--">
+        <node begin="0" cat="cp" end="6" id="3" rel="sat">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(als)" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="Als"/>
+          <node begin="1" cat="ssub" end="6" id="5" rel="body">
+            <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+            <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="4" end="5" frame="verb(hebben,sg3,aci)" his="normal" his_1="normal" id="9" infl="sg3" lcat="ssub" lemma="zien" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" tense="present" word="ziet" wvorm="pv"/>
+            <node begin="2" cat="inf" end="6" id="10" rel="vc">
+              <node begin="2" end="3" id="11" index="1" rel="su"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf(no_e),intransitive)" his="normal" his_1="normal" id="12" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="intransitive" sense="sta" word="staan" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+        <node begin="7" cat="smain" end="13" id="13" rel="nucl">
+          <node begin="7" end="8" frame="tmp_adverb" his="normal" his_1="normal" id="14" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+          <node begin="8" end="9" frame="verb(zijn,sg1,ld_pp)" his="normal" his_1="normal" id="15" infl="sg1" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="declarative" tense="present" word="ga" wvorm="pv"/>
+          <node begin="9" case="both" def="def" end="10" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="16" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+          <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="17" lcat="advp" lemma="meteen" pos="adv" postag="BW()" pt="bw" rel="mod" root="meteen" sense="meteen" word="meteen"/>
+          <node begin="11" cat="pp" end="13" id="18" rel="ld">
+            <node begin="11" end="12" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="19" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="12" end="13" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Als je hem niet ziet staan , dan ga je meteen naar huis .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="12" id="2" rel="--">
+        <node begin="0" cat="cp" end="6" id="3" rel="sat">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(als)" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="Als"/>
+          <node begin="1" cat="ssub" end="6" id="5" rel="body">
+            <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+            <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+            <node begin="4" end="5" frame="verb(hebben,sg3,aci)" his="normal" his_1="normal" id="9" infl="sg3" lcat="ssub" lemma="zien" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" tense="present" word="ziet" wvorm="pv"/>
+            <node begin="2" cat="inf" end="6" id="10" rel="vc">
+              <node begin="2" end="3" id="11" index="1" rel="su"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf(no_e),intransitive)" his="normal" his_1="normal" id="12" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="intransitive" sense="sta" word="staan" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+        <node begin="7" cat="sv1" end="12" id="13" rel="nucl">
+          <node begin="7" end="8" frame="verb(zijn,sg1,ld_pp)" his="normal" his_1="normal" id="14" infl="sg1" lcat="sv1" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="imparative" tense="present" word="ga" wvorm="pv"/>
+          <node begin="8" end="9" frame="tmp_adverb" his="normal" his_1="normal" id="15" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+          <node begin="9" end="10" frame="adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="meteen" pos="adv" postag="BW()" pt="bw" rel="mod" root="meteen" sense="meteen" word="meteen"/>
+          <node begin="10" cat="pp" end="12" id="17" rel="ld">
+            <node begin="10" end="11" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="18" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="11" end="12" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Als je hem niet ziet staan , ga dan meteen naar huis .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="9" end="10" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="13" id="2" rel="--">
+        <node begin="0" cat="np" end="9" id="3" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,sg,sbar)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="verwachting" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="verwachting" sc="sbar" sense="verwachting" word="verwachting"/>
+          <node begin="2" cat="cp" end="9" id="6" rel="vc">
+            <node begin="2" conjtype="onder" end="3" frame="complementizer(dat)" his="normal" his_1="normal" id="7" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+            <node begin="3" cat="ssub" end="9" id="8" rel="body">
+              <node begin="4" cat="np" end="6" id="9" index="2" rel="su">
+                <node begin="4" end="5" frame="determiner(een)" his="normal" his_1="normal" id="10" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="een"/>
+                <node begin="5" end="6" frame="tmp_noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="einde" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="einde" sense="einde" special="tmp" word="einde"/>
+              </node>
+              <node begin="7" end="8" frame="verb(hebben,past(sg),aux(inf))" his="normal" his_1="normal" id="12" infl="sg" lcat="ssub" lemma="zullen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="zal" sc="aux(inf)" sense="zal" tense="past" word="zou" wvorm="pv"/>
+              <node begin="3" cat="inf" end="9" id="13" rel="vc">
+                <node begin="4" end="6" id="14" index="2" rel="su"/>
+                <node begin="3" cat="pp" end="7" id="15" rel="pc">
+                  <node begin="3" end="4" frame="er_vp_adverb" getal="getal" his="normal" his_1="normal" id="16" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="obj1" root="er" sense="er" special="er" status="red" vwtype="aanw" word="er"/>
+                  <node begin="6" end="7" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="17" lcat="pp" lemma="aan" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="aan" sense="aan" vztype="fin" word="aan"/>
+                </node>
+                <node begin="8" buiging="zonder" end="9" frame="verb(zijn,inf,pc_pp(aan))" his="normal" his_1="normal" id="18" infl="inf" lcat="inf" lemma="komen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="kom" sc="pc_pp(aan)" sense="kom-aan" word="komen" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="10" end="11" frame="verb(unacc,past(sg),passive)" his="normal" his_1="normal" id="19" infl="sg" lcat="smain" lemma="worden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="word" sc="passive" sense="word" stype="declarative" tense="past" word="werd" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="13" id="20" rel="vc">
+          <node begin="0" end="9" id="21" index="1" rel="obj1"/>
+          <node begin="11" end="12" frame="adverb" his="normal" his_1="normal" id="22" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+          <node begin="12" buiging="zonder" end="13" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="23" infl="psp" lcat="ppart" lemma="bewaarheiden" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="bewaarheid" sc="transitive" sense="bewaarheid" word="bewaarheid" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="24" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De verwachting dat er een einde aan zou komen , werd niet bewaarheid .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" end="1" frame="er_vp_adverb" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="advp" lemma="er" naamval="stan" pdtype="adv-pron" persoon="3" pos="adv" postag="VNW(aanw,adv-pron,stan,red,3,getal)" pt="vnw" rel="mod" root="er" sense="er" special="er" status="red" vwtype="aanw" word="Er"/>
+        <node begin="1" end="2" frame="verb(unacc,pl,intransitive)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+        <node begin="2" cat="np" end="8" id="4" rel="su">
+          <node begin="2" buiging="zonder" end="3" frame="determiner(wat,nwh,mod,pro,yparg)" graad="basis" his="normal" his_1="normal" id="5" infl="wat" lcat="detp" lemma="allerlei" pos="det" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="det" root="allerlei" sense="allerlei" wh="nwh" word="allerlei"/>
+          <node begin="3" end="4" frame="noun(het,count,pl)" gen="het" getal="mv" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="verhaal" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="verhaal" sense="verhaal" word="verhalen"/>
+          <node begin="4" cat="pp" end="8" id="7" rel="mod">
+            <node begin="4" end="5" frame="preposition(over,[],redrel)" his="normal" his_1="normal" id="8" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sc="redrel" sense="over" vztype="init" word="over"/>
+            <node begin="5" cat="whsub" end="8" id="9" rel="vc">
+              <node begin="5" end="6" frame="wh_adjective" his="normal" his_1="normal" id="10" index="1" lcat="ap" lemma="hoe" pos="adj" postag="BW()" pt="bw" rel="whd" root="hoe" sense="hoe" wh="ywh" word="hoe"/>
+              <node begin="5" cat="ssub" end="8" id="11" rel="body">
+                <node begin="5" end="6" id="12" index="1" rel="mod"/>
+                <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="13" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+                <node begin="7" end="8" frame="verb(hebben,past(sg),intransitive)" his="normal" his_1="normal" id="14" infl="sg" lcat="ssub" lemma="winnen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="win" sc="intransitive" sense="win" tense="past" word="won" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Er zijn allerlei verhalen over hoe hij won .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg_heeft,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg_heeft" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heeft" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="10" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="pp" end="5" id="6" rel="ld">
+            <node begin="2" end="3" frame="preposition(over,[heen])" his="normal" his_1="normal" id="7" lcat="pp" lemma="over" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="over" sense="over" vztype="init" word="over"/>
+            <node begin="3" cat="np" end="5" id="8" rel="obj1">
+              <node begin="3" end="4" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="9" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="touw" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="touw" sense="touw" word="touw"/>
+            </node>
+          </node>
+          <node begin="5" buiging="zonder" end="6" frame="verb('hebben/zijn',psp,ld_pp)" his="normal" his_1="normal" id="11" infl="psp" lcat="ppart" lemma="lopen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="loop" sc="ld_pp" sense="loop" word="gelopen" wvorm="vd"/>
+          <node begin="6" cat="pp" end="10" id="12" rel="mod">
+            <node begin="6" end="7" frame="preposition(zonder,[],sbar)" his="normal" his_1="normal" id="13" lcat="pp" lemma="zonder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="zonder" sc="sbar" sense="zonder" vztype="init" word="zonder"/>
+            <node begin="7" cat="cp" end="10" id="14" rel="vc">
+              <node begin="7" conjtype="onder" end="8" frame="complementizer(dat)" his="normal" his_1="normal" id="15" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+              <node begin="8" cat="ssub" end="10" id="16" rel="body">
+                <node begin="8" case="nom" def="def" end="9" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+                <node begin="9" end="10" frame="verb(unacc,past(sg),intransitive)" his="normal" his_1="normal" id="18" infl="sg" lcat="ssub" lemma="vallen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="val" sc="intransitive" sense="val" tense="past" word="viel" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij heeft over het touw gelopen zonder dat hij viel .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,aux_psp_zijn)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="8" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" buiging="zonder" end="3" frame="verb(unacc,psp,copula)" his="normal" his_1="normal" id="6" infl="psp" lcat="ppart" lemma="worden" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="word" sc="copula" sense="word" word="geworden" wvorm="vd"/>
+          <node begin="3" cat="whrel" end="8" id="7" rel="predc">
+            <node begin="3" case="both" def="indef" end="4" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="normal" id="8" index="2" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="rhd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="wie"/>
+            <node begin="3" cat="ssub" end="8" id="9" rel="body">
+              <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="10" index="3" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node begin="6" end="7" frame="verb(hebben,past(sg),modifier(aux(inf)))" his="normal" his_1="normal" id="11" infl="sg" lcat="ssub" lemma="willen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="wil" sc="modifier(aux(inf))" sense="wil" tense="past" word="wilde" wvorm="pv"/>
+              <node begin="3" cat="inf" end="8" id="12" rel="vc">
+                <node begin="3" end="4" id="13" index="2" rel="predc"/>
+                <node begin="4" end="5" id="14" index="3" rel="su"/>
+                <node begin="5" end="6" frame="sentence_adverb" his="normal" his_1="normal" id="15" lcat="advp" lemma="altijd" pos="adv" postag="BW()" pt="bw" rel="mod" root="altijd" sense="altijd" special="sentence" word="altijd"/>
+                <node begin="7" buiging="zonder" end="8" frame="verb(unacc,inf,copula)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="zijn" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="ben" sc="copula" sense="ben" word="zijn" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is geworden wie hij altijd wilde zijn .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="ap" end="9" id="4" rel="predc">
+          <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(padv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="blind" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="blind" sense="blind" vform="adj" word="blind"/>
+          <node begin="2" cat="ap" end="9" id="6" rel="mod">
+            <node begin="2" end="3" frame="sbar_pred_adjective(adv)" his="normal" his_1="normal" id="7" infl="pred" lcat="ap" lemma="zo" pos="adj" postag="BW()" pt="bw" rel="hd" root="zo" sc="sbar" sense="zo" word="zo"/>
+            <node begin="4" cat="cp" end="9" id="8" rel="obcomp">
+              <node begin="4" conjtype="onder" end="5" frame="complementizer(dat)" his="normal" his_1="normal" id="9" lcat="cp" lemma="dat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="dat" sc="dat" sense="dat" word="dat"/>
+              <node begin="5" cat="ssub" end="9" id="10" rel="body">
+                <node begin="5" case="nom" def="def" end="6" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="11" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+                <node begin="6" end="7" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="12" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="obj1" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+                <node begin="7" end="8" frame="adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+                <node begin="8" end="9" frame="verb(hebben,sg3,transitive_ndev_ndev)" his="normal" his_1="normal" id="14" infl="sg3" lcat="ssub" lemma="zien" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" tense="present" word="ziet" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is zo blind dat hij dat niet ziet .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,past(sg),intransitive)" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="komen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="kom" sc="intransitive" sense="kom" stype="declarative" tense="past" word="kwam" wvorm="pv"/>
+        <node begin="2" cat="cp" end="7" id="4" rel="mod">
+          <node begin="2" conjtype="onder" end="3" frame="complementizer" his="normal" his_1="normal" id="5" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+          <node begin="3" cat="ssub" end="7" id="6" rel="body">
+            <node begin="3" case="nom" def="def" end="4" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="3" cat="ppart" end="6" id="8" rel="vc">
+              <node begin="3" end="4" id="9" index="1" rel="su"/>
+              <node begin="4" case="dat_acc" def="def" end="5" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="11" infl="psp" lcat="ppart" lemma="vragen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="vraag" sc="transitive" sense="vraag" word="gevraagd" wvorm="vd"/>
+            </node>
+            <node begin="6" end="7" frame="verb(hebben,past(sg),aux_psp_hebben)" his="normal" his_1="normal" id="12" infl="sg" lcat="ssub" lemma="hebben" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="past" word="had" wvorm="pv"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij kwam omdat ik hem gevraagd had .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="0" cat="smain" end="13" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(zijn,sg1,part_intransitive(weg))" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="weg_gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga_weg" sc="part_intransitive(weg)" sense="ga_weg" stype="declarative" tense="present" word="ga" wvorm="pv"/>
+        <node begin="2" end="3" frame="particle(weg)" his="normal" his_1="normal" id="4" lcat="part" lemma="weg" pos="part" postag="BW()" pt="bw" rel="svp" root="weg" sense="weg" word="weg"/>
+        <node begin="3" cat="conj" end="13" id="5" rel="mod">
+          <node begin="3" cat="cp" end="7" id="6" rel="cnj">
+            <node begin="3" conjtype="onder" end="4" frame="complementizer" his="normal" his_1="normal" id="7" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+            <node begin="4" cat="ssub" end="7" id="8" rel="body">
+              <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(padv))" graad="basis" his="normal" his_1="normal" id="10" infl="no_e" lcat="ap" lemma="moe" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="moe" sense="moe" vform="adj" word="moe"/>
+              <node begin="6" end="7" frame="verb(unacc,sg1,copula)" his="normal" his_1="normal" id="11" infl="sg1" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="ben" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="8" cat="cp" end="13" id="13" rel="cnj">
+            <node begin="8" conjtype="onder" end="9" frame="complementizer" his="normal" his_1="normal" id="14" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+            <node begin="9" cat="ssub" end="13" id="15" rel="body">
+              <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="16" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+              <node begin="10" cat="pp" end="12" id="17" rel="ld">
+                <node begin="10" end="11" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="18" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+                <node begin="11" end="12" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="19" lcat="np" lemma="bed" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="bed" sense="bed" word="bed"/>
+              </node>
+              <node begin="12" end="13" frame="verb(hebben,modal_not_u,ld_pp)" his="normal" his_1="normal" id="20" infl="modal_not_u" lcat="ssub" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="ld_pp" sense="wil" tense="present" word="wil" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik ga weg omdat ik moe ben en omdat ik naar bed wil .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="2" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="10" id="5" rel="vc">
+          <node begin="0" end="1" id="6" index="1" rel="su"/>
+          <node begin="2" end="3" frame="noun(het,mass,sg)" gen="het" getal="ev" his="normal" his_1="normal" id="7" lcat="np" lemma="alles" naamval="stan" num="sg" pdtype="pron" persoon="3o" pos="noun" postag="VNW(onbep,pron,stan,vol,3o,ev)" pt="vnw" rel="obj1" rnum="sg" root="alles" sense="alles" status="vol" vwtype="onbep" word="alles"/>
+          <node begin="3" buiging="zonder" end="4" frame="verb(hebben,psp,transitive_ndev)" his="normal" his_1="normal" id="8" infl="psp" lcat="ppart" lemma="doen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="doe" sc="transitive_ndev" sense="doe" word="gedaan" wvorm="vd"/>
+          <node begin="5" cat="cp" end="10" id="9" rel="mod">
+            <node begin="5" buiging="zonder" end="6" frame="complementizer(np)" graad="basis" his="normal" his_1="normal" id="10" lcat="cp" lemma="inclusief" pos="comp" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="cmp" root="inclusief" sc="np" sense="inclusief" word="inclusief"/>
+            <node begin="6" cat="np" end="10" id="11" rel="body">
+              <node begin="6" end="7" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="12" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="7" end="8" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="werk" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="werk" sense="werk" word="werk"/>
+              <node begin="8" cat="pp" end="10" id="14" rel="mod">
+                <node begin="8" end="9" frame="preposition(voor,[],tmp_adv)" his="normal" his_1="normal" id="15" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sc="tmp_adv" sense="voor" vztype="init" word="voor"/>
+                <node begin="9" end="10" frame="tmp_adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="morgen" pos="adv" postag="BW()" pt="bw" rel="obj1" root="morgen" sense="morgen" special="tmp" word="morgen"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb alles gedaan , inclusief het werk voor morgen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,pc_pp(aan))" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="twijfelen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="twijfel" sc="pc_pp(aan)" sense="twijfel-aan" stype="declarative" tense="present" word="twijfel" wvorm="pv"/>
+        <node begin="2" cat="pp" end="6" id="4" rel="pc">
+          <node begin="2" end="3" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="5" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+          <node begin="3" cat="whrel" end="6" id="6" rel="obj1">
+            <node begin="3" case="both" def="indef" end="4" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="rhd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="wat"/>
+            <node begin="3" cat="ssub" end="6" id="8" rel="body">
+              <node begin="3" end="4" id="9" index="1" rel="obj1"/>
+              <node begin="4" case="both" def="def" end="5" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+              <node begin="5" end="6" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="11" infl="sg3" lcat="ssub" lemma="zeggen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="zeg" sc="transitive" sense="zeg" tense="present" word="zegt" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik twijfel aan wat je zegt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="13" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="12" id="2" rel="--">
+        <node begin="0" cat="whrel" end="4" id="3" rel="mod">
+          <node begin="0" end="1" frame="er_wh_loc_adverb" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="advp" lemma="waar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(vb,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="rhd" root="waar" sense="waar" special="er_loc" status="vol" vwtype="vb" wh="ywh" word="Waar"/>
+          <node begin="0" cat="ssub" end="4" id="5" rel="body">
+            <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+            <node begin="0" cat="pp" end="3" id="7" rel="ld">
+              <node begin="0" end="1" id="8" index="1" rel="obj1"/>
+              <node begin="2" end="3" frame="preposition(vandaan,[],extracted_np)" his="normal" his_1="normal" id="9" lcat="pp" lemma="vandaan" pos="prep" postag="VZ(fin)" pt="vz" rel="hd" root="vandaan" sc="extracted_np" sense="vandaan" vztype="fin" word="vandaan"/>
+            </node>
+            <node begin="3" end="4" frame="verb(unacc,sg1,ld_pp)" his="normal" his_1="normal" id="10" infl="sg1" lcat="ssub" lemma="komen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="kom" sc="ld_pp" sense="kom" tense="present" word="kom" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(hebben,pl,pc_pp(van))" his="normal" his_1="normal" id="11" infl="pl" lcat="smain" lemma="houden" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="houd" sc="pc_pp(van)" sense="houd-van" stype="declarative" tense="present" word="houden" wvorm="pv"/>
+        <node begin="6" case="both" def="def" end="7" frame="pronoun(nwh,thi,both,de,both,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="ze" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,stan,red,3,mv)" pt="vnw" rel="su" rnum="pl" root="ze" sense="ze" special="wkpro" status="red" vwtype="pers" wh="nwh" word="ze"/>
+        <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="13" infl="no_e" lcat="ap" lemma="juist" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="juist" sense="juist" vform="adj" word="juist"/>
+        <node begin="8" cat="pp" end="12" id="14" rel="pc">
+          <node begin="8" end="9" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="15" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="9" cat="np" end="12" id="16" rel="obj1">
+            <node begin="9" cat="np" end="11" his="normal" his_1="normal" id="17" rel="det">
+              <node begin="9" end="10" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" id="18" infl="het" lcat="detp" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="det" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+              <node begin="10" end="11" frame="noun(both,both,sg)" gen="both" genus="genus" getal="ev" graad="basis" id="19" lcat="np" lemma="soort" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,genus,stan)" pt="n" rel="hd" root="soort" sense="soort" word="soort"/>
+            </node>
+            <node begin="11" end="12" frame="noun(de,mass,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="humor" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="humor" sense="humor" word="humor"/>
+          </node>
+        </node>
+      </node>
+      <node begin="12" end="13" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Waar ik vandaan kom , houden ze juist van dat soort humor .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="6" id="2" rel="--">
+        <node begin="0" cat="whrel" end="3" id="3" rel="su">
+          <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="rhd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="Wat"/>
+          <node begin="0" cat="ssub" end="3" id="5" rel="body">
+            <node begin="0" end="1" id="6" index="1" rel="obj1"/>
+            <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,u,sg,de,both,def)" gen="de" getal="getal" his="normal" his_1="normal" id="7" lcat="np" lemma="u" naamval="nomin" num="sg" pdtype="pron" per="u" persoon="2b" pos="pron" postag="VNW(pers,pron,nomin,vol,2b,getal)" pt="vnw" rel="su" rnum="sg" root="u" sense="u" status="vol" vwtype="pers" wh="nwh" word="u"/>
+            <node begin="2" end="3" frame="verb(hebben,sg3,transitive_ndev)" his="normal" his_1="normal" id="8" infl="sg3" lcat="ssub" lemma="doen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="doe" sc="transitive_ndev" sense="doe" tense="present" word="doet" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="4" end="5" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="9" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(nonadv))" graad="basis" his="normal" his_1="normal" id="10" infl="no_e" lcat="ap" lemma="onaanvaardbaar" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="onaanvaardbaar" sense="onaanvaardbaar" vform="adj" word="onaanvaardbaar"/>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wat u doet , is onaanvaardbaar .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="11" id="2" rel="--">
+        <node begin="5" end="6" frame="verb(hebben,modal_not_u,aux(inf))" his="normal" his_1="normal" id="3" infl="modal_not_u" lcat="smain" lemma="zullen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zal" sc="aux(inf)" sense="zal" stype="declarative" tense="present" word="zal" wvorm="pv"/>
+        <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="4" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="0" cat="inf" end="11" id="5" rel="vc">
+          <node begin="0" cat="whrel" end="4" id="6" rel="mod">
+            <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="7" index="2" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="rhd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="Wie"/>
+            <node begin="0" cat="ssub" end="4" id="8" rel="body">
+              <node begin="0" end="1" id="9" index="2" rel="su"/>
+              <node begin="1" end="2" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="10" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+              <node begin="2" end="3" frame="adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+              <node begin="3" end="4" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="12" infl="sg3" lcat="ssub" lemma="begrijpen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="begrijp" sc="transitive" sense="begrijp" tense="present" word="begrijpt" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="6" end="7" id="13" index="1" rel="su"/>
+          <node begin="7" end="8" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="14" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+          <node begin="8" end="9" frame="adverb" his="normal" his_1="normal" id="15" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+          <node begin="9" end="10" frame="tmp_adverb" his="normal" his_1="normal" id="16" lcat="advp" lemma="eens" pos="adv" postag="BW()" pt="bw" rel="mod" root="eens" sense="eens" special="tmp" word="eens"/>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,inf,ninv(transitive,part_transitive(uit)))" his="normal" his_1="part-V" id="17" infl="inf" lcat="inf" lemma="uit_leggen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="leg_uit" sc="part_transitive(uit)" sense="leg_uit" word="uitleggen" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wie het niet begrijpt , zal ik het nog eens uitleggen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="2" rel="--">
+        <node begin="0" cat="whrel" end="4" id="3" rel="obj1">
+          <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="rhd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="Wie"/>
+          <node begin="0" cat="ssub" end="4" id="5" rel="body">
+            <node begin="0" end="1" id="6" index="1" rel="su"/>
+            <node begin="1" cat="ap" end="3" id="7" rel="mod">
+              <node begin="1" end="2" frame="intensifier" his="normal" his_1="normal" id="8" lcat="advp" lemma="te" pos="adv" postag="BW()" pt="bw" rel="mod" root="te" sense="te" special="intensifier" word="te"/>
+              <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(tmpadv))" graad="basis" his="normal" his_1="normal" id="9" infl="no_e" lcat="ap" lemma="laat" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="laat" sense="laat" vform="adj" word="laat"/>
+            </node>
+            <node begin="3" end="4" frame="verb(unacc,sg3,intransitive)" his="normal" his_1="normal" id="10" infl="sg3" lcat="ssub" lemma="komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom" sc="intransitive" sense="kom" tense="present" word="komt" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb(hebben,pl,part_transitive(binnen))" his="normal" his_1="normal" id="11" infl="pl" lcat="smain" lemma="binnen_laten" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="laat_binnen" sc="part_transitive(binnen)" sense="laat_binnen" stype="declarative" tense="present" word="laten" wvorm="pv"/>
+        <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="12" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+        <node begin="7" cat="advp" end="9" id="13" rel="mod">
+          <node begin="7" end="8" frame="adverb" his="normal" his_1="normal" id="14" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="hd" root="niet" sense="niet" word="niet"/>
+          <node begin="8" buiging="zonder" end="9" frame="postadv_adverb" graad="comp" his="normal" his_1="normal" id="15" lcat="advp" lemma="veel" naamval="stan" pdtype="grad" pos="adv" positie="vrij" postag="VNW(onbep,grad,stan,vrij,zonder,comp)" pt="vnw" rel="mod" root="veel" sense="veel" special="postadv" vwtype="onbep" word="meer"/>
+        </node>
+        <node begin="9" end="10" frame="particle(binnen)" his="normal" his_1="normal" id="16" lcat="part" lemma="binnen" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="binnen" sense="binnen" vztype="fin" word="binnen"/>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wie te laat komt , laten we niet meer binnen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="11" id="2" rel="--">
+        <node begin="0" cat="sv1" end="5" id="3" rel="tag">
+          <node begin="0" end="1" frame="verb(hebben,sg1,aci)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="sg1" lcat="sv1" lemma="zien" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="zie" sc="aci" sense="zie" stype="imparative" tense="present" word="Zie" wvorm="pv"/>
+          <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="getal" his="normal" his_1="normal" id="5" index="1" lcat="np" lemma="je" naamval="obl" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pr,pron,obl,red,2v,getal)" pt="vnw" rel="obj1" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pr" wh="nwh" word="je"/>
+          <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+          <node begin="1" cat="inf" end="5" id="7" rel="vc">
+            <node begin="1" end="2" id="8" index="1" rel="su"/>
+            <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="9" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj2" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+            <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf(no_e),so_np)" his="normal" his_1="normal" id="10" infl="inf(no_e)" lcat="inf" lemma="staan" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="sta" sc="so_np" sense="sta" word="staan" wvorm="inf"/>
+          </node>
+        </node>
+        <node begin="6" cat="sv1" end="11" id="11" rel="nucl">
+          <node begin="6" dropped_agr="sg" dropped_prs="fir" end="7" frame="verb(zijn,sg1,ld_pp)" his="normal" his_1="normal" id="12" infl="sg1" lcat="sv1" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="topic_drop" tense="present" word="ga" wvorm="pv"/>
+          <node begin="7" end="8" frame="tmp_adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+          <node begin="8" end="9" frame="adverb" his="normal" his_1="normal" id="14" lcat="advp" lemma="meteen" pos="adv" postag="BW()" pt="bw" rel="mod" root="meteen" sense="meteen" word="meteen"/>
+          <node begin="9" cat="pp" end="11" id="15" rel="ld">
+            <node begin="9" end="10" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="16" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+            <node begin="10" end="11" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zie je hem niet staan , ga dan meteen naar huis .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" cat="ap" end="2" id="2" rel="predc">
+          <node begin="0" end="1" frame="adverb" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="mod" root="zo" sense="zo" word="Zo"/>
+          <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="4" infl="no_e" lcat="ap" lemma="belangrijk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="belangrijk" sense="belangrijk" vform="adj" word="belangrijk"/>
+        </node>
+        <node begin="2" end="3" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="5" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="3" cat="np" end="8" id="6" rel="su">
+          <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="kind_opvang" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="kind_opvang" sense="kind_opvang" word="kinderopvang"/>
+          <node begin="4" cat="pp" end="8" id="8" rel="mod">
+            <node begin="4" end="5" frame="preposition(voor,[aan,door,uit,[in,de,plaats]])" his="normal" his_1="normal" id="9" lcat="pp" lemma="voor" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="voor" sense="voor" vztype="init" word="voor"/>
+            <node begin="5" cat="whrel" end="8" id="10" rel="obj1">
+              <node begin="5" case="both" def="indef" end="6" frame="pronoun(ywh,thi,both,de,both,indef)" gen="de" getal="getal" his="normal" his_1="normal" id="11" index="1" lcat="np" lemma="wie" naamval="stan" num="both" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(vb,pron,stan,vol,3p,getal)" pt="vnw" rel="rhd" rnum="sg" root="wie" sense="wie" status="vol" vwtype="vb" wh="ywh" word="wie"/>
+              <node begin="5" cat="ssub" end="8" id="12" rel="body">
+                <node begin="5" end="6" id="13" index="1" rel="su"/>
+                <node begin="6" end="7" frame="verb(zijn,sg3,aux(inf))" his="normal" his_1="normal" id="14" infl="sg3" lcat="ssub" lemma="gaan" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ga" sc="aux(inf)" sense="ga" tense="present" word="gaat" wvorm="pv"/>
+                <node begin="5" cat="inf" end="8" id="15" rel="vc">
+                  <node begin="5" end="6" id="16" index="1" rel="su"/>
+                  <node begin="7" buiging="zonder" end="8" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="17" infl="inf" lcat="inf" lemma="werken" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="werk" sc="intransitive" sense="werk" word="werken" wvorm="inf"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zo belangrijk is kinderopvang voor wie gaat werken .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/relativeclauses.example.ok
+++ b/tests/relativeclauses.example.ok
@@ -672,26 +672,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.2.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ga</t>
-                <feat class="[ga]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ga</t>
-                  <feat class="[ga]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="full-lemma" value="weggaan"/>
           <metric class="content_word" value="true"/>
@@ -870,26 +850,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.2.w.7.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ben</t>
-                <feat class="[zijn]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zijn</t>
-                  <feat class="[zijn]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(koppelww)" set="tscan-set"/>
           <metric class="prevalenceP" value="0.999628"/>
           <metric class="prevalenceZ" value="3.37248"/>
@@ -1113,26 +1073,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.1.s.2.w.13.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.2.w.13.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
@@ -1703,26 +1643,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.3.w.7.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ga</t>
-                <feat class="[ga]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ga</t>
-                  <feat class="[ga]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -2438,26 +2358,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.4.w.8.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ga</t>
-                <feat class="[ga]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ga</t>
-                  <feat class="[ga]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -3863,7 +3763,7 @@
           <morphology>
             <morpheme class="complex">
               <t>inclusief</t>
-              <feat class="[inclusie]adjective/positive" subset="structure"/>
+              <feat class="[inclusie]adjective[f]/positive" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>inclusie</t>
@@ -3871,6 +3771,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>f</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -4271,8 +4172,8 @@
         <metric class="np_modifier_count" value="1"/>
         <metric class="character_count" value="42"/>
         <metric class="character_count_min_names" value="42"/>
-        <metric class="morpheme_count" value="10"/>
-        <metric class="morpheme_count_min_names" value="10"/>
+        <metric class="morpheme_count" value="11"/>
+        <metric class="morpheme_count_min_names" value="11"/>
         <metric class="d_level" value="0"/>
         <metric class="sub_verb_dist" value="1"/>
         <metric class="obj_verb_dist" value="0"/>
@@ -5679,26 +5580,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>zal</t>
-                <feat class="[zal]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>zal</t>
-                  <feat class="[zal]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.9.w.6.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>zal</t>
                 <feat class="[zal]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -5840,7 +5721,7 @@
           <morphology>
             <morpheme class="complex">
               <t>eens</t>
-              <feat class="[een]adjective/positive" subset="structure"/>
+              <feat class="[een]adjective[s]/positive" subset="structure"/>
               <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               <morpheme class="stem">
                 <t>een</t>
@@ -5848,6 +5729,7 @@
                 <pos class="A" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
               </morpheme>
               <morpheme class="inflection">
+                <t>s</t>
                 <feat class="positive" subset="inflection"/>
               </morpheme>
             </morpheme>
@@ -6165,8 +6047,8 @@
         <metric class="np_modifier_count" value="0"/>
         <metric class="character_count" value="42"/>
         <metric class="character_count_min_names" value="42"/>
-        <metric class="morpheme_count" value="14"/>
-        <metric class="morpheme_count_min_names" value="14"/>
+        <metric class="morpheme_count" value="15"/>
+        <metric class="morpheme_count_min_names" value="15"/>
         <metric class="d_level" value="1"/>
         <metric class="sub_verb_dist" value="1.66667"/>
         <metric class="obj_verb_dist" value="1.5"/>
@@ -6859,26 +6741,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.11.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>twijfel</t>
-                <feat class="[twijfel]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>twijfel</t>
-                  <feat class="[twijfel]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -8022,26 +7884,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.13.w.4.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>kom</t>
-                <feat class="[kom]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>kom</t>
-                  <feat class="[kom]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -11379,8 +11221,8 @@
       <metric class="np_modifier_count" value="4"/>
       <metric class="character_count" value="631"/>
       <metric class="character_count_min_names" value="631"/>
-      <metric class="morpheme_count" value="191"/>
-      <metric class="morpheme_count_min_names" value="191"/>
+      <metric class="morpheme_count" value="193"/>
+      <metric class="morpheme_count_min_names" value="193"/>
       <metric class="d_level" value="42"/>
       <metric class="d_level_gt4" value="5"/>
       <metric class="imperative_count" value="3"/>
@@ -11608,8 +11450,8 @@
     <metric class="np_modifier_count" value="4"/>
     <metric class="character_count" value="631"/>
     <metric class="character_count_min_names" value="631"/>
-    <metric class="morpheme_count" value="191"/>
-    <metric class="morpheme_count_min_names" value="191"/>
+    <metric class="morpheme_count" value="193"/>
+    <metric class="morpheme_count_min_names" value="193"/>
     <metric class="d_level" value="42"/>
     <metric class="d_level_gt4" value="5"/>
     <metric class="imperative_count" value="3"/>

--- a/tests/semicolon.example.alpino
+++ b/tests/semicolon.example.alpino
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(punt_komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma=";" pos="punct" postag="LET()" pt="let" rel="--" root=";" sense=";" special="punt_komma" word=";"/>
+      <node begin="6" end="7" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="11" id="3" rel="--">
+        <node begin="0" cat="smain" end="4" id="4" rel="dp">
+          <node begin="0" end="1" frame="cleft_het_noun" genus="onz" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" lcat="np" lemma="dit" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="pl" root="dit" sense="dit" special="cleft_het" status="red" vwtype="pers" word="Dit"/>
+          <node begin="1" end="2" frame="verb(unacc,pl,cleft)" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="cleft" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="2" cat="np" end="4" id="7" rel="predc">
+            <node begin="2" end="3" frame="number(hoofd(pl_num))" his="normal" his_1="number_expression" id="8" infl="pl_num" lcat="detp" lemma="twee" naamval="stan" numtype="hoofd" pos="num" positie="prenom" postag="TW(hoofd,prenom,stan)" pt="tw" rel="det" root="twee" sense="twee" word="twee"/>
+            <node begin="3" end="4" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="zin" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="hd" rnum="pl" root="zin" sense="zin" word="zinnen"/>
+          </node>
+        </node>
+        <node begin="5" cat="du" end="11" id="10" rel="dp">
+          <node begin="5" end="6" frame="adverb" his="normal" his_1="normal" id="11" lcat="advp" lemma="althans" pos="adv" postag="BW()" pt="bw" rel="nucl" root="althans" sense="althans" word="althans"/>
+          <node begin="7" cat="smain" end="11" id="12" rel="tag">
+            <node begin="7" end="8" frame="dip_sbar_adverb" his="normal" his_1="normal" id="13" lcat="advp" lemma="zo" pos="adv" postag="BW()" pt="bw" rel="mod" root="zo" sc="dip_sbar" sense="zo" word="zo"/>
+            <node begin="8" end="9" frame="verb(hebben,pl,transitive_ndev_ndev)" his="normal" his_1="normal" id="14" infl="pl" lcat="smain" lemma="zien" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" tense="present" word="zien" wvorm="pv"/>
+            <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="normal" id="15" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="we"/>
+            <node begin="10" end="11" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="16" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="obj1" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dit zijn twee zinnen ; althans , zo zien we dat .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/smallconjuncts.example.alpino
+++ b/tests/smallconjuncts.example.alpino
@@ -1,0 +1,861 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="13" id="2" rel="--">
+        <node begin="0" cat="cp" end="5" id="3" rel="sat">
+          <node begin="0" conjtype="onder" end="1" frame="complementizer(als)" his="normal" his_1="decap" his_1_1="normal" id="4" lcat="cp" lemma="als" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="als" sc="als" sense="als" word="Als"/>
+          <node begin="1" cat="ssub" end="5" id="5" rel="body">
+            <node begin="1" case="both" def="def" end="2" frame="pronoun(nwh,je,sg,de,both,def,wkpro)" gen="de" getal="ev" his="normal" his_1="normal" id="6" lcat="np" lemma="je" naamval="nomin" num="sg" pdtype="pron" per="je" persoon="2v" pos="pron" postag="VNW(pers,pron,nomin,red,2v,ev)" pt="vnw" rel="su" rnum="sg" root="je" sense="je" special="wkpro" status="red" vwtype="pers" wh="nwh" word="je"/>
+            <node begin="2" cat="ap" end="4" id="7" rel="predc">
+              <node begin="2" end="3" frame="intensifier" his="normal" his_1="normal" id="8" lcat="advp" lemma="te" pos="adv" postag="BW()" pt="bw" rel="mod" root="te" sense="te" special="intensifier" word="te"/>
+              <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(tmpadv))" graad="basis" his="normal" his_1="normal" id="9" infl="no_e" lcat="ap" lemma="laat" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="laat" sense="laat" vform="adj" word="laat"/>
+            </node>
+            <node begin="4" end="5" frame="verb(unacc,sg_bent,copula)" his="normal" his_1="normal" id="10" infl="sg_bent" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="bent" wvorm="pv"/>
+          </node>
+        </node>
+        <node begin="6" cat="conj" end="13" id="11" rel="nucl">
+          <node begin="6" cat="sv1" end="10" id="12" rel="cnj">
+            <node begin="6" end="7" frame="verb(zijn,sg1,ld_pp)" his="normal" his_1="normal" id="13" infl="sg1" lcat="sv1" lemma="gaan" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ga" sc="ld_pp" sense="ga" stype="imparative" tense="present" word="ga" wvorm="pv"/>
+            <node begin="7" end="8" frame="tmp_adverb" his="normal" his_1="normal" id="14" lcat="advp" lemma="dan" pos="adv" postag="BW()" pt="bw" rel="mod" root="dan" sense="dan" special="tmp" word="dan"/>
+            <node begin="8" cat="pp" end="10" id="15" rel="ld">
+              <node begin="8" end="9" frame="preposition(naar,[toe])" his="normal" his_1="normal" id="16" lcat="pp" lemma="naar" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="naar" sense="naar" vztype="init" word="naar"/>
+              <node begin="9" end="10" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="huis" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="huis" sense="huis" word="huis"/>
+            </node>
+          </node>
+          <node begin="10" conjtype="neven" end="11" frame="conj(en)" his="normal" his_1="normal" id="18" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="11" cat="sv1" end="13" id="19" rel="cnj">
+            <node begin="11" end="12" frame="verb(unacc,sg1,ld_adv)" his="normal" his_1="normal" id="20" infl="sg1" lcat="sv1" lemma="blijven" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="blijf" sc="ld_adv" sense="blijf" stype="imparative" tense="present" word="blijf" wvorm="pv"/>
+            <node begin="12" end="13" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="21" lcat="advp" lemma="daar" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(aanw,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="ld" root="daar" sense="daar" special="er_loc" status="vol" vwtype="aanw" word="daar"/>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="22" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Als je te laat bent , ga dan naar huis en blijf daar .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="Dat"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="ap" end="10" id="4" rel="predc">
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="leuk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="leuk" sense="leuk" vform="adj" word="leuk"/>
+          <node begin="3" cat="conj" end="10" id="6" rel="mod">
+            <node begin="3" cat="pp" end="6" id="7" rel="cnj">
+              <node begin="3" end="4" frame="preposition(in,[])" his="normal" his_1="normal" id="8" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="4" cat="np" end="6" id="9" rel="obj1">
+                <node begin="4" end="5" frame="determiner(de)" his="normal" his_1="normal" id="10" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="5" end="6" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="middag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="middag" sense="middag" special="tmp" word="middag"/>
+              </node>
+            </node>
+            <node begin="6" conjtype="neven" end="7" frame="conj(of)" his="normal" his_1="normal" id="12" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+            <node begin="7" cat="pp" end="10" id="13" rel="cnj">
+              <node begin="7" end="8" frame="preposition(in,[])" his="normal" his_1="normal" id="14" lcat="pp" lemma="in" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="in" sense="in" vztype="init" word="in"/>
+              <node begin="8" cat="np" end="10" id="15" rel="obj1">
+                <node begin="8" end="9" frame="determiner(de)" his="normal" his_1="normal" id="16" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                <node begin="9" end="10" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="avond" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="avond" sense="avond" special="tmp" word="avond"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat is leuk in de middag of in de avond .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="0" cat="smain" end="10" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="Dat"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="ap" end="10" id="4" rel="predc">
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv),subject_vp)" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="leuk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="leuk" sc="subject_vp" sense="leuk" vform="adj" word="leuk"/>
+          <node begin="3" cat="conj" end="10" id="6" rel="vc">
+            <node begin="3" cat="oti" end="6" id="7" rel="cnj">
+              <node begin="3" end="4" frame="complementizer(om)" his="normal" his_1="normal" id="8" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+              <node begin="4" cat="ti" end="6" id="9" rel="body">
+                <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="10" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,transitive_ndev_ndev)" his="normal" his_1="normal" id="11" infl="inf" lcat="inf" lemma="horen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="body" root="hoor" sc="transitive_ndev_ndev" sense="hoor" word="horen" wvorm="inf"/>
+              </node>
+            </node>
+            <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="7" cat="oti" end="10" id="13" rel="cnj">
+              <node begin="7" end="8" frame="complementizer(om)" his="normal" his_1="normal" id="14" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+              <node begin="8" cat="ti" end="10" id="15" rel="body">
+                <node begin="8" end="9" frame="complementizer(te)" his="normal" his_1="normal" id="16" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="9" buiging="zonder" end="10" frame="verb(hebben,inf(no_e),transitive_ndev_ndev)" his="normal" his_1="normal" id="17" infl="inf(no_e)" lcat="inf" lemma="zien" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="body" root="zie" sc="transitive_ndev_ndev" sense="zie" word="zien" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat is leuk om te horen en om te zien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" end="1" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="Dat"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="ap" end="9" id="4" rel="predc">
+          <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv),subject_vp)" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="leuk" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="leuk" sc="subject_vp" sense="leuk" vform="adj" word="leuk"/>
+          <node begin="3" cat="oti" end="9" id="6" rel="vc">
+            <node begin="3" end="4" frame="complementizer(om)" his="normal" his_1="normal" id="7" lcat="oti" lemma="om" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="om" sc="om" sense="om" vztype="init" word="om"/>
+            <node begin="4" cat="conj" end="9" id="8" rel="body">
+              <node begin="4" cat="ti" end="6" id="9" rel="cnj">
+                <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="10" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,transitive_ndev_ndev)" his="normal" his_1="normal" id="11" infl="inf" lcat="inf" lemma="horen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="body" root="hoor" sc="transitive_ndev_ndev" sense="hoor" word="horen" wvorm="inf"/>
+              </node>
+              <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="7" cat="ti" end="9" id="13" rel="cnj">
+                <node begin="7" end="8" frame="complementizer(te)" his="normal" his_1="normal" id="14" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+                <node begin="8" buiging="zonder" end="9" frame="verb(hebben,inf(no_e),transitive_ndev_ndev)" his="normal" his_1="normal" id="15" infl="inf(no_e)" lcat="inf" lemma="zien" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="body" root="zie" sc="transitive_ndev_ndev" sense="zie" word="zien" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Dat is leuk om te horen en te zien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="0" cat="np" end="9" id="2" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="2" cat="conj" end="9" id="5" rel="mod">
+            <node begin="2" cat="rel" end="5" id="6" rel="cnj">
+              <node begin="2" case="no_obl" end="3" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="7" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="2" cat="ssub" end="5" id="8" rel="body">
+                <node begin="2" end="3" id="9" index="2" rel="su"/>
+                <node begin="3" case="dat_acc" def="def" end="4" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+                <node begin="4" end="5" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="11" infl="sg" lcat="ssub" lemma="slaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="sla" sc="transitive" sense="sla" tense="past" word="sloeg" wvorm="pv"/>
+              </node>
+            </node>
+            <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="6" cat="rel" end="9" id="13" rel="cnj">
+              <node begin="6" case="no_obl" end="7" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="14" index="3" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+              <node begin="6" cat="ssub" end="9" id="15" rel="body">
+                <node begin="6" end="7" id="16" index="3" rel="su"/>
+                <node begin="7" case="dat_acc" def="def" end="8" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+                <node begin="8" end="9" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="18" infl="sg" lcat="ssub" lemma="bespugen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="bespuug" sc="transitive" sense="bespuug" tense="past" word="bespuugde" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="9" end="10" frame="verb(unacc,sg_is,passive)" his="normal" his_1="normal" id="19" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="passive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="11" id="20" rel="vc">
+          <node begin="0" end="9" id="21" index="1" rel="obj1"/>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,ninv(transitive,part_transitive(op)))" his="normal" his_1="part-V" id="22" infl="psp" lcat="ppart" lemma="op_pakken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="pak_op" sc="part_transitive(op)" sense="pak_op" word="opgepakt" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="23" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De man die mij sloeg en die mij bespuugde is opgepakt .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="smain" end="9" id="1" rel="--">
+        <node begin="0" cat="np" end="7" id="2" index="1" rel="su">
+          <node begin="0" end="1" frame="determiner(de)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="De"/>
+          <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+          <node begin="2" cat="rel" end="7" id="5" rel="mod">
+            <node begin="2" case="no_obl" end="3" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="6" index="2" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+            <node begin="2" cat="conj" end="7" id="7" rel="body">
+              <node begin="2" cat="ssub" end="5" id="8" rel="cnj">
+                <node begin="2" end="3" id="9" index="2" rel="su"/>
+                <node begin="3" case="dat_acc" def="def" end="4" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="10" index="3" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+                <node begin="4" end="5" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="11" infl="sg" lcat="ssub" lemma="slaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="sla" sc="transitive" sense="sla" tense="past" word="sloeg" wvorm="pv"/>
+              </node>
+              <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+              <node begin="2" cat="ssub" end="7" id="13" rel="cnj">
+                <node begin="2" end="3" id="14" index="2" rel="su"/>
+                <node begin="3" end="4" id="15" index="3" rel="obj1"/>
+                <node begin="6" end="7" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="16" infl="sg" lcat="ssub" lemma="verwonden" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="verwond" sc="transitive" sense="verwond" tense="past" word="verwondde" wvorm="pv"/>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node begin="7" end="8" frame="verb(unacc,sg_is,aux_psp_zijn)" his="normal" his_1="normal" id="17" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="9" id="18" rel="vc">
+          <node begin="0" end="7" id="19" index="1" rel="su"/>
+          <node begin="8" buiging="zonder" end="9" frame="verb(zijn,psp,intransitive)" his="normal" his_1="normal" id="20" infl="psp" lcat="ppart" lemma="vluchten" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="vlucht" sc="intransitive" sense="vlucht" word="gevlucht" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">De man die mij sloeg en verwondde is gevlucht .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="9" id="2" rel="--">
+        <node begin="0" cat="np" end="2" id="3" index="1" rel="su">
+          <node begin="0" buiging="met-e" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="Deze"/>
+          <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+        </node>
+        <node begin="2" end="3" frame="verb('hebben/zijn',sg,modifier(aux(inf)))" his="normal" his_1="normal" id="6" infl="sg" lcat="smain" lemma="moeten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" stype="declarative" tense="present" word="moet" wvorm="pv"/>
+        <node begin="0" cat="inf" end="9" id="7" rel="vc">
+          <node begin="0" end="2" id="8" index="1" rel="su"/>
+          <node begin="0" cat="conj" end="8" id="9" rel="vc">
+            <node begin="0" cat="ppart" end="4" id="10" rel="cnj">
+              <node begin="0" end="2" id="11" index="1" rel="obj1"/>
+              <node begin="3" buiging="zonder" end="4" frame="verb(hebben,psp,ninv(transitive,part_transitive(op)))" his="normal" his_1="part-V" id="12" infl="psp" lcat="ppart" lemma="op_nemen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="neem_op" sc="part_transitive(op)" sense="neem_op" word="opgenomen" wvorm="vd"/>
+            </node>
+            <node begin="0" cat="ppart" end="6" id="13" rel="cnj">
+              <node begin="0" end="2" id="14" index="1" rel="obj1"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="15" infl="psp" lcat="ppart" lemma="onderzoeken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="onderzoek" sc="transitive" sense="onderzoek" word="onderzocht" wvorm="vd"/>
+            </node>
+            <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="16" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="0" cat="ppart" end="8" id="17" rel="cnj">
+              <node begin="0" end="2" id="18" index="1" rel="obj1"/>
+              <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,transitive_ndev)" his="normal" his_1="normal" id="19" infl="psp" lcat="ppart" lemma="helpen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="help" sc="transitive_ndev" sense="help" word="geholpen" wvorm="vd"/>
+            </node>
+          </node>
+          <node begin="8" buiging="zonder" end="9" frame="verb(unacc,inf,passive)" his="normal" his_1="normal" id="20" infl="inf" lcat="inf" lemma="worden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="word" sc="passive" sense="word" word="worden" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Deze man moet opgenomen , onderzocht en geholpen worden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" cat="np" end="2" id="2" index="1" rel="su">
+          <node begin="0" buiging="met-e" end="1" frame="determiner(de,nwh,nmod,pro,nparg)" his="normal" his_1="decap" his_1_1="normal" id="3" infl="de" lcat="detp" lemma="deze" naamval="stan" npagr="rest" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,met-e,rest)" pt="vnw" rel="det" root="deze" sense="deze" vwtype="aanw" wh="nwh" word="Deze"/>
+          <node begin="1" end="2" frame="noun(de,count,bare_meas)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="4" lcat="np" lemma="man" naamval="stan" ntype="soort" num="bare_meas" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="man" sense="man" word="man"/>
+        </node>
+        <node begin="2" end="3" frame="verb('hebben/zijn',sg,modifier(aux(inf)))" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="moeten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="moet" sc="modifier(aux(inf))" sense="moet" stype="declarative" tense="present" word="moet" wvorm="pv"/>
+        <node begin="0" cat="inf" end="7" id="6" rel="vc">
+          <node begin="0" end="2" id="7" index="1" rel="su"/>
+          <node begin="0" cat="conj" end="6" id="8" rel="vc">
+            <node begin="0" cat="ppart" end="4" id="9" rel="cnj">
+              <node begin="0" end="2" id="10" index="1" rel="obj1"/>
+              <node begin="3" buiging="zonder" end="4" frame="verb(hebben,psp,ninv(transitive,part_transitive(op)))" his="normal" his_1="part-V" id="11" infl="psp" lcat="ppart" lemma="op_nemen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="neem_op" sc="part_transitive(op)" sense="neem_op" word="opgenomen" wvorm="vd"/>
+            </node>
+            <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="0" cat="ppart" end="6" id="13" rel="cnj">
+              <node begin="0" end="2" id="14" index="1" rel="obj1"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(hebben,psp,transitive_ndev)" his="normal" his_1="normal" id="15" infl="psp" lcat="ppart" lemma="helpen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="help" sc="transitive_ndev" sense="help" word="geholpen" wvorm="vd"/>
+            </node>
+          </node>
+          <node begin="6" buiging="zonder" end="7" frame="verb(unacc,inf,passive)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="worden" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="word" sc="passive" sense="word" word="worden" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Deze man moet opgenomen en geholpen worden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(dubb_punt)" his="normal" his_1="normal" id="1" lcat="punct" lemma=":" pos="punct" postag="LET()" pt="let" rel="--" root=":" sense=":" special="dubb_punt" word=":"/>
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="2" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="du" end="9" id="3" rel="--">
+        <node begin="0" cat="np" end="3" id="4" rel="nucl">
+          <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="5" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+          <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="6" infl="no_e" lcat="ap" lemma="oer_oud" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="oer_oud" sense="oer_oud" vform="adj" word="oeroud"/>
+          <node begin="2" end="3" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="dilemma" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="dilemma" sense="dilemma" word="dilemma"/>
+        </node>
+        <node begin="4" cat="conj" end="9" id="8" rel="sat">
+          <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="aanval" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="cnj" rnum="pl" root="aanval" sense="aanval" word="aanvallen"/>
+          <node begin="6" buiging="zonder" end="7" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="10" lcat="np" lemma="verstoppen" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="cnj" rnum="sg" root="verstop" sc="intransitive" sense="verstop" special="v_noun" word="verstoppen" wvorm="inf"/>
+          <node begin="7" conjtype="neven" end="8" frame="conj(of)" his="normal" his_1="normal" id="11" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+          <node begin="8" end="9" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="vlucht" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="cnj" rnum="pl" root="vlucht" sense="vlucht" word="vluchten"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een oeroud dilemma : aanvallen , verstoppen of vluchten .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="3" end="4" frame="punct(dubb_punt)" his="normal" his_1="normal" id="1" lcat="punct" lemma=":" pos="punct" postag="LET()" pt="let" rel="--" root=":" sense=":" special="dubb_punt" word=":"/>
+      <node begin="0" cat="du" end="7" id="2" rel="--">
+        <node begin="0" cat="np" end="3" id="3" rel="nucl">
+          <node begin="0" end="1" frame="determiner(een)" his="normal" his_1="decap" his_1_1="normal" id="4" infl="een" lcat="detp" lemma="een" lwtype="onbep" naamval="stan" npagr="agr" pos="det" postag="LID(onbep,stan,agr)" pt="lid" rel="det" root="een" sense="een" word="Een"/>
+          <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="5" infl="no_e" lcat="ap" lemma="oer_oud" pos="adj" positie="prenom" postag="ADJ(prenom,basis,zonder)" pt="adj" rel="mod" root="oer_oud" sense="oer_oud" vform="adj" word="oeroud"/>
+          <node begin="2" end="3" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="dilemma" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="dilemma" sense="dilemma" word="dilemma"/>
+        </node>
+        <node begin="4" cat="conj" end="7" id="7" rel="sat">
+          <node begin="4" end="5" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="aanval" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="cnj" rnum="pl" root="aanval" sense="aanval" word="aanvallen"/>
+          <node begin="5" conjtype="neven" end="6" frame="conj(of)" his="normal" his_1="normal" id="9" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+          <node begin="6" end="7" frame="noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="vlucht" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="cnj" rnum="pl" root="vlucht" sense="vlucht" word="vluchten"/>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Een oeroud dilemma : aanvallen of vluchten .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="16" id="0" rel="top">
+      <node begin="0" cat="du" end="15" id="1" rel="--">
+        <node begin="0" conjtype="neven" end="1" frame="complementizer(root)" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="du" lemma="en" pos="comp" postag="VG(neven)" pt="vg" rel="dlink" root="en" sc="root" sense="en" word="En"/>
+        <node begin="1" cat="conj" end="15" id="3" rel="nucl">
+          <node begin="1" cat="smain" end="6" id="4" rel="cnj">
+            <node begin="2" end="3" frame="verb(zijn,past(sg),aux(te_inf))" his="normal" his_1="normal" id="5" infl="sg" lcat="smain" lemma="beginnen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="begin" sc="aux(te_inf)" sense="begin" stype="declarative" tense="past" word="begon" wvorm="pv"/>
+            <node begin="3" end="4" frame="het_noun" genus="onz" getal="ev" his="normal" his_1="normal" id="6" index="1" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="noun" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="su" rnum="sg" root="het" sense="het" special="het" status="red" vwtype="pers" word="het"/>
+            <node begin="1" cat="ti" end="6" id="7" rel="vc">
+              <node begin="4" end="5" frame="complementizer(te)" his="normal" his_1="normal" id="8" lcat="ti" lemma="te" pos="comp" postag="VZ(init)" pt="vz" rel="cmp" root="te" sc="te" sense="te" vztype="init" word="te"/>
+              <node begin="1" cat="inf" end="6" id="9" rel="body">
+                <node begin="1" end="2" frame="tmp_adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="toen" pos="adv" postag="BW()" pt="bw" rel="mod" root="toen" sense="toen" special="tmp" word="toen"/>
+                <node begin="3" end="4" id="11" index="1" rel="su"/>
+                <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,het_subj)" his="normal" his_1="normal" id="12" infl="inf" lcat="inf" lemma="regenen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="regen" sc="het_subj" sense="het-regen" word="regenen" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+          <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="13" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="7" cat="smain" end="15" id="14" rel="cnj">
+            <node begin="7" end="8" frame="determiner(het,nwh,nmod,pro,nparg)" getal="ev" his="normal" his_1="normal" id="15" infl="het" lcat="np" lemma="dat" naamval="stan" pdtype="pron" persoon="3o" pos="det" postag="VNW(aanw,pron,stan,vol,3o,ev)" pt="vnw" rel="su" rnum="sg" root="dat" sense="dat" status="vol" vwtype="aanw" wh="nwh" word="dat"/>
+            <node begin="8" end="9" frame="verb(hebben,past(sg),transitive_ndev)" his="normal" his_1="normal" id="16" infl="sg" lcat="smain" lemma="doen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="doe" sc="transitive_ndev" sense="doe" stype="declarative" tense="past" word="deed" wvorm="pv"/>
+            <node begin="9" end="10" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" genus="onz" getal="ev" his="normal" his_1="normal" id="17" infl="het" lcat="np" lemma="het" naamval="stan" pdtype="pron" persoon="3" pos="det" postag="VNW(pers,pron,stan,red,3,ev,onz)" pt="vnw" rel="obj1" rnum="sg" root="het" sense="het" status="red" vwtype="pers" wh="nwh" word="het"/>
+            <node begin="10" cat="np" end="15" id="18" rel="mod">
+              <node begin="10" end="11" frame="determiner(de)" his="normal" his_1="normal" id="19" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+              <node begin="11" end="12" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="20" lcat="np" lemma="rest" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="rest" sense="rest" special="tmp" word="rest"/>
+              <node begin="12" cat="pp" end="15" id="21" rel="mod">
+                <node begin="12" end="13" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="22" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+                <node begin="13" cat="np" end="15" id="23" rel="obj1">
+                  <node begin="13" end="14" frame="determiner(de)" his="normal" his_1="normal" id="24" infl="de" lcat="detp" lemma="de" lwtype="bep" naamval="stan" npagr="rest" pos="det" postag="LID(bep,stan,rest)" pt="lid" rel="det" root="de" sense="de" word="de"/>
+                  <node begin="14" end="15" frame="tmp_noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="25" lcat="np" lemma="dag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dag" sense="dag" special="tmp" word="dag"/>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="15" end="16" frame="punct(punt)" his="normal" his_1="normal" id="26" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">En toen begon het te regenen en dat deed het de rest van de dag .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),fixed([[gewonnen],refl],no_passive))" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="geven" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="geef" sc="fixed([[gewonnen],refl],no_passive)" sense="zich-gewonnen-geef" stype="declarative" tense="past" word="gaf" wvorm="pv"/>
+        <node begin="2" end="3" frame="reflexive(u_thi,both)" getal="getal" his="normal" his_1="normal" id="4" lcat="np" lemma="zich" naamval="obl" num="both" pdtype="pron" per="u_thi" persoon="3" pos="pron" postag="VNW(refl,pron,obl,red,3,getal)" pt="vnw" refl="refl" rel="se" root="zich" sense="zich" status="red" vwtype="refl" word="zich"/>
+        <node begin="3" cat="pp" end="7" id="5" rel="mod">
+          <node begin="3" end="4" frame="preposition(zonder,[])" his="normal" his_1="normal" id="6" lcat="pp" lemma="zonder" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="zonder" sense="zonder" vztype="init" word="zonder"/>
+          <node begin="4" cat="conj" end="7" id="7" rel="obj1">
+            <node begin="4" end="5" frame="noun(het,mass,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="slag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="cnj" rnum="sg" root="slag" sense="slag" word="slag"/>
+            <node begin="5" conjtype="neven" end="6" frame="conj(of)" his="normal" his_1="normal" id="9" lcat="vg" lemma="of" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="of" sense="of" word="of"/>
+            <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="stoot" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="stoot" sense="stoot" word="stoot"/>
+          </node>
+        </node>
+        <node begin="7" buiging="zonder" end="8" frame="fixed_part([gewonnen])" his="normal" his_1="normal" id="11" lcat="fixed" lemma="gewonnen" pos="fixed" positie="prenom" postag="WW(vd,prenom,zonder)" pt="ww" rel="svp" root="gewonnen" sense="gewonnen" word="gewonnen" wvorm="vd"/>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij gaf zich zonder slag of stoot gewonnen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="2" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,past(sg),intransitive)" his="normal" his_1="normal" id="4" infl="sg" lcat="smain" lemma="hoesten" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="hoest" sc="intransitive" sense="hoest" stype="declarative" tense="past" word="hoestte" wvorm="pv"/>
+        <node begin="3" cat="conj" end="10" id="5" rel="mod">
+          <node begin="3" cat="whrel" end="6" id="6" rel="cnj">
+            <node begin="3" case="both" def="indef" end="4" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="rhd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="wat"/>
+            <node begin="3" cat="ssub" end="6" id="8" rel="body">
+              <node begin="3" end="4" id="9" index="1" rel="su"/>
+              <node begin="4" case="dat_acc" def="def" end="5" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+              <node begin="5" end="6" frame="verb(hebben,past(sg),ninv(transitive,part_transitive(teleur)))" his="normal" his_1="part-V" id="11" infl="sg" lcat="ssub" lemma="teleur_stellen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="stel_teleur" sc="part_transitive(teleur)" sense="stel_teleur" tense="past" word="teleurstelde" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="7" cat="whrel" end="10" id="13" rel="cnj">
+            <node begin="7" case="both" def="indef" end="8" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="14" index="2" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="rhd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="wat"/>
+            <node begin="7" cat="ssub" end="10" id="15" rel="body">
+              <node begin="7" end="8" id="16" index="2" rel="su"/>
+              <node begin="8" case="dat_acc" def="def" end="9" frame="pronoun(nwh,fir,sg,de,dat_acc,def)" gen="de" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="mij" naamval="obl" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pr,pron,obl,vol,1,ev)" pt="vnw" rel="obj1" rnum="sg" root="mij" sense="mij" status="vol" vwtype="pr" wh="nwh" word="mij"/>
+              <node begin="9" end="10" frame="verb(hebben,past(sg),transitive)" his="normal" his_1="normal" id="18" infl="sg" lcat="ssub" lemma="ergeren" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="erger" sc="transitive" sense="erger" tense="past" word="ergerde" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij hoestte , wat mij teleurstelde en wat mij ergerde .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="2" skips="1"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="robust_skip" id="1" lcat="--" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="--" root="en" sense="en" word="en"/>
+      <node begin="0" cat="du" end="9" id="2" rel="--">
+        <node begin="0" cat="smain" end="6" id="3" rel="dp">
+          <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+          <node begin="1" end="2" frame="verb(unacc,sg_is,aan_het)" his="normal" his_1="normal" id="5" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aan_het" sense="ben-aan_het" stype="declarative" tense="present" word="is" wvorm="pv"/>
+          <node begin="2" end="3" frame="sentence_adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="altijd" pos="adv" postag="BW()" pt="bw" rel="mod" root="altijd" sense="altijd" special="sentence" word="altijd"/>
+          <node begin="0" cat="ahi" end="6" id="7" rel="vc">
+            <node begin="3" cat="mwu" end="5" his="normal" his_1="normal" id="8" rel="cmp">
+              <node begin="3" end="4" frame="complementizer(aan_het)" id="9" lcat="ahi" lemma="aan" pos="comp" postag="VZ(init)" pt="vz" rel="mwp" root="aan" sc="aan_het" sense="aan" vztype="init" word="aan"/>
+              <node begin="4" end="5" frame="complementizer(aan_het)" id="10" lcat="ahi" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="comp" postag="LID(bep,stan,evon)" pt="lid" rel="mwp" root="het" sc="aan_het" sense="het" word="het"/>
+            </node>
+            <node begin="0" cat="inf" end="6" id="11" rel="body">
+              <node begin="0" end="1" id="12" index="1" rel="su"/>
+              <node begin="5" buiging="zonder" end="6" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="13" infl="inf" lcat="inf" lemma="schikken" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="schik" sc="intransitive" sense="schik" word="schikken" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+        <node begin="7" cat="np" end="9" id="14" rel="dp">
+          <node begin="7" end="8" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="15" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+          <node begin="8" buiging="zonder" end="9" frame="v_noun(intransitive)" getal-n="zonder-n" his="normal" his_1="normal" id="16" lcat="np" lemma="plooien" pos="verb" positie="nom" postag="WW(inf,nom,zonder,zonder-n)" pt="ww" rel="hd" rnum="sg" root="plooi" sc="intransitive" sense="plooi" special="v_noun" word="plooien" wvorm="inf"/>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="robust_skip" id="17" lcat="--" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is altijd aan het schikken en het plooien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="conj" end="7" id="4" rel="predc">
+          <node begin="2" cat="ap" end="4" id="5" rel="cnj">
+            <node aform="base" begin="2" buiging="zonder" end="3" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="6" index="1" infl="no_e" lcat="ap" lemma="erg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="erg" sense="erg" vform="adj" word="erg"/>
+            <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="7" infl="no_e" lcat="ap" lemma="mooi" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="mooi" sense="mooi" vform="adj" word="mooi"/>
+          </node>
+          <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="8" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="2" cat="ap" end="7" id="9" rel="cnj">
+            <node begin="2" end="3" id="10" index="1" rel="mod"/>
+            <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="bijzonder" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="bijzonder" sense="bijzonder" vform="adj" word="bijzonder"/>
+            <node aform="base" begin="6" buiging="zonder" end="7" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="12" infl="no_e" lcat="ap" lemma="intelligent" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="hd" root="intelligent" sense="intelligent" vform="adj" word="intelligent"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is erg mooi en bijzonder intelligent .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,ld_adv)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="ld_adv" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node aform="base" begin="2" end="3" frame="adjective(both(tmpadv))" his="normal" his_1="normal" id="4" infl="both" lcat="ap" lemma="even" pos="adj" postag="BW()" pt="bw" rel="mod" root="even" sense="even" vform="adj" word="even"/>
+        <node begin="3" cat="conj" end="7" id="5" rel="ld">
+          <node begin="3" end="4" frame="loc_adverb" his="normal" his_1="normal" id="6" lcat="advp" lemma="boven" pos="adv" postag="VZ(fin)" pt="vz" rel="cnj" root="boven" sense="boven" special="loc" vztype="fin" word="boven"/>
+          <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="7" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="5" cat="advp" end="7" id="8" rel="cnj">
+            <node aform="base" begin="5" end="6" frame="adjective(both(tmpadv))" his="normal" his_1="normal" id="9" infl="both" lcat="ap" lemma="even" pos="adj" postag="BW()" pt="bw" rel="mod" root="even" sense="even" vform="adj" word="even"/>
+            <node begin="6" end="7" frame="loc_adverb" his="normal" his_1="normal" id="10" lcat="advp" lemma="beneden" pos="adv" postag="VZ(fin)" pt="vz" rel="hd" root="beneden" sense="beneden" special="loc" vztype="fin" word="beneden"/>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="11" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is even boven en even beneden .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(unacc,sg_is,intransitive)" his="normal" his_1="normal" id="3" infl="sg_is" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="intransitive" sense="ben" stype="declarative" tense="present" word="is" wvorm="pv"/>
+        <node begin="2" cat="conj" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="5" lcat="advp" lemma="overal" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(onbep,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="cnj" root="overal" sense="overal" special="er_loc" status="vol" vwtype="onbep" word="overal"/>
+          <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="4" end="5" frame="er_loc_adverb" getal="getal" his="normal" his_1="normal" id="7" lcat="advp" lemma="nergens" naamval="obl" pdtype="adv-pron" persoon="3o" pos="adv" postag="VNW(onbep,adv-pron,obl,vol,3o,getal)" pt="vnw" rel="cnj" root="nergens" sense="nergens" special="er_loc" status="vol" vwtype="onbep" word="nergens"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="8" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij is overal en nergens .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="14" id="0" rel="top">
+      <node begin="7" end="8" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="13" id="2" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,transitive)" his="normal" his_1="normal" id="4" infl="sg3" lcat="smain" lemma="nemen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="neem" sc="transitive" sense="neem" stype="declarative" tense="present" word="neemt" wvorm="pv"/>
+        <node begin="2" end="3" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="5" lcat="np" lemma="ontslag" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="obj1" rnum="sg" root="ontslag" sense="ontslag" word="ontslag"/>
+        <node begin="3" cat="conj" end="13" id="6" rel="mod">
+          <node begin="3" cat="cp" end="7" id="7" rel="cnj">
+            <node begin="3" conjtype="onder" end="4" frame="complementizer" his="normal" his_1="normal" id="8" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+            <node begin="4" cat="ssub" end="7" id="9" rel="body">
+              <node begin="4" case="nom" def="def" end="5" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="10" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(padv))" graad="basis" his="normal" his_1="normal" id="11" infl="no_e" lcat="ap" lemma="moe" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="predc" root="moe" sense="moe" vform="adj" word="moe"/>
+              <node begin="6" end="7" frame="verb(unacc,sg_is,copula)" his="normal" his_1="normal" id="12" infl="sg_is" lcat="ssub" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="copula" sense="ben" tense="present" word="is" wvorm="pv"/>
+            </node>
+          </node>
+          <node begin="8" conjtype="neven" end="9" frame="conj(en)" his="normal" his_1="normal" id="13" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="9" cat="cp" end="13" id="14" rel="cnj">
+            <node begin="9" conjtype="onder" end="10" frame="complementizer" his="normal" his_1="normal" id="15" lcat="cp" lemma="omdat" pos="comp" postag="VG(onder)" pt="vg" rel="cmp" root="omdat" sense="omdat" word="omdat"/>
+            <node begin="10" cat="ssub" end="13" id="16" rel="body">
+              <node begin="10" case="nom" def="def" end="11" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node aform="base" begin="11" buiging="zonder" end="12" frame="adjective(pred(locadv))" graad="basis" his="normal" his_1="normal" id="18" infl="pred" lcat="ap" lemma="weg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="weg" sense="weg" vform="adj" word="weg"/>
+              <node begin="12" end="13" frame="verb(hebben,modal_not_u,intransitive)" his="normal" his_1="normal" id="19" infl="modal_not_u" lcat="ssub" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="intransitive" sense="wil" tense="present" word="wil" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="13" end="14" frame="punct(punt)" his="normal" his_1="normal" id="20" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij neemt ontslag omdat hij moe is , en omdat hij weg wil .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,fixed([pc(van),[genoeg]],no_passive))" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="fixed([pc(van),[genoeg]],no_passive)" sense="genoeg-heb-van" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="2" end="3" frame="fixed_part([genoeg])" his="normal" his_1="normal" id="4" lcat="fixed" lemma="genoeg" pos="fixed" postag="BW()" pt="bw" rel="svp" root="genoeg" sense="genoeg" word="genoeg"/>
+        <node begin="3" cat="pp" end="8" id="5" rel="pc">
+          <node begin="3" end="4" frame="preposition(van,[af,uit,vandaan,[af,aan]])" his="normal" his_1="normal" id="6" lcat="pp" lemma="van" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="van" sense="van" vztype="init" word="van"/>
+          <node begin="4" cat="conj" end="8" id="7" rel="obj1">
+            <node begin="4" cat="np" end="6" id="8" rel="cnj">
+              <node begin="4" buiging="zonder" end="5" frame="determiner(het,nwh,nmod,pro,nparg)" his="normal" his_1="normal" id="9" index="1" infl="het" lcat="detp" lemma="dat" naamval="stan" npagr="evon" pdtype="det" pos="det" positie="prenom" postag="VNW(aanw,det,stan,prenom,zonder,evon)" pt="vnw" rel="det" root="dat" sense="dat" vwtype="aanw" wh="nwh" word="dat"/>
+              <node begin="5" end="6" frame="ge_v_noun(intransitive)" genus="onz" getal="ev" graad="basis" his="normal" his_1="ge-" id="10" lcat="np" lemma="gezanik" naamval="stan" ntype="soort" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="gezanik" sc="intransitive" sense="gezanik" special="ge_v_noun" word="gezanik"/>
+            </node>
+            <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="11" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="4" cat="np" end="8" id="12" rel="cnj">
+              <node begin="4" end="5" id="13" index="1" rel="det"/>
+              <node begin="7" end="8" frame="ge_v_noun(intransitive)" genus="onz" getal="ev" graad="basis" his="normal" his_1="ge-" id="14" lcat="np" lemma="gezeur" naamval="stan" ntype="soort" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="gezeur" sc="intransitive" sense="gezeur" special="ge_v_noun" word="gezeur"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb genoeg van dat gezanik en gezeur .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="8" id="0" rel="top">
+      <node begin="0" cat="smain" end="7" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="0" cat="inf" end="7" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="3" buiging="zonder" end="4" frame="verb(hebben,inf,subj_control(te_inf))" his="normal" his_1="normal" id="6" infl="inf" lcat="inf" lemma="leren" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="leer" sc="subj_control(te_inf)" sense="leer" word="leren" wvorm="inf"/>
+          <node begin="0" cat="conj" end="7" id="7" rel="vc">
+            <node begin="0" cat="inf" end="5" id="8" rel="cnj">
+              <node begin="0" end="1" id="9" index="1" rel="su"/>
+              <node begin="2" case="dat_acc" def="def" end="3" frame="pronoun(nwh,thi,sg,de,dat_acc,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="10" index="2" lcat="np" lemma="hem" naamval="obl" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,obl,vol,3,ev,masc)" pt="vnw" rel="obj1" rnum="sg" root="hem" sense="hem" status="vol" vwtype="pers" wh="nwh" word="hem"/>
+              <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="11" infl="inf" lcat="inf" lemma="lopen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="loop" sc="transitive" sense="loop" word="lopen" wvorm="inf"/>
+            </node>
+            <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="0" cat="inf" end="7" id="13" rel="cnj">
+              <node begin="0" end="1" id="14" index="1" rel="su"/>
+              <node begin="2" end="3" id="15" index="2" rel="obj1"/>
+              <node begin="6" buiging="zonder" end="7" frame="verb(hebben,inf,transitive)" his="normal" his_1="normal" id="16" infl="inf" lcat="inf" lemma="fietsen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="fiets" sc="transitive" sense="fiets" word="fietsen" wvorm="inf"/>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node begin="7" end="8" frame="punct(punt)" his="normal" his_1="normal" id="17" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb hem leren lopen en fietsen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="4" end="5" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="11" id="2" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="3" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="4" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="11" id="5" rel="vc">
+          <node begin="0" end="1" id="6" index="1" rel="su"/>
+          <node begin="2" cat="conj" end="10" id="7" rel="obj1">
+            <node begin="2" cat="np" end="4" id="8" rel="cnj">
+              <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="9" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="10" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zoon" sense="zoon" word="zoon"/>
+            </node>
+            <node begin="5" cat="np" end="7" id="11" rel="cnj">
+              <node begin="5" buiging="zonder" end="6" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="12" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="dochter" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dochter" sense="dochter" word="dochter"/>
+            </node>
+            <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="14" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="8" cat="np" end="10" id="15" rel="cnj">
+              <node begin="8" buiging="zonder" end="9" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="16" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="9" end="10" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="17" lcat="np" lemma="schoon_zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="schoon_zoon" sense="schoon_zoon" word="schoonzoon"/>
+            </node>
+          </node>
+          <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,transitive_ndev_ndev)" his="normal" his_1="normal" id="18" infl="psp" lcat="ppart" lemma="zien" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" word="gezien" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb zijn zoon , zijn dochter en zijn schoonzoon gezien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="sg1" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" stype="declarative" tense="present" word="heb" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="8" id="4" rel="vc">
+          <node begin="0" end="1" id="5" index="1" rel="su"/>
+          <node begin="2" cat="conj" end="7" id="6" rel="obj1">
+            <node begin="2" cat="np" end="4" id="7" rel="cnj">
+              <node begin="2" buiging="zonder" end="3" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="8" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="3" end="4" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zoon" sense="zoon" word="zoon"/>
+            </node>
+            <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="10" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="5" cat="np" end="7" id="11" rel="cnj">
+              <node begin="5" buiging="zonder" end="6" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="12" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+              <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="dochter" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dochter" sense="dochter" word="dochter"/>
+            </node>
+          </node>
+          <node begin="7" buiging="zonder" end="8" frame="verb(hebben,psp,transitive_ndev_ndev)" his="normal" his_1="normal" id="14" infl="psp" lcat="ppart" lemma="zien" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="zie" sc="transitive_ndev_ndev" sense="zie" word="gezien" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="15" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik heb zijn zoon en zijn dochter gezien .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" cat="conj" end="5" id="2" rel="predm">
+          <node begin="0" cat="ppres" end="2" id="3" rel="cnj">
+            <node aform="base" begin="0" buiging="zonder" end="1" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="decap" his_1_1="normal" id="4" infl="no_e" lcat="ap" lemma="licht" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="licht" sense="licht" vform="adj" word="Licht"/>
+            <node aform="base" begin="1" buiging="zonder" end="2" frame="adjective(end(both))" his="normal" his_1="V-d" his_1_1="normal" id="5" infl="no_e" lcat="ppres" lemma="wankelen" pos="adj" positie="vrij" postag="WW(od,vrij,zonder)" pt="ww" rel="hd" root="wankel" sense="wankel" vform="gerund" word="wankelend" wvorm="od"/>
+          </node>
+          <node begin="2" conjtype="neven" end="3" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="3" cat="ppres" end="5" id="7" rel="cnj">
+            <node aform="base" begin="3" buiging="zonder" end="4" frame="adjective(no_e(adv))" graad="basis" his="normal" his_1="normal" id="8" infl="no_e" lcat="ap" lemma="half" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="half" sense="half" vform="adj" word="half"/>
+            <node aform="base" begin="4" buiging="zonder" end="5" frame="adjective(end(both))" his="normal" his_1="V-d" his_1_1="normal" id="9" infl="no_e" lcat="ppres" lemma="vallen" pos="adj" positie="vrij" postag="WW(od,vrij,zonder)" pt="ww" rel="hd" root="val" sense="val" vform="gerund" word="vallend" wvorm="od"/>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="verb('hebben/zijn',past(sg),intransitive)" his="normal" his_1="normal" id="10" infl="sg" lcat="smain" lemma="strompelen" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="strompel" sc="intransitive" sense="strompel" stype="declarative" tense="past" word="strompelde" wvorm="pv"/>
+        <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="11" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+        <node aform="base" begin="7" buiging="zonder" end="8" frame="adjective(pred(locadv))" graad="basis" his="normal" his_1="normal" id="12" infl="pred" lcat="ap" lemma="weg" pos="adj" positie="vrij" postag="ADJ(vrij,basis,zonder)" pt="adj" rel="mod" root="weg" sense="weg" vform="adj" word="weg"/>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Licht wankelend en half vallend strompelde hij weg .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="6" id="0" rel="top">
+      <node begin="0" cat="smain" end="5" id="1" rel="--">
+        <node begin="0" cat="conj" end="3" id="2" index="1" rel="su">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+          <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="4" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Arie" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Arie" sense="Arie" word="Arie"/>
+        </node>
+        <node begin="3" end="4" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="6" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="5" id="7" rel="vc">
+          <node begin="0" end="3" id="8" index="1" rel="su"/>
+          <node begin="4" buiging="zonder" end="5" frame="verb(unacc,psp,intransitive)" his="normal" his_1="normal" id="9" infl="psp" lcat="ppart" lemma="komen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="kom" sc="intransitive" sense="kom" word="gekomen" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="5" end="6" frame="punct(punt)" his="normal" his_1="normal" id="10" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter en Arie zijn gekomen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="10" id="0" rel="top">
+      <node begin="0" cat="conj" end="9" id="1" rel="--">
+        <node begin="0" cat="conj" end="3" id="2" rel="cnj">
+          <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="3" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+          <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="4" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Thea" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Thea" sense="Thea" word="Thea"/>
+        </node>
+        <node begin="3" conjtype="neven" end="4" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="4" cat="smain" end="9" id="7" rel="cnj">
+          <node begin="4" cat="conj" end="7" id="8" index="1" rel="su">
+            <node begin="4" end="5" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="9" lcat="np" lemma="Arie" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Arie" sense="Arie" word="Arie"/>
+            <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="10" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="6" end="7" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="11" lcat="np" lemma="Truus" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Truus" sense="Truus" word="Truus"/>
+          </node>
+          <node begin="7" end="8" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="12" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="4" cat="ppart" end="9" id="13" rel="vc">
+            <node begin="4" end="7" id="14" index="1" rel="su"/>
+            <node begin="8" buiging="zonder" end="9" frame="verb(unacc,psp,intransitive)" his="normal" his_1="normal" id="15" infl="psp" lcat="ppart" lemma="komen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="kom" sc="intransitive" sense="kom" word="gekomen" wvorm="vd"/>
+          </node>
+        </node>
+      </node>
+      <node begin="9" end="10" frame="punct(punt)" his="normal" his_1="normal" id="16" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter en Thea en Arie en Truus zijn gekomen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="5" end="6" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="conj" end="11" id="2" rel="--">
+        <node begin="0" cat="smain" end="5" id="3" rel="cnj">
+          <node begin="0" cat="conj" end="3" id="4" index="1" rel="su">
+            <node begin="0" end="1" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="5" lcat="np" lemma="Peter" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Peter" sense="Peter" word="Peter"/>
+            <node begin="1" conjtype="neven" end="2" frame="conj(en)" his="normal" his_1="normal" id="6" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="2" end="3" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="7" lcat="np" lemma="Thea" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Thea" sense="Thea" word="Thea"/>
+          </node>
+          <node begin="3" end="4" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="8" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+          <node begin="0" cat="ppart" end="5" id="9" rel="vc">
+            <node begin="0" end="3" id="10" index="1" rel="su"/>
+            <node begin="4" buiging="zonder" end="5" frame="verb(unacc,psp,intransitive)" his="normal" his_1="normal" id="11" infl="psp" lcat="ppart" lemma="komen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="kom" sc="intransitive" sense="kom" word="gekomen" wvorm="vd"/>
+          </node>
+        </node>
+        <node begin="6" conjtype="neven" end="7" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="7" cat="du" end="11" id="13" rel="cnj">
+          <node begin="7" cat="conj" end="10" id="14" rel="dp">
+            <node begin="7" end="8" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="15" lcat="np" lemma="Arie" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Arie" sense="Arie" word="Arie"/>
+            <node begin="8" conjtype="neven" end="9" frame="conj(en)" his="normal" his_1="normal" id="16" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+            <node begin="9" end="10" frame="proper_name(sg,'PER')" genus="zijd" getal="ev" graad="basis" his="normal" his_1="names_dictionary" id="17" lcat="np" lemma="Truus" naamval="stan" neclass="PER" ntype="eigen" num="sg" pos="name" postag="N(eigen,ev,basis,zijd,stan)" pt="n" rel="cnj" rnum="sg" root="Truus" sense="Truus" word="Truus"/>
+          </node>
+          <node begin="10" end="11" frame="sentence_adverb" his="normal" his_1="normal" id="18" lcat="advp" lemma="ook" pos="adv" postag="BW()" pt="bw" rel="dp" root="ook" sense="ook" special="sentence" word="ook"/>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="19" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Peter en Thea zijn gekomen , en Arie en Truus ook .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="conj" end="11" id="1" rel="--">
+        <node begin="0" cat="smain" end="5" id="2" rel="cnj">
+          <node begin="1" end="2" frame="verb(zijn,past(sg),aux(inf))" his="normal" his_1="normal" id="3" infl="sg" lcat="smain" lemma="gaan" pos="verb" postag="WW(pv,verl,ev)" pt="ww" pvagr="ev" pvtijd="verl" rel="hd" root="ga" sc="aux(inf)" sense="ga" tense="past" word="ging" wvorm="pv"/>
+          <node begin="2" case="nom" def="def" end="3" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="4" index="1" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="0" cat="inf" end="5" id="5" rel="vc">
+            <node begin="0" end="1" frame="tmp_adverb" his="normal" his_1="decap" his_1_1="normal" id="6" index="2" lcat="advp" lemma="toen" pos="adv" postag="BW()" pt="bw" rel="mod" root="toen" sense="toen" special="tmp" word="Toen"/>
+            <node begin="2" end="3" id="7" index="1" rel="su"/>
+            <node begin="3" end="4" frame="adverb" his="normal" his_1="normal" id="8" lcat="advp" lemma="toch" pos="adv" postag="BW()" pt="bw" rel="mod" root="toch" sense="toch" word="toch"/>
+            <node begin="4" buiging="zonder" end="5" frame="verb(hebben,inf,intransitive)" his="normal" his_1="normal" id="9" infl="inf" lcat="inf" lemma="twijfelen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="twijfel" sc="intransitive" sense="twijfel" word="twijfelen" wvorm="inf"/>
+          </node>
+        </node>
+        <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="10" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+        <node begin="0" cat="smain" end="11" id="11" rel="cnj">
+          <node begin="6" end="7" frame="verb(unacc,sg1,aux_psp_zijn)" his="normal" his_1="normal" id="12" infl="sg1" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" tense="present" word="ben" wvorm="pv"/>
+          <node begin="7" case="nom" def="def" end="8" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="13" index="3" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+          <node begin="0" cat="ppart" end="11" id="14" rel="vc">
+            <node begin="0" end="1" id="15" index="2" rel="mod"/>
+            <node begin="7" end="8" id="16" index="3" rel="su"/>
+            <node begin="8" cat="ap" end="10" id="17" rel="mod">
+              <node begin="8" end="9" frame="adverb" his="normal" his_1="normal" id="18" lcat="advp" lemma="nog" pos="adv" postag="BW()" pt="bw" rel="mod" root="nog" sense="nog" word="nog"/>
+              <node aform="base" begin="9" end="10" frame="adjective(both(tmpadv))" his="normal" his_1="normal" id="19" infl="both" lcat="ap" lemma="even" pos="adj" postag="BW()" pt="bw" rel="hd" root="even" sense="even" vform="adj" word="even"/>
+            </node>
+            <node begin="10" buiging="zonder" end="11" frame="verb(zijn,psp,ninv(intransitive,part_intransitive(terug)))" his="normal" his_1="part-V" id="20" infl="psp" lcat="ppart" lemma="terug_lopen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="loop_terug" sc="part_intransitive(terug)" sense="loop_terug" word="teruggelopen" wvorm="vd"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Toen ging ik toch twijfelen en ben ik nog even teruggelopen .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="0" cat="conj" end="8" id="2" rel="vc">
+          <node begin="0" cat="whsub" end="4" id="3" rel="cnj">
+            <node begin="0" case="both" def="indef" end="1" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="4" index="1" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="whd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="Wat"/>
+            <node begin="0" cat="ssub" end="4" id="5" rel="body">
+              <node begin="1" case="nom" def="def" end="2" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="6" index="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node begin="2" end="3" frame="verb(unacc,sg3,aux(te_inf))" his="normal" his_1="normal" id="7" infl="sg3" lcat="ssub" lemma="komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom" sc="aux(te_inf)" sense="kom" tense="present" word="komt" wvorm="pv"/>
+              <node begin="0" cat="inf" end="4" id="8" rel="vc">
+                <node begin="0" end="1" id="9" index="1" rel="obj1"/>
+                <node begin="1" end="2" id="10" index="2" rel="su"/>
+                <node begin="3" buiging="zonder" end="4" frame="verb(hebben,inf(no_e),transitive_ndev)" his="normal" his_1="normal" id="11" infl="inf(no_e)" lcat="inf" lemma="doen" pos="verb" positie="vrij" postag="WW(inf,vrij,zonder)" pt="ww" rel="hd" root="doe" sc="transitive_ndev" sense="doe" word="doen" wvorm="inf"/>
+              </node>
+            </node>
+          </node>
+          <node begin="4" conjtype="neven" end="5" frame="conj(en)" his="normal" his_1="normal" id="12" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="5" cat="whsub" end="8" id="13" rel="cnj">
+            <node begin="5" case="both" def="indef" end="6" frame="pronoun(ywh,thi,sg,het,both,indef,nparg)" gen="het" getal="ev" his="normal" his_1="normal" id="14" index="3" lcat="np" lemma="wat" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3o" pos="pron" postag="VNW(vb,pron,stan,vol,3o,ev)" pt="vnw" rel="whd" rnum="sg" root="wat" sense="wat" special="nparg" status="vol" vwtype="vb" wh="ywh" word="wat"/>
+            <node begin="5" cat="ssub" end="8" id="15" rel="body">
+              <node begin="5" end="6" id="16" index="3" rel="obj1"/>
+              <node begin="6" case="nom" def="def" end="7" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="normal" id="17" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="hij"/>
+              <node begin="7" end="8" frame="verb(hebben,modal_not_u,transitive_ndev_ndev)" his="normal" his_1="normal" id="18" infl="modal_not_u" lcat="ssub" lemma="willen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="wil" sc="transitive_ndev_ndev" sense="wil" tense="present" word="wil" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="8" end="9" frame="verb(hebben,sg,tr_sbar)" his="normal" his_1="normal" id="19" infl="sg" lcat="smain" lemma="weten" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="weet" sc="tr_sbar" sense="weet" stype="declarative" tense="present" word="weet" wvorm="pv"/>
+        <node begin="9" case="nom" def="def" end="10" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="normal" id="20" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="ik"/>
+        <node begin="10" end="11" frame="adverb" his="normal" his_1="normal" id="21" lcat="advp" lemma="niet" pos="adv" postag="BW()" pt="bw" rel="mod" root="niet" sense="niet" word="niet"/>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="22" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Wat hij komt doen en wat hij wil weet ik niet .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="12" id="0" rel="top">
+      <node begin="0" cat="smain" end="11" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,pl,de,nom,def,wkpro)" gen="de" getal="mv" his="normal" his_1="decap" his_1_1="normal" id="2" index="1" lcat="np" lemma="we" naamval="nomin" num="pl" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,red,1,mv)" pt="vnw" rel="su" rnum="pl" root="we" sense="we" special="wkpro" status="red" vwtype="pers" wh="nwh" word="We"/>
+        <node begin="1" end="2" frame="verb(hebben,pl,aux_psp_hebben)" his="normal" his_1="normal" id="3" infl="pl" lcat="smain" lemma="hebben" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="heb" sc="aux_psp_hebben" sense="heb" tense="present" word="hebben" wvorm="pv"/>
+        <node begin="0" cat="conj" end="11" id="4" rel="vc">
+          <node begin="0" cat="ppart" end="7" id="5" rel="cnj">
+            <node begin="0" end="1" id="6" index="1" rel="su"/>
+            <node begin="2" end="3" frame="tmp_adverb" his="normal" his_1="normal" id="7" lcat="advp" lemma="toen" pos="adv" postag="BW()" pt="bw" rel="mod" root="toen" sense="toen" special="tmp" word="toen"/>
+            <node begin="3" cat="pp" end="6" id="8" rel="ld">
+              <node begin="3" end="4" frame="preposition(langs,[heen])" his="normal" his_1="normal" id="9" lcat="pp" lemma="langs" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="langs" sense="langs" vztype="init" word="langs"/>
+              <node begin="4" cat="np" end="6" id="10" rel="obj1">
+                <node begin="4" end="5" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="11" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+                <node begin="5" end="6" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="12" lcat="np" lemma="strand" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="strand" sense="strand" word="strand"/>
+              </node>
+            </node>
+            <node begin="6" buiging="zonder" end="7" frame="verb('hebben/zijn',psp,ld_pp)" his="normal" his_1="normal" id="13" infl="psp" lcat="ppart" lemma="wandelen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="wandel" sc="ld_pp" sense="wandel" word="gewandeld" wvorm="vd"/>
+          </node>
+          <node begin="7" conjtype="neven" end="8" frame="conj(en)" his="normal" his_1="normal" id="14" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="0" cat="ppart" end="11" id="15" rel="cnj">
+            <node begin="0" end="1" id="16" index="1" rel="su"/>
+            <node begin="8" cat="np" end="10" id="17" rel="obj1">
+              <node begin="8" end="9" frame="determiner(het,nwh,nmod,pro,nparg,wkpro)" his="normal" his_1="normal" id="18" infl="het" lcat="detp" lemma="het" lwtype="bep" naamval="stan" npagr="evon" pos="det" postag="LID(bep,stan,evon)" pt="lid" rel="det" root="het" sense="het" wh="nwh" word="het"/>
+              <node begin="9" end="10" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="dim" his="normal" his_1="normal" id="19" lcat="np" lemma="stad" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,dim,onz,stan)" pt="n" rel="hd" rnum="sg" root="stad_DIM" sense="stad_DIM" word="stadje"/>
+            </node>
+            <node begin="10" buiging="zonder" end="11" frame="verb(hebben,psp,transitive)" his="normal" his_1="normal" id="20" infl="psp" lcat="ppart" lemma="verkennen" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="verken" sc="transitive" sense="verken" word="verkend" wvorm="vd"/>
+          </node>
+        </node>
+      </node>
+      <node begin="11" end="12" frame="punct(punt)" his="normal" his_1="normal" id="21" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">We hebben toen langs het strand gewandeld en het stadje verkend .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="11" id="0" rel="top">
+      <node begin="2" end="3" frame="punct(komma)" his="normal" his_1="normal" id="1" lcat="punct" lemma="," pos="punct" postag="LET()" pt="let" rel="--" root="," sense="," special="komma" word=","/>
+      <node begin="0" cat="smain" end="10" id="2" rel="--">
+        <node begin="0" cat="conj" end="8" id="3" index="1" rel="su">
+          <node begin="0" cat="np" end="2" id="4" rel="cnj">
+            <node begin="0" buiging="zonder" end="1" frame="determiner(pron)" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="5" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="Zijn"/>
+            <node begin="1" end="2" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="6" lcat="np" lemma="zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="zoon" sense="zoon" word="zoon"/>
+          </node>
+          <node begin="3" cat="np" end="5" id="7" rel="cnj">
+            <node begin="3" buiging="zonder" end="4" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="8" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+            <node begin="4" end="5" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="9" lcat="np" lemma="dochter" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="dochter" sense="dochter" word="dochter"/>
+          </node>
+          <node begin="5" conjtype="neven" end="6" frame="conj(en)" his="normal" his_1="normal" id="10" lcat="vg" lemma="en" pos="vg" postag="VG(neven)" pt="vg" rel="crd" root="en" sense="en" word="en"/>
+          <node begin="6" cat="np" end="8" id="11" rel="cnj">
+            <node begin="6" buiging="zonder" end="7" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="12" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+            <node begin="7" end="8" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="13" lcat="np" lemma="schoon_zoon" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="schoon_zoon" sense="schoon_zoon" word="schoonzoon"/>
+          </node>
+        </node>
+        <node begin="8" end="9" frame="verb(unacc,pl,aux_psp_zijn)" his="normal" his_1="normal" id="14" infl="pl" lcat="smain" lemma="zijn" pos="verb" postag="WW(pv,tgw,mv)" pt="ww" pvagr="mv" pvtijd="tgw" rel="hd" root="ben" sc="aux_psp_zijn" sense="ben" stype="declarative" tense="present" word="zijn" wvorm="pv"/>
+        <node begin="0" cat="ppart" end="10" id="15" rel="vc">
+          <node begin="0" end="8" id="16" index="1" rel="su"/>
+          <node begin="9" buiging="zonder" end="10" frame="verb(unacc,psp,intransitive)" his="normal" his_1="normal" id="17" infl="psp" lcat="ppart" lemma="verongelukken" pos="verb" positie="vrij" postag="WW(vd,vrij,zonder)" pt="ww" rel="hd" root="verongeluk" sc="intransitive" sense="verongeluk" word="verongelukt" wvorm="vd"/>
+        </node>
+      </node>
+      <node begin="10" end="11" frame="punct(punt)" his="normal" his_1="normal" id="18" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Zijn zoon , zijn dochter en zijn schoonzoon zijn verongelukt .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/smallconjuncts.example.ok
+++ b/tests/smallconjuncts.example.ok
@@ -4376,26 +4376,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.8.w.2.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>heb</t>
-                <feat class="[heb]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>heb</t>
-                  <feat class="[heb]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -5099,26 +5079,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.9.w.6.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>bijzonder</t>
-                <feat class="[bijzonder]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>bijzonder</t>
-                  <feat class="[bijzonder]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
           <metric class="prevalenceP" value="0.999467"/>
@@ -7673,26 +7633,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>moet</t>
-                <feat class="[moet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>moet</t>
-                  <feat class="[moet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.14.w.3.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>moet</t>
                 <feat class="[moet]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -8277,26 +8217,6 @@
             </morphology>
           </alt>
           <alt xml:id="tscan.p.1.s.15.w.3.alt-mor.2" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>moet</t>
-                <feat class="[moet]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>moet</t>
-                  <feat class="[moet]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.15.w.3.alt-mor.3" auth="no">
             <morphology>
               <morpheme class="complex">
                 <t>moet</t>
@@ -13700,26 +13620,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.23.w.13.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
                 <feat class="[wil]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -14227,28 +14127,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.24.w.6.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>horen</t>
-                <feat class="[[hoor]verb[en]/present-tense/plural/singular]verb" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>hoor</t>
-                  <feat class="[hoor]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>en</t>
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="plural" subset="inflection"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="singular" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -14835,28 +14713,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.25.w.6.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>horen</t>
-                <feat class="[[hoor]verb[en]/present-tense/plural/singular]verb" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>hoor</t>
-                  <feat class="[hoor]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>en</t>
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="plural" subset="inflection"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="singular" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -16808,26 +16664,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.1.s.28.w.7.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>ga</t>
-                <feat class="[ga]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>ga</t>
-                  <feat class="[ga]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>
@@ -17688,26 +17524,6 @@
             <morphology>
               <morpheme class="complex">
                 <t>wil</t>
-                <feat class="[wil]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                <morpheme class="stem">
-                  <t>wil</t>
-                  <feat class="[wil]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
-          <alt xml:id="tscan.p.1.s.29.w.8.alt-mor.3" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>wil</t>
                 <feat class="[wil]verb/present-tense/singular/3rd-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
@@ -17785,7 +17601,7 @@
             <morphology>
               <morpheme class="complex">
                 <t>weet</t>
-                <feat class="[wijt]verb/present-tense/singular/2nd-person-verb/inversed" subset="structure"/>
+                <feat class="[wijt]verb/present-tense/singular/1st-person-verb" subset="structure"/>
                 <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
                 <morpheme class="stem">
                   <t>wijt</t>
@@ -17795,8 +17611,7 @@
                 <morpheme class="inflection">
                   <feat class="present-tense" subset="inflection"/>
                   <feat class="singular" subset="inflection"/>
-                  <feat class="2nd-person-verb" subset="inflection"/>
-                  <feat class="inversed" subset="inflection"/>
+                  <feat class="1st-person-verb" subset="inflection"/>
                 </morpheme>
               </morpheme>
             </morphology>

--- a/tests/svp.example.alpino
+++ b/tests/svp.example.alpino
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<treebank>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="9" id="0" rel="top">
+      <node begin="0" cat="smain" end="8" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,part_transitive(op))" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg3" lcat="smain" lemma="op_roepen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="roep_op" sc="part_transitive(op)" sense="roep_op" stype="declarative" tense="present" word="ROEPT" wvorm="pv"/>
+        <node begin="2" cat="pp" end="5" id="4" rel="mod">
+          <node begin="2" end="3" frame="preposition(met,[mee,[en,al]])" his="normal" his_1="normal" id="5" lcat="pp" lemma="met" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="met" sense="met" vztype="init" word="met"/>
+          <node begin="3" cat="np" end="5" id="6" rel="obj1">
+            <node begin="3" buiging="zonder" end="4" frame="determiner(pron)" getal="ev" his="normal" his_1="normal" id="7" infl="pron" lcat="detp" lemma="zijn" naamval="stan" npagr="agr" pdtype="det" persoon="3" pos="det" positie="prenom" postag="VNW(bez,det,stan,vol,3,ev,prenom,zonder,agr)" pron="true" pt="vnw" rel="det" root="zijn" sense="zijn" status="vol" vwtype="bez" word="zijn"/>
+            <node begin="4" end="5" frame="noun(het,count,sg)" gen="het" genus="onz" getal="ev" graad="basis" his="normal" his_1="normal" id="8" lcat="np" lemma="optreden" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="hd" rnum="sg" root="optreden" sense="optreden" word="optreden"/>
+          </node>
+        </node>
+        <node begin="5" cat="np" end="7" id="9" rel="obj1">
+          <node aform="base" begin="5" buiging="zonder" end="6" frame="adjective(no_e(odet_adv))" graad="basis" his="normal" his_1="normal" id="10" infl="no_e" lcat="detp" lemma="veel" naamval="stan" npagr="agr" pdtype="grad" pos="adj" positie="prenom" postag="VNW(onbep,grad,stan,prenom,zonder,agr,basis)" pt="vnw" rel="det" root="veel" sense="veel" vform="adj" vwtype="onbep" word="veel"/>
+          <node begin="6" end="7" frame="noun(de,count,sg)" gen="de" genus="zijd" getal="ev" graad="basis" his="normal" his_1="normal" id="11" lcat="np" lemma="weerstand" naamval="stan" ntype="soort" num="sg" pos="noun" postag="N(soort,ev,basis,zijd,stan)" pt="n" rel="hd" rnum="sg" root="weerstand" sense="weerstand" word="weerstand"/>
+        </node>
+        <node begin="7" end="8" frame="particle(op)" his="special" his_1="decap" his_1_1="normal" id="12" lcat="part" lemma="op" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="op" sense="op" vztype="fin" word="OP"/>
+      </node>
+      <node begin="8" end="9" frame="punct(punt)" his="normal" his_1="normal" id="13" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij ROEPT met zijn optreden veel weerstand OP .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,thi,sg,de,nom,def)" gen="de" genus="masc" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="hij" naamval="nomin" num="sg" pdtype="pron" per="thi" persoon="3" pos="pron" postag="VNW(pers,pron,nomin,vol,3,ev,masc)" pt="vnw" rel="su" rnum="sg" root="hij" sense="hij" status="vol" vwtype="pers" wh="nwh" word="Hij"/>
+        <node begin="1" end="2" frame="verb(hebben,sg3,part_transitive(uit))" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg3" lcat="smain" lemma="uit_schelden" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="scheld_uit" sc="part_transitive(uit)" sense="scheld_uit" stype="declarative" tense="present" word="SCHELDT" wvorm="pv"/>
+        <node begin="2" cat="np" end="5" id="4" rel="obj1">
+          <node begin="2" case="both" def="def" end="3" frame="pronoun(nwh,thi,sg,de,both,def,strpro)" gen="de" getal="ev" his="normal" his_1="normal" id="5" lcat="np" lemma="iedereen" naamval="stan" num="sg" pdtype="pron" per="thi" persoon="3p" pos="pron" postag="VNW(onbep,pron,stan,vol,3p,ev)" pt="vnw" rel="hd" rnum="sg" root="iedereen" sense="iedereen" special="strpro" status="vol" vwtype="onbep" wh="nwh" word="iedereen"/>
+          <node begin="3" cat="rel" end="5" id="6" rel="mod">
+            <node begin="3" case="no_obl" end="4" frame="rel_pronoun(de,no_obl)" gen="de" getal="getal" his="normal" his_1="normal" id="7" index="1" lcat="np" lemma="die" naamval="stan" pdtype="pron" persoon="persoon" pos="pron" postag="VNW(betr,pron,stan,vol,persoon,getal)" pt="vnw" rel="rhd" rnum="sg" root="die" sense="die" status="vol" vwtype="betr" wh="rel" word="die"/>
+            <node begin="3" cat="ssub" end="5" id="8" rel="body">
+              <node begin="3" end="4" id="9" index="1" rel="su"/>
+              <node begin="4" end="5" frame="verb(unacc,sg3,ninv(intransitive,part_intransitive(langs)))" his="normal" his_1="part-V" id="10" infl="sg3" lcat="ssub" lemma="langs_komen" pos="verb" postag="WW(pv,tgw,met-t)" pt="ww" pvagr="met-t" pvtijd="tgw" rel="hd" root="kom_langs" sc="part_intransitive(langs)" sense="kom_langs" tense="present" word="langskomt" wvorm="pv"/>
+            </node>
+          </node>
+        </node>
+        <node begin="5" end="6" frame="particle(uit)" his="special" his_1="decap" his_1_1="normal" id="11" lcat="part" lemma="uit" pos="part" postag="VZ(fin)" pt="vz" rel="svp" root="uit" sense="uit" vztype="fin" word="UIT"/>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="12" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Hij SCHELDT iedereen die langskomt UIT .</sentence>
+  </alpino_ds>
+  <alpino_ds version="1.14">
+    <parser build="Alpino-x86_64-linux-glibc2.5-git819-sicstus" date="2023-04-29T21:21" cats="1" skips="0"/>
+    <node begin="0" cat="top" end="7" id="0" rel="top">
+      <node begin="0" cat="smain" end="6" id="1" rel="--">
+        <node begin="0" case="nom" def="def" end="1" frame="pronoun(nwh,fir,sg,de,nom,def)" gen="de" getal="ev" his="normal" his_1="decap" his_1_1="normal" id="2" lcat="np" lemma="ik" naamval="nomin" num="sg" pdtype="pron" per="fir" persoon="1" pos="pron" postag="VNW(pers,pron,nomin,vol,1,ev)" pt="vnw" rel="su" rnum="sg" root="ik" sense="ik" status="vol" vwtype="pers" wh="nwh" word="Ik"/>
+        <node begin="1" end="2" frame="verb(hebben,sg1,part_pc_pp(deel,aan))" his="special" his_1="decap" his_1_1="normal" id="3" infl="sg1" lcat="smain" lemma="deel_nemen" pos="verb" postag="WW(pv,tgw,ev)" pt="ww" pvagr="ev" pvtijd="tgw" rel="hd" root="neem_deel" sc="part_pc_pp(deel,aan)" sense="neem_deel-aan" stype="declarative" tense="present" word="NEEM" wvorm="pv"/>
+        <node aform="base" begin="2" end="3" frame="adjective(both(osentadv))" his="normal" his_1="normal" id="4" infl="both" lcat="ap" lemma="graag" pos="adj" postag="BW()" pt="bw" rel="mod" root="graag" sense="graag" vform="adj" word="graag"/>
+        <node begin="3" cat="pp" end="5" id="5" rel="pc">
+          <node begin="3" end="4" frame="preposition(aan,[vooraf])" his="normal" his_1="normal" id="6" lcat="pp" lemma="aan" pos="prep" postag="VZ(init)" pt="vz" rel="hd" root="aan" sense="aan" vztype="init" word="aan"/>
+          <node begin="4" end="5" frame="tmp_noun(de,count,pl)" gen="de" getal="mv" graad="basis" his="normal" his_1="normal" id="7" lcat="np" lemma="wedstrijd" ntype="soort" num="pl" pos="noun" postag="N(soort,mv,basis)" pt="n" rel="obj1" rnum="pl" root="wedstrijd" sense="wedstrijd" special="tmp" word="wedstrijden"/>
+        </node>
+        <node begin="5" end="6" frame="particle(deel)" genus="onz" getal="ev" graad="basis" his="special" his_1="decap" his_1_1="normal" id="8" lcat="part" lemma="deel" naamval="stan" ntype="soort" pos="part" postag="N(soort,ev,basis,onz,stan)" pt="n" rel="svp" root="deel" sense="deel" word="DEEL"/>
+      </node>
+      <node begin="6" end="7" frame="punct(punt)" his="normal" his_1="normal" id="9" lcat="punct" lemma="." pos="punct" postag="LET()" pt="let" rel="--" root="." sense="." special="punt" word="."/>
+    </node>
+    <sentence sentid="127.0.0.1">Ik NEEM graag aan wedstrijden DEEL .</sentence>
+  </alpino_ds>
+</treebank>

--- a/tests/svp.example.ok
+++ b/tests/svp.example.ok
@@ -1033,36 +1033,6 @@
               </morpheme>
             </morpheme>
           </morphology>
-          <alt xml:id="tscan.p.2.s.1.w.5.alt-mor.1" auth="no">
-            <morphology>
-              <morpheme class="complex">
-                <t>optreden</t>
-                <feat class="[[op]preposition[treed]verb[e]/present-tense/plural[n]/plural]verb" subset="structure"/>
-                <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex">
-                  <feat class="PV" subset="compound"/>
-                </pos>
-                <morpheme class="stem">
-                  <t>op</t>
-                  <feat class="[op]preposition" subset="structure"/>
-                  <pos class="P" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="stem">
-                  <t>treed</t>
-                  <feat class="[treed]verb" subset="structure"/>
-                  <pos class="V" set="http://ilk.uvt.nl/folia/sets/frog-mbpos-clex"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>e</t>
-                  <feat class="present-tense" subset="inflection"/>
-                  <feat class="plural" subset="inflection"/>
-                </morpheme>
-                <morpheme class="inflection">
-                  <t>n</t>
-                  <feat class="plural" subset="inflection"/>
-                </morpheme>
-              </morpheme>
-            </morphology>
-          </alt>
           <pos class="wwform(hoofdww)" set="tscan-set"/>
           <metric class="content_word" value="true"/>
           <metric class="content_word_strict" value="true"/>

--- a/tests/testall
+++ b/tests/testall
@@ -3,6 +3,7 @@
 \rm -f *.diff
 \rm -f *.tmp
 \rm -f *.out*
+\rm -f out*.alpino_lookup.data
 
 if [ "$tscan_bin" = "" ];
 then echo "tscan_bin not set";

--- a/tests/testone.sh
+++ b/tests/testone.sh
@@ -2,7 +2,7 @@
 
 if [ "$tscan_bin" = "" ];
 then echo "tscan_bin not set";
-     exit;
+	exit;
 fi
 
 OK="\033[1;32m OK  \033[0m"
@@ -10,10 +10,9 @@ FAIL="\033[1;31m  FAILED  \033[0m"
 KNOWNFAIL="\033[1;33m  KNOWN FAILURES  \033[0m"
 
 export comm="$VG $tscan_bin/tscan"
-result=0
-for file in $@
-do if test -e $file
-    then
+
+function do_test() {
+	local file="$1"
 	\rm -f $file.diff
 	\rm -f $file.err
 	\rm -f $file.out
@@ -24,15 +23,40 @@ do if test -e $file
 	./foliadiff.sh $file.tscan.xml $file.ok >& $file.diff
 	if [ $? -ne 0 ];
 	then
-	    echo -e $FAIL;
-	    echo "differences logged in $file.diff";
-		result=1
+		echo -e $FAIL;
+		echo "differences logged in $file.diff";
+		return 1
 	else
-	  echo -e $OK
-	  rm $file.diff
+		echo -e $OK
+		rm $file.diff
+		return 0
 	fi
-    else
+}
+
+result=0
+attempt=0
+for file in $@
+do if test -e $file
+then
+	file_result=1
+	while [ $attempt -le 3 ]
+	do
+		if [ $attempt -gt 0 ];
+		then
+			echo "retry..."
+			sleep 5
+		fi
+		do_test "$file"
+		file_result=$?
+		if [ $file_result -eq 0 ];
+		then
+			break
+		fi
+		attempt=$((attempt + 1))
+	done
+else
 	echo "file $file not found"
-    fi
+	result=1
+fi
 done
 exit $result

--- a/tests/testone.sh
+++ b/tests/testone.sh
@@ -18,6 +18,7 @@ do if test -e $file
 	\rm -f $file.err
 	\rm -f $file.out
 	\rm -f $file.tscan.xml
+	\rm -f $file.*.alpino.xml
 	echo -n "Tscanning  $file "
 	$comm --config=tscan.cfg --skip=c -t $file > $file.out 2> $file.err
 	./foliadiff.sh $file.tscan.xml $file.ok >& $file.diff

--- a/tests/tscan.cfg
+++ b/tests/tscan.cfg
@@ -1,7 +1,11 @@
 useAlpino=1
 useAlpinoServer=1
+saveAlpinoOutput=1
+saveAlpinoMetadata=0
 useWopr=0
 useCompoundSplitter=0
+
+alpino_lookup="../tests/alpino_lookup.data"
 
 styleSheet="tscanview.xsl"
 

--- a/tscan.cfg.example
+++ b/tscan.cfg.example
@@ -1,5 +1,7 @@
 useAlpino=1
 useAlpinoServer=1
+saveAlpinoOutput=1
+saveAlpinoMetadata=1
 useWopr=0
 useCompoundSplitter=1
 

--- a/webservice/setup.py
+++ b/webservice/setup.py
@@ -34,5 +34,5 @@ setup(
     ],
     package_data = {'tscanservice':['*.wsgi','*.yml'] },
     include_package_data=True,
-    install_requires=['CLAM >= 3.0', 'textract', 'python-magic']
+    install_requires=['CLAM >= 3.0', 'lxml', 'textract', 'python-magic']
 )

--- a/webservice/tscanservice/tscan.py
+++ b/webservice/tscanservice/tscan.py
@@ -370,6 +370,8 @@ parameters_list = [
                    description='MTLD factor size', default=0.720),
     ChoiceParameter(id='useAlpino', name='Use Alpino parser',
                     description='Use Alpino parser?', choices=['yes', 'no'], default='yes'),
+    ChoiceParameter(id='alpinoOutput', name='Store Alpino output',
+                    description='Store the Alpino output and input as a treebank file', choices=['yes', 'no'], default='no'),
     ChoiceParameter(id='useWopr', name='Use Wopr', description='Use Wopr?', choices=[
         'yes', 'no'], default='yes'),
     ChoiceParameter(id='sentencePerLine', name='One sentence per line',

--- a/webservice/tscanservice/tscan.py
+++ b/webservice/tscanservice/tscan.py
@@ -14,7 +14,7 @@
 ###############################################################
 
 from clam.common.parameters import *
-from clam.common.formats import *
+from clam.common.formats import AlpinoXMLFormat, CSVFormat, FoLiAXMLFormat, PlainTextFormat, XMLStyleSheet
 from clam.common.converters import *
 from clam.common.viewers import *
 from clam.common.data import *  # AbstractConverter
@@ -35,7 +35,7 @@ except ModuleNotFoundError:
 
 
 class DocumentTextConverter(AbstractConverter):
-    acceptforinput = [clam.common.formats.PlainTextFormat]
+    acceptforinput = [PlainTextFormat]
 
     converttool = 'textract'
 
@@ -215,6 +215,17 @@ PROFILES = [
             extension='.data',
             optional=True,
             unique=True,
+        ),
+        # 20230318: Added possibility to enter pre-parsed treebanks
+        InputTemplate(
+            'alpino',
+            AlpinoXMLFormat,
+            'Alpino XML',
+            StaticParameter(id='encoding', name='Encoding',
+                            description='The character encoding of the file', value='utf-8'),
+            extension='.xml',
+            optional=True,
+            multi=True
         ),
         # ------------------------------------------------------------------------------------------------------------------------
         OutputTemplate(


### PR DESCRIPTION
This allows uploading a pre-parsed Alpino treebank to skip parsing. It will also use a lookup to prevent having to re-parse the same sentence twice. (It will also store the parses in the INPUT folder, this is deliberate, because it will really speed things up when restarting a project).

Any generated Alpino-parses can be saved for download.

Furthermore, I've updated the tests to skip Alpino parsing (uses a pre-parsed treebank) and checked that it works with the latest version of all the dependencies.
