### PR TITLE
Windows line endings -> Unix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh        text eol=lf 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.sh        text eol=lf 
+configure.ac        text eol=lf 
+Makefile.am        text eol=lf 


### PR DESCRIPTION
Problem with issue #82 is that the line endings of the /docker/deployment/add-alpino.sh file are Windows line endings, while they should be Unix line endings. Not sure if it is only because I downloaded the files on a Windows machine, but at least this commit should fix that for all .sh files.